### PR TITLE
docs: Update continuation prompt to be based on main branch

### DIFF
--- a/CONTINUATION_PROMPT.md
+++ b/CONTINUATION_PROMPT.md
@@ -2,10 +2,10 @@
 
 ## Current Status Summary
 
-**Branch**: `claude/work-stealing-migration-01D8QY8wG6fDLMjVeu3H8UCC`
+**Branch**: `main`
 **Tests**: 329/329 passing (100%)
-**Commits**: 40 commits ready for PR
-**Lines Changed**: +20,335 lines
+**Status**: All Phases 1-5 complete and merged to main
+**Code Base**: ~20,335 lines of production code and tests
 
 ### Completed Phases
 
@@ -23,7 +23,7 @@
 
 ## Prompt for Next Session
 
-I'm continuing work on **ProjectKeystone**, a C++20 Hierarchical Multi-Agent System (HMAS). The project has completed Phases 1-5 with all 329 tests passing. Here's where we are:
+I'm continuing work on **ProjectKeystone**, a C++20 Hierarchical Multi-Agent System (HMAS). The project has completed Phases 1-5 with all 329 tests passing on the main branch. Here's where we are:
 
 ### What's Been Completed
 
@@ -35,9 +35,9 @@ I'm continuing work on **ProjectKeystone**, a C++20 Hierarchical Multi-Agent Sys
 
 ### Current Branch
 
-- **Branch**: `claude/work-stealing-migration-01D8QY8wG6fDLMjVeu3H8UCC`
-- **Status**: All changes committed and pushed
-- **PR**: Ready to create (see `PR_DESCRIPTION.md`)
+- **Branch**: `main`
+- **Status**: Production-ready with all phases merged
+- **Tests**: 329/329 passing (100%)
 
 ### Project Structure
 
@@ -231,16 +231,6 @@ ProjectKeystone/
 
 ## Quick Start Commands
 
-### Create the PR
-```bash
-cd /home/user/ProjectKeystone
-gh pr create \
-  --title "feat: Complete Phase A-D and Phases 4-5 - Production-Ready HMAS" \
-  --body-file PR_DESCRIPTION.md \
-  --base main \
-  --head claude/work-stealing-migration-01D8QY8wG6fDLMjVeu3H8UCC
-```
-
 ### Run All Tests
 ```bash
 docker-compose up test
@@ -255,51 +245,100 @@ docker-compose up test-tsan   # ThreadSanitizer
 docker-compose up test-ubsan  # UndefinedBehaviorSanitizer
 ```
 
+### Create New Feature Branch
+```bash
+# For Phase 6 (Production Deployment)
+git checkout -b claude/phase-6-production-deployment-<session-id>
+
+# For Phase 7 (AI Integration)
+git checkout -b claude/phase-7-ai-integration-<session-id>
+
+# For Phase 8 (Real Distributed System)
+git checkout -b claude/phase-8-distributed-system-<session-id>
+```
+
 ---
 
 ## Recommended Prompt for Next Session
 
 **If continuing with Phase 6 (Production Deployment)**:
 
-> I'm working on ProjectKeystone HMAS (C++20 hierarchical multi-agent system). We've completed Phases 1-5 with 329/329 tests passing. Now I want to prepare for production deployment (Phase 6).
+> I'm working on ProjectKeystone HMAS (C++20 hierarchical multi-agent system). Phases 1-5 are complete and merged to main with 329/329 tests passing. Now I want to prepare for production deployment (Phase 6).
 >
 > Current status:
-> - Branch: `claude/work-stealing-migration-01D8QY8wG6fDLMjVeu3H8UCC`
-> - All tests passing, ready for PR
+> - Branch: `main` (all phases merged)
+> - 329/329 tests passing
+> - Production-ready HMAS with async work-stealing, distributed simulation, and chaos engineering
 >
-> Next steps:
-> 1. Create production Dockerfile with multi-stage build
+> Next steps for Phase 6:
+> 1. Optimize Dockerfile for production (multi-stage build, security hardening)
 > 2. Create Kubernetes deployment manifests (StatefulSet, Service, ConfigMap)
-> 3. Add Prometheus metrics exporter
-> 4. Create Grafana dashboard for HMAS visualization
+> 3. Add Prometheus metrics exporter (integrate with existing Metrics class)
+> 4. Create Grafana dashboard for HMAS hierarchy visualization
 >
-> Please start with optimizing the Dockerfile for production. The current Dockerfile is in the root directory.
+> Please create a new branch `claude/phase-6-production-deployment-<session-id>` and start with optimizing the Dockerfile for production. The current Dockerfile is in the root directory.
 
 **If continuing with Phase 7 (AI Integration)**:
 
-> I'm working on ProjectKeystone HMAS (C++20 hierarchical multi-agent system). We've completed Phases 1-5 with 329/329 tests passing. Now I want to add LLM integration (Phase 7).
+> I'm working on ProjectKeystone HMAS (C++20 hierarchical multi-agent system). Phases 1-5 are complete and merged to main with 329/329 tests passing. Now I want to add LLM integration (Phase 7).
 >
 > Current status:
-> - Branch: `claude/work-stealing-migration-01D8QY8wG6fDLMjVeu3H8UCC`
+> - Branch: `main` (all phases merged)
 > - We have `AsyncTaskAgent` as the base L3 executor
+> - Production-ready HMAS with full async hierarchy
 >
