### PR TITLE
fix: ecosystem audit — critical NATS, daemon, and client bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ __pycache__/
 *.pyc
 .pixi/
 pixi.lock
+
+# Cloned repos from /advise skill
+ProjectMnemosyne/
+build/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,25 +8,25 @@ ProjectKeystone is an automated task DAG execution layer that sits on top of ai-
 
 ## How DAG Traversal Works
 
-1. A NATS message arrives on `hi.tasks.{team_id}.{task_id}.updated` with `status: "done"`.
+1. A NATS message arrives on `hi.tasks.{team_id}.{task_id}.{verb}` with `status: "completed"` (or verb `completed`).
 2. `NATSListener._on_task_event` extracts `team_id` and calls `TaskClaimer.advance_dag(team_id)`.
 3. `advance_dag` fetches all tasks for the team via `GET /api/teams/{team_id}/tasks`.
 4. `DAGWalker.find_ready_tasks(tasks)` identifies tasks where:
-   - `status == "todo"` (not already claimed or in progress)
-   - All task IDs in `depends_on` resolve to tasks with `status == "done"`
+   - `status == "pending"` (not already claimed or in progress)
+   - All task IDs in `blocked_by` resolve to tasks with `status == "completed"`
 5. `get_available_agents()` calls `GET /api/agents/unified` and filters for agents that are `active` and not currently assigned to a task.
-6. Each ready task is paired with an available agent and claimed via `PUT /api/teams/{team_id}/tasks/{task_id}` setting `status = "in_progress"` and `assignedTo = agent_id`.
+6. Each ready task is paired with an available agent and claimed via `PUT /api/teams/{team_id}/tasks/{task_id}` setting `status = "in_progress"` and `assigneeAgentId = agent_id`.
 
 ## Agent Selection Logic
 
 - Agents are fetched from `GET /api/agents/unified` which returns agents across all hosts.
-- An agent is considered available if its `status` is `"active"` and it has no current task assignment (or its current task is `done`).
-- Agent-to-task matching is round-robin across available agents: tasks are zipped with agents. If there are more ready tasks than available agents, remaining tasks stay `todo` until the next DAG advancement cycle.
+- An agent is considered available if its `status` is `"active"` and `session_status` is `"online"` and it has no current task assignment.
+- Agent-to-task matching is round-robin across available agents: tasks are zipped with agents. If there are more ready tasks than available agents, remaining tasks stay `pending` until the next DAG advancement cycle.
 
 ## Key Principles
 
 - **No own storage**: All state lives in ai-maestro. Keystone is stateless.
-- **Idempotent**: `advance_dag` can be called multiple times safely — it only claims `todo` tasks, so already-claimed tasks are skipped.
+- **Idempotent**: `advance_dag` can be called multiple times safely — it only claims `pending` tasks, so already-claimed tasks are skipped.
 - **Event-driven**: The primary trigger is NATS. On startup, Keystone also does a full scan to advance any stalled DAGs.
 - **Fail gracefully**: If ai-maestro is unreachable or returns errors, log and retry — never crash the daemon.
 
@@ -79,11 +79,11 @@ just format             # ruff format
 |--------|----------|---------|
 | GET | `/api/teams` | List all teams |
 | GET | `/api/teams/{id}/tasks` | List tasks with dependency info |
-| PUT | `/api/teams/{id}/tasks/{taskId}` | Update task status / assignedTo |
+| PUT | `/api/teams/{id}/tasks/{taskId}` | Update task status / assigneeAgentId |
 | GET | `/api/agents/unified` | List all agents across hosts |
 
 ## Task Status Values
 
-`todo` → `in_progress` → `review` → `done` (or `blocked`)
+`backlog` → `pending` → `in_progress` → `review` → `completed`
 
-Keystone only transitions tasks from `todo` → `in_progress`. All other transitions are performed by agents or humans in ai-maestro directly.
+Keystone only transitions tasks from `pending` → `in_progress`. All other transitions are performed by agents or humans in ai-maestro directly.

--- a/src/keystone/daemon.py
+++ b/src/keystone/daemon.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import json
 import logging
 import signal
 import sys
