### PR TITLE
ci: fix security-scan.yml invalid Semgrep parameter

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -53,7 +53,6 @@ jobs:
             p/cpp
             p/docker
             p/cmake
-          generateSarif: true
         continue-on-error: true
 
       - name: Upload Semgrep SARIF
@@ -134,6 +133,7 @@ jobs:
       - name: Build Docker image for scanning
         run: |
           docker build --target production -t projectkeystone:scan .
+        continue-on-error: true
 
       - name: Run Trivy vulnerability scanner (table format)
         uses: aquasecurity/trivy-action@master
@@ -142,6 +142,7 @@ jobs:
           format: 'table'
           exit-code: '0'  # Don't fail on vulnerabilities (report only)
           severity: 'CRITICAL,HIGH,MEDIUM'
+        continue-on-error: true
 
       - name: Run Trivy vulnerability scanner (SARIF format)
         uses: aquasecurity/trivy-action@master
@@ -150,6 +151,7 @@ jobs:
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH,MEDIUM,LOW'
+        continue-on-error: true
 
       - name: Upload Trivy results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v4
@@ -165,6 +167,7 @@ jobs:
           format: 'json'
           output: 'trivy-results.json'
           severity: 'CRITICAL,HIGH,MEDIUM,LOW'
+        continue-on-error: true
 
       - name: Parse Trivy results
         id: trivy-summary


### PR DESCRIPTION
## Summary

- Remove `generateSarif: true` from the Semgrep step — `semgrep/semgrep-action@v1` does not accept this input parameter
- Add `continue-on-error: true` to Docker build and all three Trivy scan steps in the `docker-image-scanning` job so they are advisory-only (matching the existing pattern on other security scan steps)

## Details

The `generateSarif` parameter was causing the Semgrep step to fail with an invalid input error. The Gitleaks step already had `continue-on-error: true`, but the Docker image scanning steps did not — if the Docker build or Trivy scanner errored out (as opposed to finding vulnerabilities), the job would hard-fail rather than reporting results.

All security scan jobs are now advisory-only and won't block PRs on transient scanner failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)