### PR TITLE
refactor: convert unsized integers to sized types (int32_t, uint32_t, size_t)

### DIFF
--- a/include/core/failure_injector.hpp
+++ b/include/core/failure_injector.hpp
@@ -2,6 +2,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <cstdint>
 #include <mutex>
 #include <random>
 #include <string>
@@ -40,7 +41,7 @@ class FailureInjector {
    *
    * @param seed Random seed for reproducibility (0 = random)
    */
-  explicit FailureInjector(unsigned int seed = 0);
+  explicit FailureInjector(uint32_t seed = 0);
 
   // ========================================================================
   // Agent Crash Simulation
@@ -141,9 +142,9 @@ class FailureInjector {
   /**
    * @brief Get total number of injected failures
    *
-   * @return int Total failures
+   * @return int32_t Total failures
    */
-  int getTotalFailures() const;
+  int32_t getTotalFailures() const;
 
   /**
    * @brief Get list of currently failed agents
@@ -190,7 +191,7 @@ class FailureInjector {
   mutable std::mutex rng_mutex_;
 
   // Statistics
-  mutable std::atomic<int> total_failures_{0};
+  mutable std::atomic<int32_t> total_failures_{0};
 };
 
 }  // namespace core

--- a/include/network/hmas_coordinator_service.hpp
+++ b/include/network/hmas_coordinator_service.hpp
@@ -4,6 +4,7 @@
 #include "network/task_router.hpp"
 #include "network/yaml_parser.hpp"
 
+#include <cstdint>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -23,7 +24,7 @@ struct TaskState {
   std::string assigned_agent_id;
   std::string assigned_node_ip_port;
   hmas::TaskPhase phase{hmas::TASK_PHASE_PENDING};
-  int progress_percent{0};
+  int32_t progress_percent{0};
   std::string current_subtask;
   std::chrono::system_clock::time_point created_at;
   std::chrono::system_clock::time_point updated_at;
@@ -83,7 +84,7 @@ class HMASCoordinatorServiceImpl final : public hmas::HMASCoordinator::Service {
   /// @param current_subtask Currently executing subtask name
   void updateTaskStatus(const std::string& task_id,
                         hmas::TaskPhase phase,
-                        int progress = 0,
+                        int32_t progress = 0,
                         const std::string& current_subtask = "");
 
   /// Get task state
@@ -100,7 +101,7 @@ class HMASCoordinatorServiceImpl final : public hmas::HMASCoordinator::Service {
   /// Clean up completed/failed tasks older than threshold
   /// @param age_threshold_ms Age threshold in milliseconds
   /// @return Number of tasks cleaned up
-  int cleanupOldTasks(int64_t age_threshold_ms = 3600000);  // Default: 1 hour
+  int32_t cleanupOldTasks(int64_t age_threshold_ms = 3600000);  // Default: 1 hour
 
  private:
   /// Generate unique task ID

--- a/include/network/service_registry.hpp
+++ b/include/network/service_registry.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <chrono>
+#include <cstdint>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -18,13 +19,13 @@ namespace network {
 struct AgentRegistrationInfo {
   std::string agent_id;
   std::string agent_type;
-  int level;
+  int32_t level;
   std::string ip_port;
   std::vector<std::string> capabilities;
   std::chrono::system_clock::time_point last_heartbeat;
   float cpu_usage_percent{0.0f};
   float memory_usage_mb{0.0f};
-  int active_tasks{0};
+  int32_t active_tasks{0};
 };
 
 /// Service Registry - manages agent registration and discovery
@@ -33,7 +34,7 @@ class ServiceRegistry final {
  public:
   /// Constructor
   /// @param heartbeat_timeout_ms Timeout for heartbeat (default: 3000ms)
-  explicit ServiceRegistry(int heartbeat_timeout_ms = 3000);
+  explicit ServiceRegistry(int32_t heartbeat_timeout_ms = 3000);
 
   /// Destructor
   ~ServiceRegistry();
@@ -51,7 +52,7 @@ class ServiceRegistry final {
   /// @return true if registered successfully, false if agent_id already exists
   bool registerAgent(const std::string& agent_id,
                      const std::string& agent_type,
-                     int level,
+                     int32_t level,
                      const std::string& ip_port,
                      const std::vector<std::string>& capabilities);
 
@@ -64,7 +65,7 @@ class ServiceRegistry final {
   bool updateHeartbeat(const std::string& agent_id,
                        float cpu_usage_percent = 0.0f,
                        float memory_usage_mb = 0.0f,
-                       int active_tasks = 0);
+                       int32_t active_tasks = 0);
 
   /// Unregister an agent
   /// @param agent_id Agent identifier
@@ -85,9 +86,9 @@ class ServiceRegistry final {
   /// @return List of matching agents
   std::vector<AgentRegistrationInfo> queryAgents(
       const std::string& agent_type = "",
-      int level = -1,
+      int32_t level = -1,
       const std::vector<std::string>& required_capabilities = {},
-      int max_results = 0,
+      int32_t max_results = 0,
       bool only_alive = true) const;
 
   /// List all registered agents
@@ -102,7 +103,7 @@ class ServiceRegistry final {
 
   /// Clean up dead agents (those with expired heartbeats)
   /// @return Number of agents removed
-  int cleanupDeadAgents();
+  int32_t cleanupDeadAgents();
 
   /// Get heartbeat timeout
   std::chrono::milliseconds getHeartbeatTimeout() const { return heartbeat_timeout_; }

--- a/src/agents/module_lead_agent.cpp
+++ b/src/agents/module_lead_agent.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
 #include <numeric>
 #include <regex>
 #include <sstream>
@@ -102,11 +103,11 @@ std::string ModuleLeadAgent::synthesizeResults() {
   }
 
   // Parse each result as a number and sum them
-  int total = 0;
+  int32_t total = 0;
   const auto& results = coordination_.getResults();
   for (const auto& result : results) {
     try {
-      int value = std::stoi(result);
+      int32_t value = std::stoi(result);
       total += value;
     } catch (const std::exception&) {
       // Skip non-numeric results
@@ -215,7 +216,7 @@ void ModuleLeadAgent::processYamlModule(const std::string& yaml_spec) {
 
   // Generate child task YAMLs and submit to TaskAgents
   coordination_.transitionTo(State::WAITING_FOR_TASKS, stateToString(State::WAITING_FOR_TASKS));
-  coordination_.initializeCoordination(static_cast<int>(tasks.size()));
+  coordination_.initializeCoordination(static_cast<int32_t>(tasks.size()));
 
   for (size_t i = 0; i < tasks.size(); ++i) {
     // Create child task spec

--- a/src/agents/task_agent.cpp
+++ b/src/agents/task_agent.cpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <cctype>
 #include <chrono>
+#include <cstdint>
 #include <cstdio>
 #include <regex>
 #include <sstream>
@@ -213,7 +214,7 @@ std::string TaskAgent::executeBash(const std::string& command) {
   }
 
   // Manual close to get status (release() transfers ownership)
-  int status = pclose(pipe.release());
+  int32_t status = pclose(pipe.release());
   if (status != 0) {
     std::stringstream ss;
     ss << "Command exited with status " << status;

--- a/src/agents/task_execution_strategy.cpp
+++ b/src/agents/task_execution_strategy.cpp
@@ -3,6 +3,7 @@
 #include "core/error_sanitizer.hpp"
 
 #include <array>
+#include <cstdint>
 #include <regex>
 #include <sstream>
 #include <stdexcept>
@@ -122,7 +123,7 @@ std::string TaskExecutionStrategy::executeBashCommand(const std::string& cmd) co
   }
 
   // Get exit status
-  int status = pclose(pipe.fp);
+  int32_t status = pclose(pipe.fp);
   pipe.fp = nullptr;  // Mark as closed
 
   if (status != 0) {

--- a/src/core/failure_injector.cpp
+++ b/src/core/failure_injector.cpp
@@ -7,8 +7,7 @@
 namespace keystone {
 namespace core {
 
-FailureInjector::FailureInjector(uint32_t seed)
-    : rng_(seed == 0 ? std::random_device{}() : seed) {}
+FailureInjector::FailureInjector(uint32_t seed) : rng_(seed == 0 ? std::random_device{}() : seed) {}
 
 // ============================================================================
 // Agent Crash Simulation

--- a/src/core/failure_injector.cpp
+++ b/src/core/failure_injector.cpp
@@ -1,12 +1,13 @@
 #include "core/failure_injector.hpp"
 
 #include <algorithm>
+#include <cstdint>
 #include <sstream>
 
 namespace keystone {
 namespace core {
 
-FailureInjector::FailureInjector(unsigned int seed)
+FailureInjector::FailureInjector(uint32_t seed)
     : rng_(seed == 0 ? std::random_device{}() : seed) {}
 
 // ============================================================================
@@ -85,7 +86,7 @@ bool FailureInjector::shouldAgentFail(const std::string& agent_id) {
 // Statistics
 // ============================================================================
 
-int FailureInjector::getTotalFailures() const {
+int32_t FailureInjector::getTotalFailures() const {
   return total_failures_.load();
 }
 

--- a/src/network/hmas_coordinator_service.cpp
+++ b/src/network/hmas_coordinator_service.cpp
@@ -280,7 +280,7 @@ grpc::Status HMASCoordinatorServiceImpl::GetTaskProgress(grpc::ServerContext* co
 
 void HMASCoordinatorServiceImpl::updateTaskStatus(const std::string& task_id,
                                                   hmas::TaskPhase phase,
-                                                  int progress,
+                                                  int32_t progress,
                                                   const std::string& current_subtask) {
   std::lock_guard<std::mutex> lock(mutex_);
 
@@ -315,11 +315,11 @@ size_t HMASCoordinatorServiceImpl::getActiveTaskCount() const {
   return active_tasks_.size();
 }
 
-int HMASCoordinatorServiceImpl::cleanupOldTasks(int64_t age_threshold_ms) {
+int32_t HMASCoordinatorServiceImpl::cleanupOldTasks(int64_t age_threshold_ms) {
   std::lock_guard<std::mutex> lock(mutex_);
 
   auto now = std::chrono::system_clock::now();
-  int removed_count = 0;
+  int32_t removed_count = 0;
 
   // Clean up old completed/failed tasks
   for (auto it = active_tasks_.begin(); it != active_tasks_.end();) {
@@ -355,7 +355,7 @@ std::string HMASCoordinatorServiceImpl::generateTaskId() const {
 
   std::random_device rd;
   std::mt19937 gen(rd());
-  std::uniform_int_distribution<int> dist(1000, 9999);
+  std::uniform_int_distribution<int32_t> dist(1000, 9999);
 
   std::ostringstream oss;
   oss << "task-" << timestamp_ms << "-" << dist(gen);

--- a/src/network/service_registry.cpp
+++ b/src/network/service_registry.cpp
@@ -5,14 +5,14 @@
 
 namespace keystone::network {
 
-ServiceRegistry::ServiceRegistry(int heartbeat_timeout_ms)
+ServiceRegistry::ServiceRegistry(int32_t heartbeat_timeout_ms)
     : heartbeat_timeout_(heartbeat_timeout_ms) {}
 
 ServiceRegistry::~ServiceRegistry() = default;
 
 bool ServiceRegistry::registerAgent(const std::string& agent_id,
                                     const std::string& agent_type,
-                                    int level,
+                                    int32_t level,
                                     const std::string& ip_port,
                                     const std::vector<std::string>& capabilities) {
   std::lock_guard<std::mutex> lock(mutex_);
@@ -41,7 +41,7 @@ bool ServiceRegistry::registerAgent(const std::string& agent_id,
 bool ServiceRegistry::updateHeartbeat(const std::string& agent_id,
                                       float cpu_usage_percent,
                                       float memory_usage_mb,
-                                      int active_tasks) {
+                                      int32_t active_tasks) {
   std::lock_guard<std::mutex> lock(mutex_);
 
   auto it = agents_.find(agent_id);
@@ -75,9 +75,9 @@ std::optional<AgentRegistrationInfo> ServiceRegistry::getAgent(const std::string
 
 std::vector<AgentRegistrationInfo> ServiceRegistry::queryAgents(
     const std::string& agent_type,
-    int level,
+    int32_t level,
     const std::vector<std::string>& required_capabilities,
-    int max_results,
+    int32_t max_results,
     bool only_alive) const {
   std::lock_guard<std::mutex> lock(mutex_);
 
@@ -107,7 +107,7 @@ std::vector<AgentRegistrationInfo> ServiceRegistry::queryAgents(
     results.push_back(info);
 
     // Check max results limit
-    if (max_results > 0 && static_cast<int>(results.size()) >= max_results) {
+    if (max_results > 0 && static_cast<int32_t>(results.size()) >= max_results) {
       break;
     }
   }
@@ -144,10 +144,10 @@ bool ServiceRegistry::isAgentAlive(const std::string& agent_id) const {
   return elapsed < heartbeat_timeout_;
 }
 
-int ServiceRegistry::cleanupDeadAgents() {
+int32_t ServiceRegistry::cleanupDeadAgents() {
   std::lock_guard<std::mutex> lock(mutex_);
 
-  int removed_count = 0;
+  int32_t removed_count = 0;
   auto now = std::chrono::system_clock::now();
 
   for (auto it = agents_.begin(); it != agents_.end();) {
@@ -222,7 +222,7 @@ AgentRegistrationInfo ServiceRegistry::fromProtoRegistration(const hmas::AgentRe
   info.level = reg.level();
   info.ip_port = reg.ip_port();
 
-  for (int i = 0; i < reg.capabilities_size(); ++i) {
+  for (int32_t i = 0; i < reg.capabilities_size(); ++i) {
     info.capabilities.push_back(reg.capabilities(i));
   }
 
@@ -250,7 +250,7 @@ grpc::Status ServiceRegistryServiceImpl::RegisterAgent(grpc::ServerContext* cont
   (void)context;  // Unused
 
   std::vector<std::string> capabilities;
-  for (int i = 0; i < request->capabilities_size(); ++i) {
+  for (int32_t i = 0; i < request->capabilities_size(); ++i) {
     capabilities.push_back(request->capabilities(i));
   }
 
@@ -312,7 +312,7 @@ grpc::Status ServiceRegistryServiceImpl::QueryAgents(grpc::ServerContext* contex
   (void)context;  // Unused
 
   std::vector<std::string> required_capabilities;
-  for (int i = 0; i < request->required_capabilities_size(); ++i) {
+  for (int32_t i = 0; i < request->required_capabilities_size(); ++i) {
     required_capabilities.push_back(request->required_capabilities(i));
   }
 

--- a/tests/integration/test_registry_integration.cpp
+++ b/tests/integration/test_registry_integration.cpp
@@ -443,8 +443,8 @@ TEST_F(RegistryIntegrationTest, ThreadSafeRegistryOperations) {
   }
 
   // 5 threads: query hasAgent() 1000 times each
-  std::atomic<int> queries{0};
-  for (int t = 5; t < 10; ++t) {
+  std::atomic<int32_t> queries{0};
+  for (int32_t t = 5; t < 10; ++t) {
     threads.emplace_back([this, &queries]() {
       for (int32_t i = 0; i < 1000; ++i) {
         bus_->hasAgent("agent_" + std::to_string(i % 100));
@@ -454,8 +454,8 @@ TEST_F(RegistryIntegrationTest, ThreadSafeRegistryOperations) {
   }
 
   // 5 threads: route messages 100 times each
-  std::atomic<int> routed{0};
-  for (int t = 10; t < 15; ++t) {
+  std::atomic<int32_t> routed{0};
+  for (int32_t t = 10; t < 15; ++t) {
     threads.emplace_back([this, &routed]() {
       for (int32_t i = 0; i < 100; ++i) {
         auto msg = KeystoneMessage::create("sender", "agent_" + std::to_string(i % 100), "message");

--- a/tests/unit/test_failure_injector.cpp
+++ b/tests/unit/test_failure_injector.cpp
@@ -175,7 +175,7 @@ TEST_F(FailureInjectorTest, ShouldFailProbabilistic) {
 
   // With 50% rate, approximately half should fail
   int32_t fail_count = 0;
-  const int trials = 1000;
+  const int32_t trials = 1000;
 
   for (int32_t i = 0; i < trials; ++i) {
     if (injector->shouldFail()) {
@@ -270,8 +270,8 @@ TEST_F(FailureInjectorTest, GetStatistics) {
 // ============================================================================
 
 TEST_F(FailureInjectorTest, ConcurrentCrashInjection) {
-  const int THREADS = 4;
-  const int CRASHES_PER_THREAD = 10;
+  const int32_t THREADS = 4;
+  const int32_t CRASHES_PER_THREAD = 10;
 
   std::vector<std::thread> threads;
   for (int32_t t = 0; t < THREADS; ++t) {
@@ -295,9 +295,9 @@ TEST_F(FailureInjectorTest, ConcurrentCrashInjection) {
 TEST_F(FailureInjectorTest, ConcurrentRandomFailures) {
   injector->setFailureRate(0.5);
 
-  const int THREADS = 4;
-  const int CHECKS_PER_THREAD = 100;
-  std::atomic<int> total_failures{0};
+  const int32_t THREADS = 4;
+  const int32_t CHECKS_PER_THREAD = 100;
+  std::atomic<int32_t> total_failures{0};
 
   std::vector<std::thread> threads;
   for (int32_t t = 0; t < THREADS; ++t) {
@@ -315,7 +315,7 @@ TEST_F(FailureInjectorTest, ConcurrentRandomFailures) {
   }
 
   // Approximately half should fail (allow wide variance due to threading)
-  int total_checks = THREADS * CHECKS_PER_THREAD;
+  int32_t total_checks = THREADS * CHECKS_PER_THREAD;
   EXPECT_GT(total_failures.load(), total_checks * 0.3);
   EXPECT_LT(total_failures.load(), total_checks * 0.7);
 }


### PR DESCRIPTION
## Summary

- Convert all bare `int`, `unsigned int` to explicit sized types (`int32_t`, `uint32_t`) across headers, implementation files, and tests
- Add `<cstdint>` includes where needed in `.cpp` files
- Update `std::atomic<int>` → `std::atomic<int32_t>` and `uniform_int_distribution<int>` → `<int32_t>`

## Files Changed

**Headers:**
- `include/network/service_registry.hpp` — struct members, constructor, method params/returns
- `include/core/failure_injector.hpp` — constructor seed param, `getTotalFailures()` return, `total_failures_` atomic
- `include/network/hmas_coordinator_service.hpp` — `progress_percent`, `updateTaskStatus()`, `cleanupOldTasks()`

**Implementation:**
- `src/network/service_registry.cpp` — match header signatures, protobuf loop counters
- `src/network/hmas_coordinator_service.cpp` — match header, fix `uniform_int_distribution`
- `src/agents/task_agent.cpp` — `pclose()` return value
- `src/agents/task_execution_strategy.cpp` — `pclose()` return value
- `src/agents/module_lead_agent.cpp` — local sum variables
- `src/core/failure_injector.cpp` — match header signatures

**Tests:**
- `tests/unit/test_failure_injector.cpp` — constants, atomics
- `tests/integration/test_registry_integration.cpp` — loop variables, atomics

## Test Plan

- [x] `src/core/failure_injector.cpp` compiles cleanly under debug preset
- [x] `tests/unit/test_failure_injector.cpp` compiles cleanly
- [x] `keystone_core` library builds without errors
- [ ] Full test suite blocked by pre-existing `spdlog/fmt/fmt.h` missing include path (not introduced by this PR — confirmed present before these changes)

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)