@@ -76,10 +75,10 @@ async def _print_status(maestro_client: MaestroClient) -> None:
         for task in tasks:
             table.add_row(
                 task.id,
-                task.title,
+                task.subject,
                 task.status.value,
-                task.assigned_to or "",
-                ", ".join(task.depends_on),
+                task.assignee_agent_id or "",
+                ", ".join(task.blocked_by),
             )
         console.print(table)
 
@@ -92,7 +91,6 @@ async def main(args: argparse.Namespace) -> None:
 
     if args.status:
         await _print_status(maestro_client)
-        await maestro_client.close()
         return
 
     task_claimer = TaskClaimer(maestro_client)

--- a/src/keystone/maestro_client.py
+++ b/src/keystone/maestro_client.py
@@ -12,21 +12,38 @@ logger = logging.getLogger(__name__)
 class MaestroClient:
     def __init__(self, url: str, api_key: str = "") -> None:
         self.url = url.rstrip("/")
-        self.headers = {"Content-Type": "application/json"}
+        self.headers: dict[str, str] = {"Content-Type": "application/json"}
         if api_key:
             self.headers["Authorization"] = f"Bearer {api_key}"
+        self._client: httpx.AsyncClient | None = None
+
+    async def _http(self) -> httpx.AsyncClient:
+        """Return a persistent async HTTP client, creating one if needed."""
+        if self._client is None or self._client.is_closed:
+            self._client = httpx.AsyncClient(
+                base_url=self.url,
+                headers=self.headers,
+                timeout=30.0,
+            )
+        return self._client
+
+    async def close(self) -> None:
+        """Close the persistent HTTP client."""
+        if self._client and not self._client.is_closed:
+            await self._client.aclose()
+            self._client = None
 
     async def get_tasks(self, team_id: str) -> list[Task]:
-        async with httpx.AsyncClient() as client:
-            r = await client.get(f"{self.url}/api/teams/{team_id}/tasks", headers=self.headers)
-            r.raise_for_status()
-            return [_task_from_api(t) for t in r.json()["tasks"]]
+        client = await self._http()
+        r = await client.get(f"/api/teams/{team_id}/tasks")
+        r.raise_for_status()
+        return [_task_from_api(t) for t in r.json()["tasks"]]
 
     async def update_task(self, team_id: str, task_id: str, **kwargs) -> tuple[Task, list[Task]]:
         """Returns (updated_task, unblocked_tasks). unblocked_tasks is ai-maestro's gift —
         it tells us which tasks just became unblocked, so we don't need to recompute."""
         # Map Python field names to API field names
-        body = {}
+        body: dict[str, object] = {}
         if "status" in kwargs:
             status = kwargs["status"]
             body["status"] = status.value if isinstance(status, TaskStatus) else status
@@ -34,26 +51,26 @@ class MaestroClient:
             body["assigneeAgentId"] = kwargs["assignee_agent_id"]
         if "blocked_by" in kwargs:
             body["blockedBy"] = kwargs["blocked_by"]
-        async with httpx.AsyncClient() as client:
-            r = await client.put(
-                f"{self.url}/api/teams/{team_id}/tasks/{task_id}",
-                json=body, headers=self.headers
-            )
-            r.raise_for_status()
-            data = r.json()
-            return _task_from_api(data["task"]), [_task_from_api(t) for t in data.get("unblocked", [])]
+        client = await self._http()
+        r = await client.put(
+            f"/api/teams/{team_id}/tasks/{task_id}",
+            json=body,
+        )
+        r.raise_for_status()
+        data = r.json()
+        return _task_from_api(data["task"]), [_task_from_api(t) for t in data.get("unblocked", [])]
 
     async def get_agents(self) -> list[Agent]:
-        async with httpx.AsyncClient() as client:
-            r = await client.get(f"{self.url}/api/agents/unified", headers=self.headers)
-            r.raise_for_status()
-            return [_agent_from_api(entry["agent"]) for entry in r.json()["agents"]]
+        client = await self._http()
+        r = await client.get("/api/agents/unified")
+        r.raise_for_status()
+        return [_agent_from_api(entry["agent"]) for entry in r.json()["agents"]]
 
     async def get_teams(self) -> list[dict]:
-        async with httpx.AsyncClient() as client:
-            r = await client.get(f"{self.url}/api/teams", headers=self.headers)
-            r.raise_for_status()
-            return r.json()["teams"]
+        client = await self._http()
+        r = await client.get("/api/teams")
+        r.raise_for_status()
+        return r.json()["teams"]
 
 
 def _task_from_api(data: dict) -> Task:

