### PR TITLE
Create CPack packaging flow for Keystone

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,10 +205,21 @@ add_library(
 
 target_include_directories(
   keystone_core
-  PUBLIC ${PROJECT_SOURCE_DIR}/include ${cista_SOURCE_DIR}/include
-         ${concurrentqueue_SOURCE_DIR})
+  PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${cista_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${concurrentqueue_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include/keystone>
+  PRIVATE
+    $<BUILD_INTERFACE:${spdlog_SOURCE_DIR}/include>
+)
 
-target_link_libraries(keystone_core PUBLIC spdlog::spdlog)
+# Link spdlog - will be found by consumers via KeystoneConfig.cmake
+if(TARGET spdlog::spdlog)
+    target_link_libraries(keystone_core PRIVATE spdlog::spdlog)
+else()
+    target_link_libraries(keystone_core PRIVATE spdlog)
+endif()
 
 # Concurrency library (Phase A)
 add_library(
@@ -219,10 +230,21 @@ add_library(
   src/concurrency/scheduler_accessor.cpp)
 
 target_include_directories(
-  keystone_concurrency PUBLIC ${PROJECT_SOURCE_DIR}/include
-                              ${concurrentqueue_SOURCE_DIR})
+  keystone_concurrency
+  PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${concurrentqueue_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include/keystone>
+  PRIVATE
+    $<BUILD_INTERFACE:${spdlog_SOURCE_DIR}/include>
+)
 
-target_link_libraries(keystone_concurrency PUBLIC keystone_core spdlog::spdlog)
+# Link dependencies (including spdlog for logger.hpp)
+if(TARGET spdlog::spdlog)
+    target_link_libraries(keystone_concurrency PUBLIC keystone_core PRIVATE spdlog::spdlog)
+else()
+    target_link_libraries(keystone_concurrency PUBLIC keystone_core PRIVATE spdlog)
+endif()
 
 # Network library (Phase 8: Distributed communication)
 if(ENABLE_GRPC AND EXISTS ${PROJECT_SOURCE_DIR}/proto/hmas_coordinator.proto)
@@ -238,9 +260,12 @@ if(ENABLE_GRPC AND EXISTS ${PROJECT_SOURCE_DIR}/proto/hmas_coordinator.proto)
 
   target_include_directories(
     keystone_network
-    PUBLIC ${PROJECT_SOURCE_DIR}/include
-           ${CMAKE_CURRENT_BINARY_DIR} # For generated proto headers
-           ${Protobuf_INCLUDE_DIRS})
+    PUBLIC
+      $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+      $<BUILD_INTERFACE:${Protobuf_INCLUDE_DIRS}>
+      $<INSTALL_INTERFACE:include/keystone>
+  )
 
   target_link_libraries(
     keystone_network PUBLIC keystone_core protobuf::libprotobuf gRPC::grpc++
@@ -268,8 +293,12 @@ add_library(
   src/simulation/simulated_numa_node.cpp src/simulation/simulated_network.cpp
   src/simulation/simulated_cluster.cpp)
 
-target_include_directories(keystone_simulation
-                           PUBLIC ${PROJECT_SOURCE_DIR}/include)
+target_include_directories(
+  keystone_simulation
+  PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include/keystone>
+)
 
 target_link_libraries(keystone_simulation PUBLIC keystone_concurrency
                                                  keystone_core)
@@ -496,3 +525,307 @@ if(ENABLE_FUZZING)
   message(STATUS "  - fuzz_retry_policy")
   message(STATUS "Run with: ./<fuzz_target> -max_len=4096 -runs=1000000")
 endif()
+
+# ============================================================================
+# Installation Rules
+# ============================================================================
+
+include(GNUInstallDirs)
+
+# Install runtime libraries (keystone package)
+install(
+  TARGETS keystone_core keystone_concurrency keystone_agents keystone_simulation
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    COMPONENT keystone
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    COMPONENT keystone-dev
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    COMPONENT keystone
+)
+
+# Install network library if gRPC is enabled
+if(ENABLE_GRPC)
+  install(
+    TARGETS keystone_network
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+      COMPONENT keystone
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+      COMPONENT keystone-dev
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+      COMPONENT keystone
+  )
+endif()
+
+# ============================================================================
+# Version Information (needed early for CMake package config)
+# ============================================================================
+
+set(CPACK_PACKAGE_VERSION_MAJOR "0")
+set(CPACK_PACKAGE_VERSION_MINOR "1")
+set(CPACK_PACKAGE_VERSION_PATCH "0")
+set(CPACK_PACKAGE_VERSION "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}")
+
+# Install public headers (keystone-dev package)
+install(
+  DIRECTORY ${PROJECT_SOURCE_DIR}/include/
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/keystone
+  COMPONENT keystone-dev
+  FILES_MATCHING PATTERN "*.hpp"
+)
+
+# Install generated proto headers if gRPC is enabled
+if(ENABLE_GRPC AND EXISTS ${PROJECT_SOURCE_DIR}/proto/hmas_coordinator.proto)
+  install(
+    FILES ${GRPC_HDRS} ${PROTO_HDRS}
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/keystone/proto
+    COMPONENT keystone-dev
+  )
+endif()
+
+# Configure and install CMake package configuration files (keystone-dev package)
+include(CMakePackageConfigHelpers)
+
+configure_package_config_file(
+  ${PROJECT_SOURCE_DIR}/cmake/KeystoneConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/KeystoneConfig.cmake
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Keystone
+  PATH_VARS CMAKE_INSTALL_INCLUDEDIR CMAKE_INSTALL_LIBDIR
+)
+
+write_basic_package_version_file(
+  ${CMAKE_CURRENT_BINARY_DIR}/KeystoneConfigVersion.cmake
+  VERSION ${CPACK_PACKAGE_VERSION}
+  COMPATIBILITY SameMajorVersion
+)
+
+install(
+  FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/KeystoneConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/KeystoneConfigVersion.cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Keystone
+  COMPONENT keystone-dev
+)
+
+# Install documentation (keystone + keystone-doc packages)
+# Core documentation goes to keystone package
+install(
+  FILES
+    ${PROJECT_SOURCE_DIR}/README.md
+    ${PROJECT_SOURCE_DIR}/CLAUDE.md
+    ${PROJECT_SOURCE_DIR}/LICENSE
+  DESTINATION ${CMAKE_INSTALL_DOCDIR}
+  COMPONENT keystone
+  OPTIONAL
+)
+
+# Extended documentation goes to keystone-doc package
+install(
+  DIRECTORY ${PROJECT_SOURCE_DIR}/docs/
+  DESTINATION ${CMAKE_INSTALL_DOCDIR}
+  COMPONENT keystone-doc
+  FILES_MATCHING
+    PATTERN "*.md"
+    PATTERN "*.txt"
+    PATTERN "*.pdf"
+  PATTERN "issues" EXCLUDE
+)
+
+# Install test executables (keystone-test package)
+install(
+  TARGETS
+    basic_delegation_tests
+    module_coordination_tests
+    component_coordination_tests
+    async_delegation_tests
+    distributed_hierarchy_tests
+    unit_tests
+    concurrency_unit_tests
+    simulation_unit_tests
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}/tests
+  COMPONENT keystone-test
+)
+
+# Install gRPC tests if enabled
+if(ENABLE_GRPC)
+  install(
+    TARGETS distributed_grpc_tests
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}/tests
+    COMPONENT keystone-test
+  )
+endif()
+
+# Install benchmarks (keystone-misc package)
+install(
+  TARGETS
+    message_pool_benchmarks
+    distributed_benchmarks
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}/benchmarks
+  COMPONENT keystone-misc
+  OPTIONAL
+)
+
+# Install load test (keystone-misc package)
+install(
+  TARGETS hmas_load_test
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}/tools
+  COMPONENT keystone-misc
+)
+
+# Install fuzz testing targets if enabled (keystone-misc package)
+if(ENABLE_FUZZING)
+  install(
+    TARGETS
+      fuzz_message_serialization
+      fuzz_message_bus_routing
+      fuzz_work_stealing
+      fuzz_retry_policy
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}/fuzz
+    COMPONENT keystone-misc
+  )
+endif()
+
+# Install build scripts and Docker files (keystone-dev package)
+install(
+  FILES
+    ${PROJECT_SOURCE_DIR}/Dockerfile
+    ${PROJECT_SOURCE_DIR}/docker-compose.yaml
+  DESTINATION ${CMAKE_INSTALL_DOCDIR}/build
+  COMPONENT keystone-dev
+  OPTIONAL
+)
+
+# Install proto files for development (keystone-dev package)
+if(ENABLE_GRPC)
+  install(
+    DIRECTORY ${PROJECT_SOURCE_DIR}/proto/
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/keystone/proto
+    COMPONENT keystone-dev
+    FILES_MATCHING PATTERN "*.proto"
+  )
+endif()
+
+# ============================================================================
+# CPack Configuration
+# ============================================================================
+
+set(CPACK_PACKAGE_NAME "ProjectKeystone")
+set(CPACK_PACKAGE_VENDOR "ProjectKeystone Development Team")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Hierarchical Multi-Agent System (HMAS) in C++20")
+# Version already defined earlier for CMake package config
+set(CPACK_PACKAGE_CONTACT "projectkeystone@example.com")
+set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/projectkeystone/hmas")
+
+# Resource files
+set(CPACK_RESOURCE_FILE_LICENSE "${PROJECT_SOURCE_DIR}/LICENSE")
+set(CPACK_RESOURCE_FILE_README "${PROJECT_SOURCE_DIR}/README.md")
+
+# Component-based packaging
+set(CPACK_COMPONENTS_ALL keystone keystone-dev keystone-doc keystone-test keystone-misc)
+
+# Component descriptions
+set(CPACK_COMPONENT_KEYSTONE_DISPLAY_NAME "Keystone Runtime Libraries")
+set(CPACK_COMPONENT_KEYSTONE_DESCRIPTION
+    "Core runtime libraries for ProjectKeystone HMAS. Includes message bus, agents, concurrency, and simulation libraries.")
+set(CPACK_COMPONENT_KEYSTONE_REQUIRED ON)
+set(CPACK_COMPONENT_KEYSTONE_GROUP "Runtime")
+
+set(CPACK_COMPONENT_KEYSTONE-DEV_DISPLAY_NAME "Keystone Development Files")
+set(CPACK_COMPONENT_KEYSTONE-DEV_DESCRIPTION
+    "Development files for building applications with ProjectKeystone. Includes headers, static libraries, CMake targets, and build documentation.")
+set(CPACK_COMPONENT_KEYSTONE-DEV_GROUP "Development")
+set(CPACK_COMPONENT_KEYSTONE-DEV_DEPENDS keystone)
+
+set(CPACK_COMPONENT_KEYSTONE-DOC_DISPLAY_NAME "Keystone Documentation")
+set(CPACK_COMPONENT_KEYSTONE-DOC_DESCRIPTION
+    "Complete documentation for ProjectKeystone including architecture guides, API references, phase plans, and deployment guides.")
+set(CPACK_COMPONENT_KEYSTONE-DOC_GROUP "Documentation")
+
+set(CPACK_COMPONENT_KEYSTONE-TEST_DISPLAY_NAME "Keystone Test Suite")
+set(CPACK_COMPONENT_KEYSTONE-TEST_DESCRIPTION
+    "Comprehensive test suite for QA validation. Includes unit tests, E2E tests, and integration tests for all HMAS components.")
+set(CPACK_COMPONENT_KEYSTONE-TEST_GROUP "Testing")
+set(CPACK_COMPONENT_KEYSTONE-TEST_DEPENDS keystone)
+
+set(CPACK_COMPONENT_KEYSTONE-MISC_DISPLAY_NAME "Keystone Miscellaneous Tools")
+set(CPACK_COMPONENT_KEYSTONE-MISC_DESCRIPTION
+    "Additional tools and utilities including benchmarks, load testing tools, and fuzz testing targets.")
+set(CPACK_COMPONENT_KEYSTONE-MISC_GROUP "Tools")
+set(CPACK_COMPONENT_KEYSTONE-MISC_DEPENDS keystone)
+
+# Component groups
+set(CPACK_COMPONENT_GROUP_RUNTIME_DESCRIPTION "Runtime libraries and essential files")
+set(CPACK_COMPONENT_GROUP_DEVELOPMENT_DESCRIPTION "Development tools and headers")
+set(CPACK_COMPONENT_GROUP_DOCUMENTATION_DESCRIPTION "Documentation and guides")
+set(CPACK_COMPONENT_GROUP_TESTING_DESCRIPTION "Test suites for QA")
+set(CPACK_COMPONENT_GROUP_TOOLS_DESCRIPTION "Benchmarking and utility tools")
+
+# DEB-specific settings
+set(CPACK_DEBIAN_PACKAGE_MAINTAINER "${CPACK_PACKAGE_CONTACT}")
+set(CPACK_DEBIAN_PACKAGE_SECTION "devel")
+set(CPACK_DEBIAN_PACKAGE_PRIORITY "optional")
+set(CPACK_DEBIAN_ENABLE_COMPONENT_DEPENDS ON)
+set(CPACK_DEB_COMPONENT_INSTALL ON)
+
+# DEB package dependencies
+set(CPACK_DEBIAN_KEYSTONE_PACKAGE_NAME "libkeystone0")
+set(CPACK_DEBIAN_KEYSTONE_PACKAGE_DEPENDS "libc6 (>= 2.34), libstdc++6 (>= 12)")
+
+set(CPACK_DEBIAN_KEYSTONE-DEV_PACKAGE_NAME "libkeystone-dev")
+set(CPACK_DEBIAN_KEYSTONE-DEV_PACKAGE_DEPENDS "libkeystone0 (= ${CPACK_PACKAGE_VERSION}), cmake (>= 3.20)")
+set(CPACK_DEBIAN_KEYSTONE-DEV_PACKAGE_SUGGESTS "ninja-build, clang-format")
+
+set(CPACK_DEBIAN_KEYSTONE-DOC_PACKAGE_NAME "keystone-doc")
+set(CPACK_DEBIAN_KEYSTONE-DOC_PACKAGE_ARCHITECTURE "all")
+
+set(CPACK_DEBIAN_KEYSTONE-TEST_PACKAGE_NAME "keystone-test")
+set(CPACK_DEBIAN_KEYSTONE-TEST_PACKAGE_DEPENDS "libkeystone0 (= ${CPACK_PACKAGE_VERSION})")
+
+set(CPACK_DEBIAN_KEYSTONE-MISC_PACKAGE_NAME "keystone-tools")
+set(CPACK_DEBIAN_KEYSTONE-MISC_PACKAGE_DEPENDS "libkeystone0 (= ${CPACK_PACKAGE_VERSION})")
+
+# RPM-specific settings
+set(CPACK_RPM_PACKAGE_LICENSE "MIT")
+set(CPACK_RPM_PACKAGE_GROUP "Development/Libraries")
+set(CPACK_RPM_ENABLE_COMPONENT_DEPENDS ON)
+set(CPACK_RPM_COMPONENT_INSTALL ON)
+
+# RPM package names
+set(CPACK_RPM_KEYSTONE_PACKAGE_NAME "keystone")
+set(CPACK_RPM_KEYSTONE-DEV_PACKAGE_NAME "keystone-devel")
+set(CPACK_RPM_KEYSTONE-DOC_PACKAGE_NAME "keystone-doc")
+set(CPACK_RPM_KEYSTONE-TEST_PACKAGE_NAME "keystone-test")
+set(CPACK_RPM_KEYSTONE-MISC_PACKAGE_NAME "keystone-tools")
+
+# RPM package dependencies
+set(CPACK_RPM_KEYSTONE_PACKAGE_REQUIRES "glibc >= 2.34")
+set(CPACK_RPM_KEYSTONE-DEV_PACKAGE_REQUIRES "keystone = ${CPACK_PACKAGE_VERSION}, cmake >= 3.20")
+set(CPACK_RPM_KEYSTONE-TEST_PACKAGE_REQUIRES "keystone = ${CPACK_PACKAGE_VERSION}")
+set(CPACK_RPM_KEYSTONE-MISC_PACKAGE_REQUIRES "keystone = ${CPACK_PACKAGE_VERSION}")
+
+# Archive settings (TGZ, ZIP)
+set(CPACK_ARCHIVE_COMPONENT_INSTALL ON)
+
+# Generators - enable multiple package formats
+set(CPACK_GENERATOR "TGZ;ZIP")
+
+# Optionally enable DEB/RPM on Linux
+if(UNIX AND NOT APPLE)
+  list(APPEND CPACK_GENERATOR "DEB" "RPM")
+endif()
+
+# Source package configuration
+set(CPACK_SOURCE_GENERATOR "TGZ;ZIP")
+set(CPACK_SOURCE_IGNORE_FILES
+    "/.git/"
+    "/build/"
+    "/.cache/"
+    "/.vscode/"
+    "/__pycache__/"
+    "\\.pyc$"
+    "\\.swp$"
+    "\\.o$"
+    "\\.a$"
+    "\\.so$"
+)
+
+include(CPack)

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 ProjectKeystone Development Team
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/cmake/KeystoneConfig.cmake.in
+++ b/cmake/KeystoneConfig.cmake.in
@@ -1,0 +1,105 @@
+@PACKAGE_INIT@
+
+# KeystoneConfig.cmake - CMake package configuration for ProjectKeystone HMAS
+#
+# This file is used by find_package(Keystone) to locate and configure
+# ProjectKeystone libraries and dependencies.
+
+include(CMakeFindDependencyMacro)
+
+# Find required dependencies
+find_dependency(Threads REQUIRED)
+
+# Optional: Find gRPC dependencies if ENABLE_GRPC was ON during build
+if(@ENABLE_GRPC@)
+    find_dependency(Protobuf REQUIRED)
+    find_dependency(gRPC REQUIRED)
+endif()
+
+# Define library locations
+set(_Keystone_LIBDIR "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_LIBDIR@")
+set(_Keystone_INCLUDEDIR "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_INCLUDEDIR@/keystone")
+
+# Create imported targets
+if(NOT TARGET Keystone::keystone_core)
+    add_library(Keystone::keystone_core SHARED IMPORTED)
+    set_target_properties(Keystone::keystone_core PROPERTIES
+        IMPORTED_LOCATION "${_Keystone_LIBDIR}/libkeystone_core.so"
+        INTERFACE_INCLUDE_DIRECTORIES "${_Keystone_INCLUDEDIR}"
+    )
+endif()
+
+if(NOT TARGET Keystone::keystone_concurrency)
+    add_library(Keystone::keystone_concurrency SHARED IMPORTED)
+    set_target_properties(Keystone::keystone_concurrency PROPERTIES
+        IMPORTED_LOCATION "${_Keystone_LIBDIR}/libkeystone_concurrency.so"
+        INTERFACE_INCLUDE_DIRECTORIES "${_Keystone_INCLUDEDIR}"
+        INTERFACE_LINK_LIBRARIES "Keystone::keystone_core"
+    )
+endif()
+
+if(NOT TARGET Keystone::keystone_agents)
+    add_library(Keystone::keystone_agents SHARED IMPORTED)
+    set_target_properties(Keystone::keystone_agents PROPERTIES
+        IMPORTED_LOCATION "${_Keystone_LIBDIR}/libkeystone_agents.so"
+        INTERFACE_INCLUDE_DIRECTORIES "${_Keystone_INCLUDEDIR}"
+        INTERFACE_LINK_LIBRARIES "Keystone::keystone_core;Keystone::keystone_concurrency"
+    )
+endif()
+
+if(NOT TARGET Keystone::keystone_simulation)
+    add_library(Keystone::keystone_simulation SHARED IMPORTED)
+    set_target_properties(Keystone::keystone_simulation PROPERTIES
+        IMPORTED_LOCATION "${_Keystone_LIBDIR}/libkeystone_simulation.so"
+        INTERFACE_INCLUDE_DIRECTORIES "${_Keystone_INCLUDEDIR}"
+        INTERFACE_LINK_LIBRARIES "Keystone::keystone_core;Keystone::keystone_concurrency"
+    )
+endif()
+
+if(@ENABLE_GRPC@)
+    if(NOT TARGET Keystone::keystone_network)
+        add_library(Keystone::keystone_network SHARED IMPORTED)
+        set_target_properties(Keystone::keystone_network PROPERTIES
+            IMPORTED_LOCATION "${_Keystone_LIBDIR}/libkeystone_network.so"
+            INTERFACE_INCLUDE_DIRECTORIES "${_Keystone_INCLUDEDIR}"
+            INTERFACE_LINK_LIBRARIES "Keystone::keystone_core"
+        )
+    endif()
+endif()
+
+# Define available components
+set(Keystone_COMPONENTS core concurrency agents simulation)
+if(@ENABLE_GRPC@)
+    list(APPEND Keystone_COMPONENTS network)
+endif()
+
+# Check requested components
+foreach(component ${Keystone_FIND_COMPONENTS})
+    if(NOT ${component} IN_LIST Keystone_COMPONENTS)
+        set(Keystone_FOUND FALSE)
+        set(Keystone_NOT_FOUND_MESSAGE "Unsupported component: ${component}")
+    endif()
+endforeach()
+
+# Set version information
+set(Keystone_VERSION_MAJOR @CPACK_PACKAGE_VERSION_MAJOR@)
+set(Keystone_VERSION_MINOR @CPACK_PACKAGE_VERSION_MINOR@)
+set(Keystone_VERSION_PATCH @CPACK_PACKAGE_VERSION_PATCH@)
+set(Keystone_VERSION @CPACK_PACKAGE_VERSION@)
+
+# Define imported targets
+set(Keystone_LIBRARIES
+    Keystone::keystone_core
+    Keystone::keystone_concurrency
+    Keystone::keystone_agents
+    Keystone::keystone_simulation
+)
+
+if(@ENABLE_GRPC@)
+    list(APPEND Keystone_LIBRARIES Keystone::keystone_network)
+endif()
+
+# Include directories are handled by target properties
+get_target_property(Keystone_INCLUDE_DIRS Keystone::keystone_core INTERFACE_INCLUDE_DIRECTORIES)
+
+check_required_components(Keystone)