-> Next steps:
-> 1. Create `LLMTaskAgent` class that inherits from `AsyncTaskAgent`
-> 2. Integrate with OpenAI API (or Claude/local LLM)
+> Next steps for Phase 7:
+> 1. Design `LLMTaskAgent` class that inherits from `AsyncTaskAgent`
+> 2. Integrate with OpenAI API or Anthropic Claude API
 > 3. Implement prompt engineering for task execution
-> 4. Add tests for LLM-based task execution
+> 4. Add E2E tests for LLM-based task execution
 >
-> Please start by designing the `LLMTaskAgent` class interface and integration points.
+> Please create a new branch `claude/phase-7-ai-integration-<session-id>` and start by designing the `LLMTaskAgent` class interface and integration points.
+
+**If continuing with Phase 8 (Real Distributed System)**:
+
+> I'm working on ProjectKeystone HMAS (C++20 hierarchical multi-agent system). Phases 1-5 are complete and merged to main with 329/329 tests passing. Now I want to convert the simulated distributed system to a real multi-node deployment (Phase 8).
+>
+> Current status:
+> - Branch: `main` (all phases merged)
+> - We have `SimulatedNetwork`, `SimulatedCluster`, `SimulatedNUMANode` for testing
+> - Now need real gRPC-based communication
+>
+> Next steps for Phase 8:
+> 1. Define `.proto` files for `KeystoneMessage` and agent communication
+> 2. Implement gRPC client/server for MessageBus
+> 3. Replace `SimulatedNetwork` with real gRPC communication
+> 4. Add service discovery (etcd or Consul)
+>
+> Please create a new branch `claude/phase-8-distributed-system-<session-id>` and start by designing the `.proto` files for the message protocol.
+
+**If continuing with Phase 9 (Enhanced Testing)**:
+
+> I'm working on ProjectKeystone HMAS (C++20 hierarchical multi-agent system). Phases 1-5 are complete and merged to main with 329/329 tests passing. Now I want to enhance testing and achieve 95%+ code coverage (Phase 9).
+>
+> Current status:
+> - Branch: `main` (all phases merged)
+> - 329/329 tests passing (59 E2E + 270 unit tests)
+> - Need coverage analysis to identify gaps
+>
+> Next steps for Phase 9:
+> 1. Integrate gcov/lcov for code coverage reports
+> 2. Run coverage analysis and identify untested code paths
+> 3. Add tests to reach 95%+ coverage
+> 4. Set up coverage reporting in CI/CD
+>
+> Please create a new branch `claude/phase-9-enhanced-testing-<session-id>` and start by adding gcov/lcov integration to CMakeLists.txt.
 
 **If just reviewing/documenting**:
 
-> I'm reviewing ProjectKeystone HMAS (C++20 hierarchical multi-agent system). We've completed Phases 1-5 with 329/329 tests passing.
+> I'm reviewing ProjectKeystone HMAS (C++20 hierarchical multi-agent system). Phases 1-5 are complete and merged to main with 329/329 tests passing.
 >
 > Current status:
-> - Branch: `claude/work-stealing-migration-01D8QY8wG6fDLMjVeu3H8UCC`
-> - Ready to create PR (see PR_DESCRIPTION.md)
+> - Branch: `main` (production-ready)
+> - All phases complete (1-5, A-D)
+> - Full documentation in docs/plan/
 >
-> Please review the current architecture and suggest improvements or next steps based on the TDD_FOUR_LAYER_ROADMAP.md document.
+> Please review the current architecture and suggest the best next phase based on the TDD_FOUR_LAYER_ROADMAP.md document and completed phases.
 
 ---
 
@@ -316,14 +355,27 @@ docker-compose up test-ubsan  # UndefinedBehaviorSanitizer
 
 ## Key Metrics to Track
 
-- **Test Coverage**: Currently 329/329 (100%), aim to maintain
+- **Test Coverage**: Currently 329/329 (100%), aim to maintain and improve
 - **Build Time**: Monitor Docker build times
 - **Test Execution Time**: Currently ~39 seconds
 - **Code Quality**: No compiler warnings, sanitizer clean
 - **Performance**: Message throughput, latency percentiles
+- **Memory Safety**: No leaks (valgrind clean)
+
+---
+
+## Development Workflow
+
+1. **Create Feature Branch**: `git checkout -b claude/phase-X-<description>-<session-id>`
+2. **Make Changes**: Follow TDD approach (test first, then implement)
+3. **Run Tests**: `docker-compose up test` (all tests must pass)
+4. **Run Sanitizers**: `docker-compose up test-asan test-ubsan` (must be clean)
+5. **Commit**: Use conventional commits (`feat:`, `fix:`, `docs:`, etc.)
+6. **Push**: `git push -u origin <branch-name>`
+7. **Create PR**: Merge back to main when complete
 
 ---
 
 **Last Updated**: 2025-11-19
-**Project Status**: Production-ready HMAS with comprehensive testing
+**Project Status**: Production-ready HMAS with comprehensive testing (Phases 1-5 complete)
 **Next Phase**: TBD (choose from Options 1-5 above)


### PR DESCRIPTION
Updated CONTINUATION_PROMPT.md to reflect that all work has been merged to main:
- Changed branch references from feature branch to main
- Removed PR creation instructions (already merged)
- Updated all continuation prompts to start from main
- Added branch creation commands for new phases
- Updated development workflow to reflect main-based development

All 5 phase continuation prompts now correctly reference main as the starting point.