### PR TITLE
Make time-based fairness check configurable

### DIFF
--- a/docs/plan/adr/ADR-003-priority-queue-anti-starvation-strategy.md
+++ b/docs/plan/adr/ADR-003-priority-queue-anti-starvation-strategy.md
@@ -272,14 +272,28 @@ std::thread low_thread([&]() { while (true) process_low(); });
 ### Configuration
 
 ```cpp
-// config.hpp
+// config.hpp - Global default
 static constexpr std::chrono::milliseconds AGENT_LOW_PRIORITY_CHECK_INTERVAL{100};
 ```
 
+**Per-Agent Configuration** (Issue #23):
+```cpp
+// Each agent can override the default interval
+agent->setLowPriorityCheckInterval(std::chrono::milliseconds{50});  // Low-latency
+agent->setLowPriorityCheckInterval(std::chrono::milliseconds{500}); // High-throughput
+```
+
+**Benefits of Per-Agent Configuration**:
+- **Latency-Sensitive Agents**: Use shorter intervals (10-50ms) for interactive/real-time operations
+- **Throughput-Optimized Agents**: Use longer intervals (200-500ms) for batch processing
+- **Runtime Tunable**: No recompilation required to adjust fairness characteristics
+- **Heterogeneous Workloads**: Different agents in same system can have different latency requirements
+
 **Tuning Guide**:
-- **Latency-Sensitive**: 50ms (higher overhead, better responsiveness)
-- **Throughput-Optimized**: 200ms (lower overhead, acceptable latency)
-- **Default**: 100ms (balanced)
+- **Ultra-Low-Latency** (10ms): Interactive UI updates, real-time control systems
+- **Low-Latency** (50ms): Standard interactive agents, request-response services
+- **Default** (100ms): Balanced - good for most use cases
+- **Throughput-Optimized** (200-500ms): Batch processors, background analytics
 
 ## Validation
 
@@ -313,14 +327,18 @@ if (msg.hasDeadlinePassed()) {
 }
 ```
 
-### Phase 4: Adaptive Fairness Interval
+### Phase 4: Adaptive Fairness Interval (Partially Implemented)
 
-Adjust interval based on queue depths:
+**✅ Issue #23**: Per-agent configurable intervals implemented (runtime tunable)
+
+**Future**: Fully adaptive intervals based on queue depth:
 
 ```cpp
-// Shorter interval when low-priority queue builds up
+// Automatic adjustment when low-priority queue builds up
 if (low_priority_depth > 1000) {
-  interval = 50ms;
+  agent->setLowPriorityCheckInterval(std::chrono::milliseconds{50});
+} else if (low_priority_depth < 100) {
+  agent->setLowPriorityCheckInterval(std::chrono::milliseconds{200});
 }
 ```
 
@@ -353,6 +371,6 @@ check_lower_priority_agents_every(100ms);
 
 ---
 
-**Last Updated**: 2025-11-21
-**Version**: 1.0
+**Last Updated**: 2025-11-21 (Issue #23: Per-agent configurable intervals)
+**Version**: 1.1
 **Project**: ProjectKeystone HMAS (C++20)

--- a/include/agents/agent_base.hpp
+++ b/include/agents/agent_base.hpp
@@ -93,6 +93,44 @@ class AgentBase {
     (void)scheduler;  // Suppress unused parameter warning
   }
 
+  /**
+   * @brief Configure the low-priority message check interval
+   *
+   * Issue #23: Per-agent configurable fairness check interval.
+   *
+   * Controls how frequently this agent force-checks NORMAL/LOW priority queues
+   * to prevent starvation under sustained HIGH priority load. Different agents
+   * may have different latency requirements:
+   * - Latency-sensitive: use shorter intervals (e.g., 10ms-50ms)
+   * - Throughput-optimized: use longer intervals (e.g., 200ms-500ms)
+   *
+   * @param interval Check interval duration (default: 100ms from Config)
+   *
+   * Example:
+   * @code
+   * // Low-latency agent (interactive UI updates)
+   * agent->setLowPriorityCheckInterval(std::chrono::milliseconds{10});
+   *
+   * // High-throughput batch processor
+   * agent->setLowPriorityCheckInterval(std::chrono::milliseconds{500});
+   * @endcode
+   */
+  void setLowPriorityCheckInterval(std::chrono::milliseconds interval) {
+    low_priority_check_interval_ns_.store(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(interval).count(),
+        std::memory_order_relaxed);
+  }
+
+  /**
+   * @brief Get the current low-priority check interval
+   *
+   * @return std::chrono::milliseconds Current check interval
+   */
+  std::chrono::milliseconds getLowPriorityCheckInterval() const {
+    return std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::nanoseconds{low_priority_check_interval_ns_.load(std::memory_order_relaxed)});
+  }
+
  protected:
   /**
    * @brief Update queue depth metrics
@@ -116,6 +154,10 @@ class AgentBase {
   // under sustained HIGH priority load
   // THREAD-SAFE: Using atomic to prevent data races from concurrent getMessage() calls
   std::atomic<int64_t> last_low_priority_check_ns_;
+
+  // Issue #23: Per-agent configurable fairness interval (defaults to Config value)
+  // THREAD-SAFE: Atomic for lock-free read/write from concurrent getMessage() and setter
+  std::atomic<int64_t> low_priority_check_interval_ns_;
 
   // FIX M1: Backpressure - Queue size limits to prevent memory exhaustion
   std::atomic<bool> backpressure_applied_{

--- a/src/agents/agent_base.cpp
+++ b/src/agents/agent_base.cpp
@@ -16,6 +16,14 @@ AgentBase::AgentBase(const std::string& agent_id) : agent_id_(agent_id) {
   last_low_priority_check_ns_.store(
       std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch()).count(),
       std::memory_order_relaxed);
+
+  // Issue #23: Initialize per-agent fairness interval to default from Config
+  low_priority_check_interval_ns_.store(
+      std::chrono::duration_cast<std::chrono::nanoseconds>(
+          core::Config::AGENT_LOW_PRIORITY_CHECK_INTERVAL)
+          .count(),
+      std::memory_order_relaxed);
+
   // Phase C: Priority queues initialized by default constructors
 }
 
@@ -90,21 +98,20 @@ void AgentBase::receiveMessage(const core::KeystoneMessage& msg) {
 
 std::optional<core::KeystoneMessage> AgentBase::getMessage() {
   // FIX C1: Time-based priority fairness to prevent LOW priority starvation
-  // Strategy: Every Config::AGENT_LOW_PRIORITY_CHECK_INTERVAL, force-check NORMAL/LOW
-  // queues to ensure fairness even under sustained HIGH priority load
-  // THREAD-SAFE: Uses atomic for last_low_priority_check_ns_
+  // Issue #23: Now uses per-agent configurable interval instead of global constant
+  // Strategy: Every interval_ns, force-check NORMAL/LOW queues to ensure fairness
+  // even under sustained HIGH priority load
+  // THREAD-SAFE: Uses atomic for last_low_priority_check_ns_ and interval
 
   core::KeystoneMessage msg;
   auto now = std::chrono::steady_clock::now();
   auto now_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch()).count();
 
-  // Load last check time (atomic, thread-safe)
+  // Load last check time and interval (atomic, thread-safe)
   int64_t last_check_ns = last_low_priority_check_ns_.load(std::memory_order_relaxed);
-  auto interval_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
-                         core::Config::AGENT_LOW_PRIORITY_CHECK_INTERVAL)
-                         .count();
+  int64_t interval_ns = low_priority_check_interval_ns_.load(std::memory_order_relaxed);
 
-  // Every 100ms, force-check lower priorities regardless of HIGH queue state
+  // Every interval_ns, force-check lower priorities regardless of HIGH queue state
   if (now_ns - last_check_ns >= interval_ns) {
     // Try to update last check time (only one thread succeeds)
     last_low_priority_check_ns_.store(now_ns, std::memory_order_relaxed);

--- a/tests/unit/test_message_priority.cpp
+++ b/tests/unit/test_message_priority.cpp
@@ -1,6 +1,8 @@
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include "agents/agent_base.hpp"
@@ -188,4 +190,159 @@ TEST(MessagePriorityTest, GetMessageRespectsPriority) {
   // No more messages
   auto msg4 = agent->getMessage();
   EXPECT_FALSE(msg4.has_value());
+}
+
+// ========================================================================
+// Issue #23: Configurable Fairness Check Interval Tests
+// ========================================================================
+
+/**
+ * @brief Test that default fairness interval is set from Config
+ */
+TEST(MessagePriorityTest, DefaultFairnessIntervalFromConfig) {
+  auto agent = std::make_shared<TestPriorityAgent>("test_agent");
+
+  // Default should be 100ms from Config::AGENT_LOW_PRIORITY_CHECK_INTERVAL
+  auto interval = agent->getLowPriorityCheckInterval();
+  EXPECT_EQ(interval, std::chrono::milliseconds{100});
+}
+
+/**
+ * @brief Test setting custom fairness interval
+ */
+TEST(MessagePriorityTest, SetCustomFairnessInterval) {
+  auto agent = std::make_shared<TestPriorityAgent>("test_agent");
+
+  // Set to 50ms (low-latency agent)
+  agent->setLowPriorityCheckInterval(std::chrono::milliseconds{50});
+  EXPECT_EQ(agent->getLowPriorityCheckInterval(),
+            std::chrono::milliseconds{50});
+
+  // Set to 500ms (high-throughput agent)
+  agent->setLowPriorityCheckInterval(std::chrono::milliseconds{500});
+  EXPECT_EQ(agent->getLowPriorityCheckInterval(),
+            std::chrono::milliseconds{500});
+
+  // Set to 10ms (ultra-low-latency)
+  agent->setLowPriorityCheckInterval(std::chrono::milliseconds{10});
+  EXPECT_EQ(agent->getLowPriorityCheckInterval(),
+            std::chrono::milliseconds{10});
+}
+
+/**
+ * @brief Test different agents can have different intervals
+ */
+TEST(MessagePriorityTest, DifferentAgentsDifferentIntervals) {
+  auto low_latency_agent = std::make_shared<TestPriorityAgent>("low_latency");
+  auto high_throughput_agent =
+      std::make_shared<TestPriorityAgent>("high_throughput");
+
+  // Configure different intervals
+  low_latency_agent->setLowPriorityCheckInterval(std::chrono::milliseconds{10});
+  high_throughput_agent->setLowPriorityCheckInterval(
+      std::chrono::milliseconds{500});
+
+  // Verify they retain separate configurations
+  EXPECT_EQ(low_latency_agent->getLowPriorityCheckInterval(),
+            std::chrono::milliseconds{10});
+  EXPECT_EQ(high_throughput_agent->getLowPriorityCheckInterval(),
+            std::chrono::milliseconds{500});
+}
+
+/**
+ * @brief Test that fairness mechanism uses configured interval
+ *
+ * This test verifies that the fairness check actually honors the configured
+ * interval by testing with a very short interval (1ms) and ensuring LOW
+ * priority messages get processed even with continuous HIGH priority load.
+ */
+TEST(MessagePriorityTest, FairnessMechanismUsesConfiguredInterval) {
+  auto agent = std::make_shared<TestPriorityAgent>("test_agent");
+
+  // Set very short interval (1ms) to make fairness trigger quickly
+  agent->setLowPriorityCheckInterval(std::chrono::milliseconds{1});
+
+  // Send one LOW priority message
+  auto low_msg = KeystoneMessage::create("sender", "test_agent", "cmd", "LOW");
+  low_msg.priority = Priority::LOW;
+  agent->receiveMessage(low_msg);
+
+  // Send many HIGH priority messages after
+  for (int i = 0; i < 5; ++i) {
+    auto high_msg = KeystoneMessage::create("sender", "test_agent", "cmd",
+                                            "HIGH" + std::to_string(i));
+    high_msg.priority = Priority::HIGH;
+    agent->receiveMessage(high_msg);
+  }
+
+  // Wait for fairness interval to elapse (1ms + safety margin)
+  std::this_thread::sleep_for(std::chrono::milliseconds{5});
+
+  // First getMessage should process HIGH (normal priority order)
+  auto msg1 = agent->getMessage();
+  ASSERT_TRUE(msg1.has_value());
+  EXPECT_EQ(*msg1->payload, "HIGH0");
+
+  // Continue processing HIGH messages
+  auto msg2 = agent->getMessage();
+  ASSERT_TRUE(msg2.has_value());
+  EXPECT_EQ(*msg2->payload, "HIGH1");
+
+  // Wait for another fairness interval
+  std::this_thread::sleep_for(std::chrono::milliseconds{5});
+
+  // Now the fairness mechanism should kick in and process LOW
+  // (even though HIGH messages are still available)
+  auto msg3 = agent->getMessage();
+  ASSERT_TRUE(msg3.has_value());
+  EXPECT_EQ(*msg3->payload, "LOW");
+}
+
+/**
+ * @brief Test thread safety of setting interval concurrently
+ *
+ * Verifies that setLowPriorityCheckInterval is thread-safe using atomics
+ */
+TEST(MessagePriorityTest, ConcurrentIntervalSettingThreadSafe) {
+  auto agent = std::make_shared<TestPriorityAgent>("test_agent");
+
+  // Launch multiple threads setting different intervals
+  std::vector<std::thread> threads;
+  for (int i = 0; i < 10; ++i) {
+    threads.emplace_back([&agent, i]() {
+      agent->setLowPriorityCheckInterval(
+          std::chrono::milliseconds{10 + i * 10});
+    });
+  }
+
+  // Wait for all threads
+  for (auto& t : threads) {
+    t.join();
+  }
+
+  // Should have one of the set values (exact value is non-deterministic due to
+  // race)
+  auto final_interval = agent->getLowPriorityCheckInterval();
+  EXPECT_GE(final_interval.count(), 10);
+  EXPECT_LE(final_interval.count(), 100);
+}
+
+/**
+ * @brief Test extreme interval values
+ */
+TEST(MessagePriorityTest, ExtremeIntervalValues) {
+  auto agent = std::make_shared<TestPriorityAgent>("test_agent");
+
+  // Very short interval (1μs)
+  agent->setLowPriorityCheckInterval(std::chrono::microseconds{1});
+  EXPECT_EQ(agent->getLowPriorityCheckInterval(), std::chrono::microseconds{1});
+
+  // Very long interval (10 seconds)
+  agent->setLowPriorityCheckInterval(std::chrono::seconds{10});
+  EXPECT_EQ(agent->getLowPriorityCheckInterval(), std::chrono::seconds{10});
+
+  // Zero interval (should work but may cause constant fairness checks)
+  agent->setLowPriorityCheckInterval(std::chrono::milliseconds{0});
+  EXPECT_EQ(agent->getLowPriorityCheckInterval(),
+            std::chrono::milliseconds{0});
 }


### PR DESCRIPTION
Implements runtime-configurable fairness check intervals to address different agent latency requirements in heterogeneous HMAS workloads.

Problem (Issue #23):
--------------------
- Global 100ms fairness interval was hardcoded in Config
- High-throughput agents (10K msgs/sec) experienced 1000-message latency for LOW priority messages
- No way to tune latency vs throughput tradeoff per agent
- Latency-sensitive and throughput-optimized agents shared same interval

Solution:
---------
Implemented Option 1 (Per-Agent Configuration) from issue discussion:

1. Added `low_priority_check_interval_ns_` atomic member to AgentBase
2. Added `setLowPriorityCheckInterval()` and `getLowPriorityCheckInterval()`
3. Defaults to Config::AGENT_LOW_PRIORITY_CHECK_INTERVAL (100ms)
4. Each agent can override interval at runtime
5. Thread-safe using atomics (relaxed memory ordering)

Benefits:
---------
- Latency-sensitive agents: use 10-50ms intervals
- Throughput-optimized agents: use 200-500ms intervals
- Runtime tunable: no recompilation needed
- Backward compatible: defaults to existing 100ms global constant
- Simple API: single setter/getter methods
- Zero overhead: atomic loads already in hot path

Changes:
--------
- include/agents/agent_base.hpp:
  * Added low_priority_check_interval_ns_ atomic member
  * Added setLowPriorityCheckInterval() setter with usage examples
  * Added getLowPriorityCheckInterval() getter

- src/agents/agent_base.cpp:
  * Initialize interval to Config default in constructor
  * Updated getMessage() to use per-agent interval

- tests/unit/test_message_priority.cpp:
  * DefaultFairnessIntervalFromConfig: Verify 100ms default
  * SetCustomFairnessInterval: Test 10ms/50ms/500ms configurations
  * DifferentAgentsDifferentIntervals: Verify independence
  * FairnessMechanismUsesConfiguredInterval: Behavioral verification
  * ConcurrentIntervalSettingThreadSafe: Thread safety test
  * ExtremeIntervalValues: Edge case testing (1μs, 10s, 0ms)

- docs/plan/adr/ADR-003-priority-queue-anti-starvation-strategy.md:
  * Added per-agent configuration section
  * Updated tuning guide with use cases
  * Marked Phase 4 adaptive intervals as partially implemented
  * Version bumped to 1.1

Testing:
--------
- 6 new unit tests (100% pass expected)
- Tests cover: defaults, configuration, independence, behavior, thread safety, and edge cases
- Note: Build currently blocked by pre-existing task_agent.cpp compilation error (unrelated to this change)

Design Rationale:
-----------------
Chose Option 1 (per-agent) over Option 2 (adaptive) and Option 3 (priority-specific) because:
- Simple: single setter, backward compatible
- Flexible: supports future adaptive algorithms
- Aligns with architecture: each agent manages own inbox
- Enables Option 2: adaptive code can call setter dynamically

Addresses: #23
Type: Enhancement (P2 - Medium)
Effort: 2 hours (as estimated)