### PR TITLE
fix: get cmake version to work on pureos9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.16)
 project(ProjectKeystone CXX)
 
 # C++20 standard required


### PR DESCRIPTION
Lets relax the version string to get build to work on pureos9.