### PR TITLE
feat(core): Add AgentLevel enum type (Phase 0)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -498,6 +498,7 @@ add_executable(
   tests/unit/test_coordination_state.cpp # Stream B Phase B1: CoordinationState template tests (FIX: added mutexes)
   tests/unit/test_task_cancellation.cpp # Phase 1.2 (Issue #52): Task cancellation notification
   tests/unit/test_security_regression.cpp # PR #1: Security vulnerability regression tests
+  tests/unit/test_agent_types.cpp # PR #2: AgentLevel enum and type definitions
 )
 
 # Add gRPC test fixture if gRPC is enabled (Phase 2.2: Issue #53)

--- a/include/core/agent_types.hpp
+++ b/include/core/agent_types.hpp
@@ -1,0 +1,120 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace keystone {
+namespace core {
+
+/**
+ * @brief Agent hierarchy levels in the 4-layer HMAS architecture
+ *
+ * ProjectKeystone implements a 4-layer hierarchy:
+ * - L0 (Chief Architect): Strategic decisions, system-wide coordination
+ * - L1 (Component Lead): Component architecture, module coordination
+ * - L2 (Module Lead): Module design, task decomposition
+ * - L3 (Task Agent): Concrete execution, code implementation
+ *
+ * Using uint8_t ensures minimal memory footprint (4 possible values: 0-3)
+ * while providing type safety and preventing invalid levels at compile time.
+ */
+enum class AgentLevel : uint8_t {
+  L0 = 0,  ///< Chief Architect (Level 0)
+  L1 = 1,  ///< Component Lead (Level 1)
+  L2 = 2,  ///< Module Lead (Level 2)
+  L3 = 3   ///< Task Agent (Level 3)
+};
+
+/**
+ * @brief Convert AgentLevel enum to string representation
+ *
+ * @param level Agent level enum value
+ * @return String representation ("L0", "L1", "L2", "L3")
+ *
+ * Example:
+ * @code
+ * std::string name = agentLevelToString(AgentLevel::L0);  // "L0"
+ * @endcode
+ */
+inline std::string agentLevelToString(AgentLevel level) {
+  switch (level) {
+    case AgentLevel::L0:
+      return "L0";
+    case AgentLevel::L1:
+      return "L1";
+    case AgentLevel::L2:
+      return "L2";
+    case AgentLevel::L3:
+      return "L3";
+    default:
+      return "UNKNOWN";
+  }
+}
+
+/**
+ * @brief Convert string to AgentLevel enum
+ *
+ * @param str String representation ("L0", "L1", "L2", "L3")
+ * @return AgentLevel if valid, nullopt if invalid
+ *
+ * Example:
+ * @code
+ * auto level = stringToAgentLevel("L2");
+ * if (level.has_value()) {
+ *   // Use level.value()
+ * }
+ * @endcode
+ */
+inline std::optional<AgentLevel> stringToAgentLevel(std::string_view str) {
+  if (str == "L0") return AgentLevel::L0;
+  if (str == "L1") return AgentLevel::L1;
+  if (str == "L2") return AgentLevel::L2;
+  if (str == "L3") return AgentLevel::L3;
+  return std::nullopt;
+}
+
+/**
+ * @brief Get numeric value of AgentLevel
+ *
+ * @param level Agent level enum value
+ * @return Underlying uint8_t value (0, 1, 2, or 3)
+ *
+ * Example:
+ * @code
+ * uint8_t value = agentLevelValue(AgentLevel::L2);  // 2
+ * @endcode
+ */
+inline uint8_t agentLevelValue(AgentLevel level) {
+  return static_cast<uint8_t>(level);
+}
+
+/**
+ * @brief Check if level is valid (L0-L3 range)
+ *
+ * @param value Numeric value to check
+ * @return true if value is in range [0, 3], false otherwise
+ */
+inline bool isValidAgentLevel(uint8_t value) { return value <= 3; }
+
+/**
+ * @brief Convert numeric value to AgentLevel
+ *
+ * @param value Numeric value (0-3)
+ * @return AgentLevel if valid, nullopt if out of range
+ *
+ * Example:
+ * @code
+ * auto level = valueToAgentLevel(2);  // AgentLevel::L2
+ * @endcode
+ */
+inline std::optional<AgentLevel> valueToAgentLevel(uint8_t value) {
+  if (!isValidAgentLevel(value)) {
+    return std::nullopt;
+  }
+  return static_cast<AgentLevel>(value);
+}
+
+}  // namespace core
+}  // namespace keystone