--- a/src/keystone/nats_listener.py
+++ b/src/keystone/nats_listener.py
@@ -6,13 +6,17 @@ import logging
 import nats
 from nats.aio.client import Client as NATSClient
 from nats.aio.msg import Msg
+from nats.js import JetStreamContext
 
 from keystone.task_claimer import TaskClaimer
 
 logger = logging.getLogger(__name__)
 
-# Subject pattern published by ProjectHermes for all task state changes
-TASK_SUBJECT = "hi.tasks.*.*.updated"
+# Wildcard subject to receive all task events (updated, completed, failed, etc.)
+TASK_SUBJECT = "hi.tasks.>"
+
+# Durable consumer name for JetStream at-least-once delivery
+DURABLE_NAME = "keystone-dag"
 
 
 class NATSListener:
@@ -22,30 +26,33 @@ class NATSListener:
         self._nats_url = nats_url
         self._task_claimer = task_claimer
         self._nc: NATSClient | None = None
+        self._js: JetStreamContext | None = None
 
     async def start(self) -> None:
-        """Connect to NATS and subscribe to task events."""
+        """Connect to NATS and subscribe to task events via JetStream durable consumer."""
         logger.info("Connecting to NATS at %s", self._nats_url)
         self._nc = await nats.connect(self._nats_url)
-        await self._nc.subscribe(TASK_SUBJECT, cb=self._on_task_event)
-        logger.info("Subscribed to %s", TASK_SUBJECT)
+        self._js = self._nc.jetstream()
+        await self._js.subscribe(TASK_SUBJECT, durable=DURABLE_NAME, cb=self._on_task_event)
+        logger.info("Subscribed to %s (durable=%s)", TASK_SUBJECT, DURABLE_NAME)
 
     async def _on_task_event(self, msg: Msg) -> None:
-        """Handle incoming task update events.
+        """Handle incoming task events.
 
-        Subject format: hi.tasks.{team_id}.{task_id}.updated
+        Subject format: hi.tasks.{team_id}.{task_id}.{verb}  (5 parts)
         Payload: JSON with at least {"status": "...", ...}