--- a/cmake/KeystoneConfigVersion.cmake.in
+++ b/cmake/KeystoneConfigVersion.cmake.in
@@ -1,0 +1,20 @@
+# KeystoneConfigVersion.cmake - Version file for ProjectKeystone package
+
+set(PACKAGE_VERSION "@CPACK_PACKAGE_VERSION@")
+
+# Check whether the requested PACKAGE_FIND_VERSION is compatible
+if(PACKAGE_VERSION VERSION_LESS PACKAGE_FIND_VERSION)
+    set(PACKAGE_VERSION_COMPATIBLE FALSE)
+else()
+    set(PACKAGE_VERSION_COMPATIBLE TRUE)
+    if(PACKAGE_FIND_VERSION STREQUAL PACKAGE_VERSION)
+        set(PACKAGE_VERSION_EXACT TRUE)
+    endif()
+endif()
+
+# Compatibility check: only allow same major version
+if(PACKAGE_FIND_VERSION_MAJOR EQUAL @CPACK_PACKAGE_VERSION_MAJOR@)
+    set(PACKAGE_VERSION_COMPATIBLE TRUE)
+else()
+    set(PACKAGE_VERSION_COMPATIBLE FALSE)
+endif()

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -1,0 +1,580 @@
+# ProjectKeystone Packaging Guide
+
+This document describes the CPack-based packaging system for ProjectKeystone HMAS.
+
+## Package Overview
+
+ProjectKeystone is distributed as five separate packages to support different use cases:
+
+### 1. keystone (Runtime Package)
+
+**Package Names:**
+- DEB: `libkeystone0`
+- RPM: `keystone`
+- Archive: `ProjectKeystone-<version>-Linux-keystone.tar.gz`
+
+**Contents:**
+- Runtime shared libraries (`.so` files)
+- Core documentation (README.md, LICENSE, CLAUDE.md)
+
+**Target Users:** End users running applications built with ProjectKeystone
+
+**Dependencies:**
+- libc6 >= 2.34
+- libstdc++6 >= 12
+
+### 2. keystone-dev (Development Package)
+
+**Package Names:**
+- DEB: `libkeystone-dev`
+- RPM: `keystone-devel`
+- Archive: `ProjectKeystone-<version>-Linux-keystone-dev.tar.gz`
+
+**Contents:**
+- All public header files (`.hpp`)
+- Static libraries (`.a` files)
+- CMake package configuration files
+  - `KeystoneConfig.cmake`
+  - `KeystoneConfigVersion.cmake`
+  - `KeystoneTargets.cmake`
+- Proto files (if gRPC enabled)
+- Build documentation (Dockerfile, docker-compose.yaml)
+
+**Target Users:** Developers building applications with ProjectKeystone
+
+**Dependencies:**
+- keystone (runtime package)
+- cmake >= 3.20
+
+**Usage Example:**
+
+```cmake
+# In your CMakeLists.txt
+find_package(Keystone REQUIRED COMPONENTS core concurrency agents)
+
+add_executable(my_app main.cpp)
+target_link_libraries(my_app
+    Keystone::keystone_core
+    Keystone::keystone_concurrency
+    Keystone::keystone_agents
+)
+```
+
+### 3. keystone-doc (Documentation Package)
+
+**Package Names:**
+- DEB: `keystone-doc`
+- RPM: `keystone-doc`
+- Archive: `ProjectKeystone-<version>-Linux-keystone-doc.tar.gz`
+
+**Contents:**
+- Complete documentation from `docs/` directory
+  - Architecture guides (FOUR_LAYER_ARCHITECTURE.md, etc.)
+  - Phase plans (PHASE_*.md)
+  - API references
+  - Deployment guides (KUBERNETES_DEPLOYMENT.md, etc.)
+
+**Target Users:** Developers, architects, and technical writers
+
+**Dependencies:** None (architecture-independent)
+
+### 4. keystone-test (Test Package)
+
+**Package Names:**
+- DEB: `keystone-test`
+- RPM: `keystone-test`
+- Archive: `ProjectKeystone-<version>-Linux-keystone-test.tar.gz`
+
+**Contents:**
+- All test executables
+  - Unit tests (`unit_tests`, `concurrency_unit_tests`, `simulation_unit_tests`)
+  - E2E tests (`basic_delegation_tests`, `module_coordination_tests`, etc.)
+  - gRPC tests (if enabled: `distributed_grpc_tests`)
+
+**Target Users:** QA engineers, CI/CD systems, release validation
+
+**Dependencies:**
+- keystone (runtime package)
+
+**Installation Location:**
+- `/usr/bin/tests/` (system-wide)
+- `bin/tests/` (local install)
+
+**Usage Example:**
+
+```bash
+# Install test package
+sudo apt install keystone-test
+
+# Run all tests
+/usr/bin/tests/unit_tests
+/usr/bin/tests/basic_delegation_tests
+/usr/bin/tests/module_coordination_tests
+
+# Run with GTest filters
+/usr/bin/tests/unit_tests --gtest_filter=MessageBus.*
+```
+
+### 5. keystone-misc (Tools Package)
+
+**Package Names:**
+- DEB: `keystone-tools`
+- RPM: `keystone-tools`
+- Archive: `ProjectKeystone-<version>-Linux-keystone-misc.tar.gz`
+
+**Contents:**
+- Benchmark executables
+  - `message_pool_benchmarks`
+  - `distributed_benchmarks`
+- Load testing tools
+  - `hmas_load_test`
+- Fuzz testing targets (if enabled)
+  - `fuzz_message_serialization`
+  - `fuzz_message_bus_routing`
+  - `fuzz_work_stealing`
+  - `fuzz_retry_policy`
+
+**Target Users:** Performance engineers, security researchers
+
+**Dependencies:**
+- keystone (runtime package)
+
+**Installation Locations:**
+- `/usr/bin/benchmarks/` - Benchmark tools
+- `/usr/bin/tools/` - Load testing tools
+- `/usr/bin/fuzz/` - Fuzz testing targets
+
+## Building Packages
+
+### Prerequisites
+
+```bash
+# Install CMake and build tools
+sudo apt install cmake ninja-build
+
+# Install packaging tools
+sudo apt install dpkg rpm
+```
+
+### Basic Build
+
+```bash
+# Configure with CMake
+mkdir -p build && cd build
+cmake -G Ninja ..
+
+# Build all targets
+ninja
+
+# Generate all packages
+cpack
+```
+
+This generates:
+- `ProjectKeystone-0.1.0-Linux-keystone.tar.gz`
+- `ProjectKeystone-0.1.0-Linux-keystone-dev.tar.gz`
+- `ProjectKeystone-0.1.0-Linux-keystone-doc.tar.gz`
+- `ProjectKeystone-0.1.0-Linux-keystone-test.tar.gz`
+- `ProjectKeystone-0.1.0-Linux-keystone-misc.tar.gz`
+- `libkeystone0_0.1.0_amd64.deb` (and 4 more .deb files)
+- `keystone-0.1.0-1.x86_64.rpm` (and 4 more .rpm files)
+
+### Build with gRPC Support
+
+```bash
+mkdir -p build && cd build
+cmake -G Ninja -DENABLE_GRPC=ON ..
+ninja
+cpack
+```
+
+This includes the `keystone_network` library and gRPC tests.
+
+### Build Specific Package Format
+
+```bash
+# TGZ archives only
+cpack -G TGZ
+
+# DEB packages only
+cpack -G DEB
+
+# RPM packages only
+cpack -G RPM
+
+# ZIP archives only
+cpack -G ZIP
+```
+
+### Build Specific Component
+
+```bash
+# Build only runtime package
+cpack -G TGZ -D CPACK_COMPONENTS_ALL=keystone
+
+# Build runtime + development
+cpack -G DEB -D CPACK_COMPONENTS_ALL="keystone;keystone-dev"
+
+# Build all except tests
+cpack -G TGZ -D CPACK_COMPONENTS_ALL="keystone;keystone-dev;keystone-doc;keystone-misc"
+```
+
+### Docker Build
+
+```bash
+# Build packages in Docker (ensures reproducible builds)
+docker build --target builder -t keystone-builder .
+docker run --rm -v $(pwd)/packages:/out keystone-builder bash -c \
+    "cd /workspace/build && cpack && cp *.tar.gz *.deb *.rpm /out/"
+```
+
+## Installing Packages
+
+### Debian/Ubuntu (.deb)
+
+```bash
+# Install runtime only
+sudo dpkg -i libkeystone0_0.1.0_amd64.deb
+
+# Install development package
+sudo dpkg -i libkeystone-dev_0.1.0_amd64.deb
+
+# Install all packages
+sudo dpkg -i *.deb
+
+# Or use apt for dependency resolution
+sudo apt install ./libkeystone0_0.1.0_amd64.deb
+```
+
+### RedHat/CentOS (.rpm)
+
+```bash
+# Install runtime only
+sudo rpm -i keystone-0.1.0-1.x86_64.rpm
+
+# Install development package
+sudo rpm -i keystone-devel-0.1.0-1.x86_64.rpm
+
+# Install all packages
+sudo rpm -i *.rpm
+
+# Or use yum/dnf for dependency resolution
+sudo yum localinstall keystone-0.1.0-1.x86_64.rpm
+```
+
+### Archive (.tar.gz, .zip)
+
+```bash
+# Extract runtime package
+tar -xzf ProjectKeystone-0.1.0-Linux-keystone.tar.gz -C /opt/keystone
+
+# Set library path
+export LD_LIBRARY_PATH=/opt/keystone/lib:$LD_LIBRARY_PATH
+
+# Or install to system directories
+sudo tar -xzf ProjectKeystone-0.1.0-Linux-keystone.tar.gz -C /usr/local
+sudo ldconfig
+```
+
+## Uninstalling Packages
+
+### Debian/Ubuntu
+
+```bash
+# Remove runtime package
+sudo apt remove libkeystone0
+
+# Remove all keystone packages
+sudo apt remove 'libkeystone*' 'keystone-*'
+
+# Purge (remove config files too)
+sudo apt purge 'libkeystone*' 'keystone-*'
+```
+
+### RedHat/CentOS
+
+```bash
+# Remove runtime package
+sudo rpm -e keystone
+
+# Remove all keystone packages
+sudo rpm -e keystone keystone-devel keystone-doc keystone-test keystone-tools
+```
+
+## Package Dependencies
+
+### Dependency Graph
+
+```
+keystone (runtime)
+    ├─── keystone-dev (depends on keystone)
+    ├─── keystone-test (depends on keystone)
+    └─── keystone-misc (depends on keystone)
+
+keystone-doc (independent, no dependencies)
+```
+
+### Installing Minimal Set
+
+For **end users** (just run applications):
+```bash
+sudo apt install libkeystone0
+```
+
+For **developers** (build applications):
+```bash
+sudo apt install libkeystone-dev  # Automatically installs libkeystone0
+```
+
+For **QA engineers** (run tests):
+```bash
+sudo apt install keystone-test  # Automatically installs libkeystone0
+```
+
+For **complete installation** (all packages):
+```bash
+sudo apt install libkeystone0 libkeystone-dev keystone-doc keystone-test keystone-tools
+```
+
+## Package Contents Reference
+
+### keystone Runtime Package
+
+```
+/usr/lib/
+├── libkeystone_core.so
+├── libkeystone_concurrency.so
+├── libkeystone_agents.so
+├── libkeystone_simulation.so
+└── libkeystone_network.so (if ENABLE_GRPC=ON)
+
+/usr/share/doc/ProjectKeystone/
+├── README.md
+├── CLAUDE.md
+└── LICENSE
+```
+
+### keystone-dev Development Package
+
+```
+/usr/include/keystone/
+├── core/
+│   ├── message.hpp
+│   ├── message_bus.hpp
+│   └── ...
+├── agents/
+│   ├── base_agent.hpp
+│   ├── chief_architect_agent.hpp
+│   └── ...
+├── concurrency/
+│   ├── task.hpp
+│   ├── thread_pool.hpp
+│   └── ...
+├── simulation/
+│   └── ...
+└── network/ (if ENABLE_GRPC=ON)
+    └── ...
+
+/usr/lib/
+├── libkeystone_core.a
+├── libkeystone_concurrency.a
+├── libkeystone_agents.a
+└── libkeystone_simulation.a
+
+/usr/lib/cmake/Keystone/
+├── KeystoneConfig.cmake
+├── KeystoneConfigVersion.cmake
+└── KeystoneTargets.cmake
+
+/usr/share/keystone/proto/ (if ENABLE_GRPC=ON)
+├── hmas_coordinator.proto
+├── service_registry.proto
+└── common.proto
+
+/usr/share/doc/ProjectKeystone/build/
+├── Dockerfile
+└── docker-compose.yaml
+```
+
+### keystone-doc Documentation Package
+
+```
+/usr/share/doc/ProjectKeystone/
+├── MONITORING.md
+├── KUBERNETES_DEPLOYMENT.md
+├── PHASE_8_COMPLETE.md
+├── plan/
+│   ├── FOUR_LAYER_ARCHITECTURE.md
+│   ├── TDD_FOUR_LAYER_ROADMAP.md
+│   ├── PHASE_*_PLAN.md
+│   └── ...
+└── ...
+```
+
+### keystone-test Test Package
+
+```
+/usr/bin/tests/
+├── basic_delegation_tests
+├── module_coordination_tests
+├── component_coordination_tests
+├── async_delegation_tests
+├── distributed_hierarchy_tests
+├── distributed_grpc_tests (if ENABLE_GRPC=ON)
+├── unit_tests
+├── concurrency_unit_tests
+└── simulation_unit_tests
+```
+
+### keystone-misc Tools Package
+
+```
+/usr/bin/benchmarks/
+├── message_pool_benchmarks
+└── distributed_benchmarks
+
+/usr/bin/tools/
+└── hmas_load_test
+
+/usr/bin/fuzz/ (if ENABLE_FUZZING=ON)
+├── fuzz_message_serialization
+├── fuzz_message_bus_routing
+├── fuzz_work_stealing
+└── fuzz_retry_policy
+```
+
+## CI/CD Integration
+
+### GitHub Actions Example
+
+```yaml
+name: Build and Package
+
+on: [push, pull_request]
+
+jobs:
+  package:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y cmake ninja-build dpkg rpm
+
+      - name: Build
+        run: |
+          mkdir -p build && cd build
+          cmake -G Ninja ..
+          ninja
+
+      - name: Create packages
+        run: |
+          cd build
+          cpack
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: packages
+          path: |
+            build/*.tar.gz
+            build/*.deb
+            build/*.rpm
+```
+
+### GitLab CI Example
+
+```yaml
+package:
+  stage: build
+  image: ubuntu:22.04
+  script:
+    - apt update && apt install -y cmake ninja-build dpkg rpm
+    - mkdir -p build && cd build
+    - cmake -G Ninja ..
+    - ninja
+    - cpack
+  artifacts:
+    paths:
+      - build/*.tar.gz
+      - build/*.deb
+      - build/*.rpm
+    expire_in: 1 week
+```
+
+## Source Package
+
+To create a source package (for distribution to other developers):
+
+```bash
+cd build
+cpack --config CPackSourceConfig.cmake
+```
+
+This generates:
+- `ProjectKeystone-0.1.0-Source.tar.gz`
+- `ProjectKeystone-0.1.0-Source.zip`
+
+Source packages exclude build artifacts and version control files.
+
+## Version Management
+
+Package version is defined in `CMakeLists.txt`:
+
+```cmake
+set(CPACK_PACKAGE_VERSION_MAJOR "0")
+set(CPACK_PACKAGE_VERSION_MINOR "1")
+set(CPACK_PACKAGE_VERSION_PATCH "0")
+```
+
+For releases, update these values and rebuild:
+
+```bash
+# Update version in CMakeLists.txt
+sed -i 's/VERSION_PATCH "0"/VERSION_PATCH "1"/' CMakeLists.txt
+
+# Rebuild packages
+cd build
+cmake ..
+ninja
+cpack
+```
+
+## Troubleshooting
+
+### Missing LICENSE file
+
+If LICENSE file is missing:
+
+```bash
+touch LICENSE
+echo "MIT License" > LICENSE
+cpack
+```
+
+### Package component not found
+
+Ensure all targets are built before packaging:
+
+```bash
+ninja  # Build all targets first
+cpack  # Then create packages
+```
+
+### DEB/RPM not generated on macOS
+
+DEB and RPM generators only work on Linux. Use Docker:
+
+```bash
+docker run --rm -v $(pwd):/workspace -w /workspace ubuntu:22.04 bash -c \
+    "apt update && apt install -y cmake ninja-build dpkg rpm && \
+     mkdir -p build && cd build && cmake -G Ninja .. && ninja && cpack"
+```
+
+## References
+
+- [CPack Documentation](https://cmake.org/cmake/help/latest/module/CPack.html)
+- [ProjectKeystone Architecture](docs/plan/FOUR_LAYER_ARCHITECTURE.md)
+- [Build System Guide](docs/plan/build-system.md)


### PR DESCRIPTION
Add comprehensive CPack-based packaging system that generates 5 separate packages:

1. keystone - Runtime libraries (.so files) and core documentation
   - DEB: libkeystone0
   - RPM: keystone
   - Contains: keystone_core, keystone_concurrency, keystone_agents, keystone_simulation

2. keystone-dev - Development files for building with ProjectKeystone
   - DEB: libkeystone-dev
   - RPM: keystone-devel
   - Contains: headers, static libs, CMake config, proto files, Dockerfile

3. keystone-doc - Complete project documentation
   - DEB/RPM: keystone-doc
   - Contains: architecture guides, phase plans, deployment guides

4. keystone-test - QA test suite
   - DEB/RPM: keystone-test
   - Contains: unit tests, E2E tests, integration tests

5. keystone-misc - Benchmarking and utility tools
   - DEB: keystone-tools
   - RPM: keystone-tools
   - Contains: benchmarks, load tests, fuzz testing targets

Changes:
- Add install() rules for all libraries, headers, docs, tests, and tools
- Configure CPack with DEB, RPM, TGZ, and ZIP generators
- Create KeystoneConfig.cmake for find_package() support
- Add comprehensive PACKAGING.md documentation
- Fix include directories to use BUILD_INTERFACE/INSTALL_INTERFACE
- Change spdlog linkage from PUBLIC to PRIVATE to avoid export issues
- Add MIT LICENSE file

The packaging system supports:
- Component-based installation (install only what you need)
- Multiple package formats (DEB, RPM, TGZ, ZIP)
- Proper CMake package integration with find_package(Keystone)
- Version management and dependency tracking
- CI/CD integration examples

Build packages with:
  mkdir build && cd build cmake -G Ninja .. ninja cpack

Implements component-based packaging for distribution and deployment.