--- a/tests/unit/test_agent_types.cpp
+++ b/tests/unit/test_agent_types.cpp
@@ -1,0 +1,135 @@
+/**
+ * @file test_agent_types.cpp
+ * @brief Unit tests for agent type definitions (AgentLevel enum)
+ */
+
+#include <gtest/gtest.h>
+
+#include "core/agent_types.hpp"
+
+namespace keystone {
+namespace core {
+namespace {
+
+// =============================================================================
+// AgentLevel Enum Tests
+// =============================================================================
+
+TEST(AgentTypesTest, AgentLevelEnumValues) {
+  // Verify enum underlying values are correct (0-3)
+  EXPECT_EQ(static_cast<uint8_t>(AgentLevel::L0), 0u);
+  EXPECT_EQ(static_cast<uint8_t>(AgentLevel::L1), 1u);
+  EXPECT_EQ(static_cast<uint8_t>(AgentLevel::L2), 2u);
+  EXPECT_EQ(static_cast<uint8_t>(AgentLevel::L3), 3u);
+}
+
+TEST(AgentTypesTest, AgentLevelToString) {
+  EXPECT_EQ(agentLevelToString(AgentLevel::L0), "L0");
+  EXPECT_EQ(agentLevelToString(AgentLevel::L1), "L1");
+  EXPECT_EQ(agentLevelToString(AgentLevel::L2), "L2");
+  EXPECT_EQ(agentLevelToString(AgentLevel::L3), "L3");
+}
+
+TEST(AgentTypesTest, StringToAgentLevel) {
+  // Valid conversions
+  auto l0 = stringToAgentLevel("L0");
+  ASSERT_TRUE(l0.has_value());
+  EXPECT_EQ(l0.value(), AgentLevel::L0);
+
+  auto l1 = stringToAgentLevel("L1");
+  ASSERT_TRUE(l1.has_value());
+  EXPECT_EQ(l1.value(), AgentLevel::L1);
+
+  auto l2 = stringToAgentLevel("L2");
+  ASSERT_TRUE(l2.has_value());
+  EXPECT_EQ(l2.value(), AgentLevel::L2);
+
+  auto l3 = stringToAgentLevel("L3");
+  ASSERT_TRUE(l3.has_value());
+  EXPECT_EQ(l3.value(), AgentLevel::L3);
+
+  // Invalid conversions
+  EXPECT_FALSE(stringToAgentLevel("L4").has_value());
+  EXPECT_FALSE(stringToAgentLevel("").has_value());
+  EXPECT_FALSE(stringToAgentLevel("l0").has_value());  // case-sensitive
+  EXPECT_FALSE(stringToAgentLevel("Level0").has_value());
+  EXPECT_FALSE(stringToAgentLevel("INVALID").has_value());
+}
+
+TEST(AgentTypesTest, AgentLevelValue) {
+  EXPECT_EQ(agentLevelValue(AgentLevel::L0), 0u);
+  EXPECT_EQ(agentLevelValue(AgentLevel::L1), 1u);
+  EXPECT_EQ(agentLevelValue(AgentLevel::L2), 2u);
+  EXPECT_EQ(agentLevelValue(AgentLevel::L3), 3u);
+}
+
+TEST(AgentTypesTest, IsValidAgentLevel) {
+  // Valid levels (0-3)
+  EXPECT_TRUE(isValidAgentLevel(0));
+  EXPECT_TRUE(isValidAgentLevel(1));
+  EXPECT_TRUE(isValidAgentLevel(2));
+  EXPECT_TRUE(isValidAgentLevel(3));
+
+  // Invalid levels (4+)
+  EXPECT_FALSE(isValidAgentLevel(4));
+  EXPECT_FALSE(isValidAgentLevel(5));
+  EXPECT_FALSE(isValidAgentLevel(10));
+  EXPECT_FALSE(isValidAgentLevel(255));
+}
+
+TEST(AgentTypesTest, ValueToAgentLevel) {
+  // Valid values
+  auto l0 = valueToAgentLevel(0);
+  ASSERT_TRUE(l0.has_value());
+  EXPECT_EQ(l0.value(), AgentLevel::L0);
+
+  auto l1 = valueToAgentLevel(1);
+  ASSERT_TRUE(l1.has_value());
+  EXPECT_EQ(l1.value(), AgentLevel::L1);
+
+  auto l2 = valueToAgentLevel(2);
+  ASSERT_TRUE(l2.has_value());
+  EXPECT_EQ(l2.value(), AgentLevel::L2);
+
+  auto l3 = valueToAgentLevel(3);
+  ASSERT_TRUE(l3.has_value());
+  EXPECT_EQ(l3.value(), AgentLevel::L3);
+
+  // Invalid values
+  EXPECT_FALSE(valueToAgentLevel(4).has_value());
+  EXPECT_FALSE(valueToAgentLevel(5).has_value());
+  EXPECT_FALSE(valueToAgentLevel(255).has_value());
+}
+
+TEST(AgentTypesTest, RoundTripConversion) {
+  // Test: enum → string → enum
+  for (uint8_t i = 0; i <= 3; ++i) {
+    auto level = valueToAgentLevel(i);
+    ASSERT_TRUE(level.has_value());
+
+    std::string str = agentLevelToString(level.value());
+    auto converted = stringToAgentLevel(str);
+    ASSERT_TRUE(converted.has_value());
+    EXPECT_EQ(converted.value(), level.value());
+  }
+
+  // Test: enum → value → enum
+  AgentLevel levels[] = {AgentLevel::L0, AgentLevel::L1, AgentLevel::L2,
+                         AgentLevel::L3};
+  for (auto level : levels) {
+    uint8_t value = agentLevelValue(level);
+    auto converted = valueToAgentLevel(value);
+    ASSERT_TRUE(converted.has_value());
+    EXPECT_EQ(converted.value(), level);
+  }
+}
+
+TEST(AgentTypesTest, EnumSize) {
+  // Verify enum uses uint8_t storage (1 byte)
+  EXPECT_EQ(sizeof(AgentLevel), sizeof(uint8_t));
+  EXPECT_EQ(sizeof(AgentLevel), 1u);
+}
+
+}  // namespace
+}  // namespace core
+}  // namespace keystone


### PR DESCRIPTION
- Define enum class AgentLevel : uint8_t with values L0-L3
- Add conversion functions (agentLevelToString, stringToAgentLevel)
- Add helper functions (agentLevelValue, isValidAgentLevel, valueToAgentLevel)
- Comprehensive unit tests (8 test cases, all passing)
- Foundation for PR #2 (sized integer conversion)

Testing:
- 8/8 AgentTypes tests passing
- All builds successful (ASan)
- Zero compiler warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)