-        When status transitions to "done", advance the DAG for the team.
+        When verb is "completed" or payload status is "completed", advance the DAG.
         """
         subject = msg.subject
         parts = subject.split(".")
-        # Expected: hi . tasks . {team_id} . {task_id} . updated  (6 parts)
-        if len(parts) < 6:
+        # Expected: hi . tasks . {team_id} . {task_id} . {verb}  (5 parts)
+        if len(parts) < 5:
             logger.warning("Unexpected subject format: %s", subject)
             return
 
         team_id = parts[2]
         task_id = parts[3]
+        verb = parts[4]
 
         try:
             payload = json.loads(msg.data.decode())
@@ -55,12 +62,14 @@ class NATSListener:
 
         status = payload.get("status") or payload.get("newStatus")
         logger.debug(
-            "Task event: team=%s task=%s status=%s", team_id, task_id, status
+            "Task event: team=%s task=%s verb=%s status=%s",
+            team_id, task_id, verb, status,
         )
 
-        if status == "completed":
+        # Advance DAG if the subject verb is "completed" or the payload status is "completed"
+        if verb == "completed" or status == "completed":
             logger.info(
-                "Task %s in team %s marked done — triggering DAG advancement",
+                "Task %s in team %s completed — triggering DAG advancement",
                 task_id,
                 team_id,
             )

--- a/tests/test_nats_listener.py
+++ b/tests/test_nats_listener.py
@@ -1,0 +1,90 @@
+"""Tests for keystone.nats_listener subject parsing and event routing."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from keystone.nats_listener import NATSListener
+
+
+def _make_msg(subject: str, data: dict) -> MagicMock:
+    """Create a fake NATS Msg with the given subject and JSON payload."""
+    msg = MagicMock()
+    msg.subject = subject
+    msg.data = json.dumps(data).encode()
+    return msg
+
+
+@pytest.fixture
+def listener() -> NATSListener:
+    claimer = AsyncMock()
+    return NATSListener(nats_url="nats://localhost:4222", task_claimer=claimer)
+
+
+@pytest.mark.asyncio
+async def test_completed_verb_triggers_advance(listener: NATSListener) -> None:
+    """A message on hi.tasks.{team}.{task}.completed should trigger DAG advancement."""
+    msg = _make_msg("hi.tasks.team1.task1.completed", {"status": "completed"})
+    await listener._on_task_event(msg)
+    listener._task_claimer.advance_dag.assert_awaited_once_with("team1")
+
+
+@pytest.mark.asyncio
+async def test_updated_with_completed_status_triggers_advance(listener: NATSListener) -> None:
+    """A message on *.updated with status=completed in payload should trigger DAG advancement."""
+    msg = _make_msg("hi.tasks.team2.task2.updated", {"status": "completed"})
+    await listener._on_task_event(msg)
+    listener._task_claimer.advance_dag.assert_awaited_once_with("team2")
+
+
+@pytest.mark.asyncio
+async def test_updated_with_non_completed_status_ignored(listener: NATSListener) -> None:
+    """A message on *.updated with status != completed should NOT trigger DAG advancement."""
+    msg = _make_msg("hi.tasks.team3.task3.updated", {"status": "in_progress"})
+    await listener._on_task_event(msg)
+    listener._task_claimer.advance_dag.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_failed_verb_ignored(listener: NATSListener) -> None:
+    """A message on *.failed should NOT trigger DAG advancement."""
+    msg = _make_msg("hi.tasks.team4.task4.failed", {"status": "failed"})
+    await listener._on_task_event(msg)
+    listener._task_claimer.advance_dag.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_malformed_subject_too_few_parts(listener: NATSListener) -> None:
+    """A subject with fewer than 5 parts should be ignored gracefully."""
+    msg = _make_msg("hi.tasks.team5", {"status": "completed"})
+    await listener._on_task_event(msg)
+    listener._task_claimer.advance_dag.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_malformed_payload_handled(listener: NATSListener) -> None:
+    """Invalid JSON payload should be logged and ignored, not crash."""
+    msg = MagicMock()
+    msg.subject = "hi.tasks.team6.task6.completed"
+    msg.data = b"not-json"
+    await listener._on_task_event(msg)
+    listener._task_claimer.advance_dag.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_five_part_subject_parsed_correctly(listener: NATSListener) -> None:
+    """Verify that hi.tasks.X.Y.Z splits into exactly 5 parts and extracts team/task/verb."""
+    msg = _make_msg("hi.tasks.alpha.bravo.completed", {"status": "completed"})
+    await listener._on_task_event(msg)
+    listener._task_claimer.advance_dag.assert_awaited_once_with("alpha")
+
+
+@pytest.mark.asyncio
+async def test_newstatus_field_also_checked(listener: NATSListener) -> None:
+    """Payload with newStatus instead of status should also be recognized."""
+    msg = _make_msg("hi.tasks.team7.task7.updated", {"newStatus": "completed"})
+    await listener._on_task_event(msg)
+    listener._task_claimer.advance_dag.assert_awaited_once_with("team7")


### PR DESCRIPTION
## Summary
- **C1**: Fix NATSListener dropping ALL messages — parts count check was `< 6` but subjects have 5 parts
- **C2**: Fix daemon.py `AttributeError` — used wrong Task model fields (`title`→`subject`, `assigned_to`→`assignee_agent_id`, `depends_on`→`blocked_by`)
- **C3**: Refactor MaestroClient to persistent `httpx.AsyncClient` with proper `close()` method (was creating new client per request)
- **I1**: Widen NATS subject from `hi.tasks.*.*.updated` to `hi.tasks.>` to catch all task verbs
- **I3**: Switch from core NATS to JetStream durable consumer (`keystone-dag`) for at-least-once delivery
- **I4**: Fix CLAUDE.md status values to match code (`todo`→`pending`, `done`→`completed`)
- **I9**: Add `ProjectMnemosyne/` and `build/` to `.gitignore`
- **M1**: Add 8 tests for NATSListener subject parsing and event routing

## Test plan
- [x] `just test` — 27/27 tests pass (11 existing + 8 new + 8 existing)
- [ ] Manual verification with running NATS server (JetStream subscription)

🤖 Generated with [Claude Code](https://claude.com/claude-code)