### PR TITLE
fix: Update documentation from Catch2 to Google Test (Issue #53 Task 2.1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,12 +231,22 @@ ProjectKeystone/
 
 ```cpp
 // E2E tests (Google Test)
-TEST(E2E_Phase1, ChiefArchitectDelegatesToTaskAgent)
-TEST(E2E_Phase2, ModuleLeadSynthesizesTaskResults)
+TEST(E2E_Phase1, ChiefArchitectDelegatesToTaskAgent) {
+    // Test implementation
+}
+
+TEST(E2E_Phase2, ModuleLeadSynthesizesTaskResults) {
+    // Test implementation
+}
 
 // Unit tests (Google Test)
-TEST(MessageQueueTest, CanPushAndPopMessages)
-TEST(ThreadPoolTest, SubmitsAndExecutesTasks)
+TEST(MessageQueueTest, CanPushAndPopMessages) {
+    // Test implementation
+}
+
+TEST(ThreadPoolTest, SubmitsAndExecutesTasks) {
+    // Test implementation
+}
 ```
 
 ### Git Workflow
@@ -394,8 +404,13 @@ E2E tests drive development. Each phase has specific E2E tests:
 **Phase 1**: Basic delegation (L0 → L3)
 
 ```cpp
-TEST_CASE("ChiefArchitect delegates to TaskAgent", "[e2e][phase1]")
-TEST_CASE("ChiefArchitect coordinates three TaskAgents", "[e2e][phase1]")
+TEST(E2E_Phase1, ChiefArchitectDelegatesToTaskAgent) {
+    // Test implementation
+}
+
+TEST(E2E_Phase1, ChiefArchitectCoordinatesThreeTaskAgents) {
+    // Test implementation
+}
 ```
 
 See [testing-strategy.md](docs/plan/testing-strategy.md) for complete test catalog.

--- a/docs/plan/MIGRATION_ARCHITECTURE_C2_C3.md
+++ b/docs/plan/MIGRATION_ARCHITECTURE_C2_C3.md
@@ -147,9 +147,9 @@ EXPECT_EQ(response.status, Response::Status::Success);
 
 ### Example: E2E Test Migration
 
-**Before** (`tests/e2e/phase1_basic_delegation.cpp`):
+**Before** (`tests/e2e/phase1_basic_delegation.cpp`) - C1 (unique_ptr + raw pointers):
 ```cpp
-TEST_CASE("ChiefArchitect delegates to TaskAgent") {
+TEST(E2E_Phase1, ChiefArchitectDelegatesToTaskAgent) {
     MessageBus bus;
 
     // Create agents (unique_ptr, raw pointer registration)
@@ -166,13 +166,13 @@ TEST_CASE("ChiefArchitect delegates to TaskAgent") {
     auto msg = KeystoneMessage::create("chief", "task", "echo hello");
     auto response = task->processMessage(msg);  // Sync
 
-    REQUIRE(response.status == Response::Status::Success);
+    EXPECT_EQ(response.status, Response::Status::Success);
 }
 ```
 
-**After** (`tests/e2e/phase1_basic_delegation.cpp`):
+**After** (`tests/e2e/phase1_basic_delegation.cpp`) - C2/C3 (shared_ptr + async):
 ```cpp
-TEST_CASE("ChiefArchitect delegates to TaskAgent") {
+TEST(E2E_Phase1, ChiefArchitectDelegatesToTaskAgent) {
     MessageBus bus;
 
     // FIX C2: Create agents with shared_ptr
@@ -190,7 +190,7 @@ TEST_CASE("ChiefArchitect delegates to TaskAgent") {
     auto task_result = task->processMessage(msg);  // Returns Task<Response>
     auto response = task_result.get();  // Get result from coroutine
 
-    REQUIRE(response.status == Response::Status::Success);
+    EXPECT_EQ(response.status, Response::Status::Success);
 }
 ```
 

--- a/docs/plan/adr/ADR-013-coroutine-safety-patterns.md
+++ b/docs/plan/adr/ADR-013-coroutine-safety-patterns.md
@@ -610,8 +610,11 @@ GoodTask<int> will_compile() {
 ### Testing Coroutine Safety
 
 ```cpp
+#include <gtest/gtest.h>
+#include "concurrency/task.hpp"
+
 // Unit test: Verify Task RAII
-TEST_CASE("Task destructor cleans up coroutine handle") {
+TEST(CoroutineSafetyTest, TaskDestructorCleansUpCoroutineHandle) {
     {
         Task<int> task = simple_coro();
         auto handle = task.get_handle();
@@ -621,13 +624,13 @@ TEST_CASE("Task destructor cleans up coroutine handle") {
 }
 
 // Unit test: Exception safety
-TEST_CASE("Task captures and re-throws exceptions") {
+TEST(CoroutineSafetyTest, TaskCapturesAndRethrowsExceptions) {
     Task<int> task = throwing_coro();
-    EXPECT_THROWS([&]() { task.get(); });
+    EXPECT_THROW(task.get(), std::runtime_error);
 }
 
 // Unit test: Symmetric transfer
-TEST_CASE("Coroutine chains work without stack overflow") {
+TEST(CoroutineSafetyTest, CoroutineChainsWorkWithoutStackOverflow) {
     Task<int> result = deep_chain(1000);  // 1000 levels deep
     EXPECT_EQ(result.get(), 1000);  // Should complete without stack error
 }

--- a/docs/plan/testing-strategy.md
+++ b/docs/plan/testing-strategy.md
@@ -314,13 +314,14 @@ BENCHMARK_MAIN();
 
 ```cpp
 // tests/stress/ChaosTest.cpp
-#include <catch2/catch_test_macros.hpp>
+#include <gtest/gtest.h>
 #include "agents/chief_architect_agent.hpp"
 #include "core/thread_pool.hpp"
 
 namespace Keystone::Stress::Test {
 
-struct ChaosFixture {
+class ChaosTest : public ::testing::Test {
+protected:
     // Randomly kill agents
     void injectAgentFailure() {
         // Implementation...
@@ -362,7 +363,7 @@ TEST_F(ChaosTest, SystemHandlesRandomAgentFailures) {
 }
 
 TEST(StressTest, LongDurationStability) {
-    // Run for 24 hours (tagged with .long to exclude from normal runs)
+    // Run for 24 hours (marked as long-running, exclude from regular test runs)
     auto start = std::chrono::steady_clock::now();
     auto end = start + std::chrono::hours(24);
 
@@ -454,7 +455,7 @@ Profiling tests are located in `tests/unit/test_profiling.cpp` and validate:
 
 ```cpp
 // Step 1: RED - Write failing test
-TEST_CASE("AgentBase can send messages", "[unit][agent-base]") {
+TEST(AgentBaseTest, CanSendMessages) {
     AgentBase sender, receiver;
     KeystoneMessage msg = MessageBuilder()
         .from(sender.getId())
@@ -726,23 +727,27 @@ TEST(RootAgentTest, CreatesMultipleBranchesForComplexTaskDecomposition)
 
 ```cpp
 // BAD: Tests depend on each other
-TEST_CASE("Initialize global state", "[bad]") {
-    global_state = initialize();  // ❌ Shared state
+static State global_state;  // ❌ Global state shared across tests
+
+TEST(BadTestExample, InitializeGlobalState) {
+    global_state = initialize();
 }
-TEST_CASE("Check state is ready", "[bad]") {
-    REQUIRE(global_state.isReady());  // ❌ Depends on previous test
+
+TEST(BadTestExample, CheckStateIsReady) {
+    EXPECT_TRUE(global_state.isReady());  // ❌ Depends on previous test
 }
 
 // GOOD: Each test is independent using fixtures
-struct GoodExampleFixture {
-    GoodExampleFixture() {
+class GoodExampleTest : public ::testing::Test {
+protected:
+    void SetUp() override {
         state_ = initialize();  // ✅ Fresh state per test
     }
     State state_;
 };
 
 TEST_F(GoodExampleTest, StateIsProperlyInitialized) {
-    ASSERT_TRUE(state_.isReady());
+    EXPECT_TRUE(state_.isReady());
 }
 ```
 
@@ -750,19 +755,19 @@ TEST_F(GoodExampleTest, StateIsProperlyInitialized) {
 
 ```cpp
 // BAD: Non-deterministic
-TEST_CASE("Work completes within timeout", "[bad]") {
+TEST(DeterministicTest, WorkCompletesWithinTimeout) {
     auto start = now();
     doWork();
     auto elapsed = now() - start;
-    REQUIRE(elapsed < 100ms);  // ❌ Flaky on slow machines
+    EXPECT_LT(elapsed, std::chrono::milliseconds(100));  // ❌ Flaky on slow machines
 }
 
 // GOOD: Deterministic with mocking
-TEST_CASE("Work uses expected clock time", "[unit]") {
+TEST(DeterministicTest, WorkUsesExpectedClockTime) {
     MockClock clock;
     clock.setTime(0);
     doWorkWithClock(clock);
-    REQUIRE(clock.getTime() == 50);  // ✅ Deterministic
+    EXPECT_EQ(clock.getTime(), 50);  // ✅ Deterministic
 }
 ```
 


### PR DESCRIPTION
Updates all documentation to use Google Test instead of outdated Catch2 references.

## Changes
- **docs/plan/testing-strategy.md**: 7 test examples converted to GTest format
- **CLAUDE.md**: Test naming conventions updated
- **ADR-013**: Coroutine safety patterns updated
- **MIGRATION_ARCHITECTURE**: Examples updated

## Verification
✅ All Catch2 references eliminated from documentation
✅ Consistent GTest syntax throughout
✅ Test examples match actual framework used

Closes #53

🤖 Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>