### PR TITLE
feat(agents): handle TASK_FAILED events to prevent DAG deadlocks

### DIFF
--- a/include/agents/coordination_state.hpp
+++ b/include/agents/coordination_state.hpp
@@ -97,7 +97,9 @@ class CoordinationState {
     std::lock_guard<std::mutex> lock(results_mutex_);
     expected_results_ = expected_count;
     received_results_ = 0;
+    failed_results_ = 0;
     results_.clear();
+    failure_messages_.clear();
     pending_subordinates_.clear();
   }
 
@@ -105,13 +107,54 @@ class CoordinationState {
    * @brief Record a result from a subordinate agent
    *
    * @param result Result payload
-   * @return true if all results received, false otherwise
+   * @return true if all results received (success + failure), false otherwise
    */
   bool recordResult(const ResultType& result) {
     std::lock_guard<std::mutex> lock(results_mutex_);
     results_.push_back(result);
     received_results_++;
     return received_results_ >= expected_results_;
+  }
+
+  /**
+   * @brief Record a failure from a subordinate agent (Issue #87)
+   *
+   * Counts the failure as a terminal result so all-received completion is
+   * detected and downstream agents are not permanently stalled.
+   *
+   * @param error_msg Error description from the failing subordinate
+   * @return true if all results (successes + failures) have been received
+   */
+  bool recordFailure(const std::string& error_msg) {
+    std::lock_guard<std::mutex> lock(results_mutex_);
+    failure_messages_.push_back(error_msg);
+    failed_results_++;
+    received_results_++;
+    return received_results_ >= expected_results_;
+  }
+
+  /**
+   * @brief Check if any subordinate reported a failure (Issue #87)
+   */
+  bool hasFailures() const {
+    std::lock_guard<std::mutex> lock(results_mutex_);
+    return failed_results_ > 0;
+  }
+
+  /**
+   * @brief Get count of failed results (Issue #87)
+   */
+  size_t getFailureCount() const {
+    std::lock_guard<std::mutex> lock(results_mutex_);
+    return failed_results_;
+  }
+
+  /**
+   * @brief Get failure messages from failed subordinates (Issue #87)
+   */
+  std::vector<std::string> getFailureMessages() const {
+    std::lock_guard<std::mutex> lock(results_mutex_);
+    return failure_messages_;
   }
 
   /**
@@ -359,7 +402,9 @@ class CoordinationState {
   // Result aggregation
   size_t expected_results_{0};
   size_t received_results_{0};
+  size_t failed_results_{0};
   std::vector<ResultType> results_;
+  std::vector<std::string> failure_messages_;
   std::unordered_map<std::string, std::string> pending_subordinates_;
   mutable std::mutex results_mutex_;
 

--- a/include/agents/lead_agent_base.hpp
+++ b/include/agents/lead_agent_base.hpp
@@ -128,6 +128,26 @@ class LeadAgentBase : public AsyncAgent {
   virtual void processSubordinateResult(const core::KeystoneMessage& result_msg) = 0;
 
   /**
+   * @brief HOOK: Handle a failure reported by a subordinate agent (Issue #87)
+   *
+   * Called when a subordinate sends a TASK_FAILED message. The default
+   * implementation records the failure in coordination state and transitions
+   * to ERROR when all results (successes + failures) have been received,
+   * preventing permanent DAG deadlock.
+   *
+   * Subclasses may override to add custom failure propagation logic.
+   *
+   * @param failure_msg Message with action_type == TASK_FAILED
+   */
+  virtual void processSubordinateFailure(const core::KeystoneMessage& failure_msg) {
+    std::string error = failure_msg.payload.value_or("subordinate task failed");
+    bool all_done = coordination_.recordFailure(error);
+    if (all_done) {
+      coordination_.transitionTo(error_state_, stateToString(error_state_));
+    }
+  }
+
+  /**
    * @brief HOOK: Convert state enum to string for logging
    *
    * Subclasses must implement this to provide state names for tracing.

--- a/include/agents/lead_agent_base_impl.hpp
+++ b/include/agents/lead_agent_base_impl.hpp
@@ -43,7 +43,13 @@ concurrency::Task<core::Response> LeadAgentBase<StateEnum>::processMessage(
     co_return response;
   }
 
-  // Step 2: Check if this is a subordinate result or a new goal
+  // Step 2a: Handle subordinate failure (Issue #87 - prevents DAG deadlock)
+  if (msg.action_type == core::ActionType::TASK_FAILED) {
+    processSubordinateFailure(msg);
+    co_return core::Response::createSuccess(msg, agent_id_, "Subordinate failure recorded");
+  }
+
+  // Step 2b: Check if this is a subordinate result or a new goal
   if (isSubordinateResult(msg)) {
     // This is a subordinate result - process it
     processSubordinateResult(msg);

--- a/include/core/message.hpp
+++ b/include/core/message.hpp
@@ -47,7 +47,8 @@ enum class ActionType {
   EXECUTE,        ///< Execute a concrete task or command
   RETURN_RESULT,  ///< Return the result of a computation
   SHUTDOWN,       ///< Graceful shutdown signal
-  CANCEL_TASK     ///< Cancel a running task (Issue #52)
+  CANCEL_TASK,    ///< Cancel a running task (Issue #52)
+  TASK_FAILED     ///< Report task failure to parent agent (Issue #87)
 };
 
 /**
@@ -75,6 +76,8 @@ inline std::string actionTypeToString(ActionType type) {
       return "SHUTDOWN";
     case ActionType::CANCEL_TASK:
       return "CANCEL_TASK";
+    case ActionType::TASK_FAILED:
+      return "TASK_FAILED";
     default:
       return "UNKNOWN";
   }

--- a/src/agents/component_lead_agent.cpp
+++ b/src/agents/component_lead_agent.cpp
@@ -105,6 +105,15 @@ void ComponentLeadAgent::processSubordinateResult(const core::KeystoneMessage& r
 
 std::string ComponentLeadAgent::synthesizeComponentResult() {
   State current_state = coordination_.getCurrentState();
+  if (current_state == State::ERROR) {
+    auto failures = coordination_.getFailureMessages();
+    std::string msg = "ERROR: " + std::to_string(coordination_.getFailureCount()) +
+                      " subordinate module(s) failed";
+    if (!failures.empty()) {
+      msg += ": " + failures.front();
+    }
+    return msg;
+  }
   if (current_state != State::AGGREGATING && current_state != State::WAITING_FOR_MODULES) {
     return "ERROR: Cannot synthesize in current state";
   }

--- a/src/agents/module_lead_agent.cpp
+++ b/src/agents/module_lead_agent.cpp
@@ -101,6 +101,15 @@ void ModuleLeadAgent::processSubordinateResult(const core::KeystoneMessage& resu
 
 std::string ModuleLeadAgent::synthesizeResults() {
   State current_state = coordination_.getCurrentState();
+  if (current_state == State::ERROR) {
+    auto failures = coordination_.getFailureMessages();
+    std::string msg = "ERROR: " + std::to_string(coordination_.getFailureCount()) +
+                      " subordinate task(s) failed";
+    if (!failures.empty()) {
+      msg += ": " + failures.front();
+    }
+    return msg;
+  }
   if (current_state != State::SYNTHESIZING && current_state != State::WAITING_FOR_TASKS) {
     return "ERROR: Cannot synthesize in current state";
   }

--- a/src/agents/task_agent.cpp
+++ b/src/agents/task_agent.cpp
@@ -81,11 +81,10 @@ concurrency::Task<core::Response> TaskAgent::processMessage(const core::Keystone
     auto response = core::Response::createError(msg, agent_id_, sanitized_error);
 
     // Issue #87: Send TASK_FAILED so parent Lead Agent can unblock the DAG
-    auto failure_msg =
-        core::KeystoneMessage::create(agent_id_,
-                                      msg.sender_id,
-                                      "response",
-                                      std::string("ERROR: ") + sanitized_error);
+    auto failure_msg = core::KeystoneMessage::create(agent_id_,
+                                                     msg.sender_id,
+                                                     "response",
+                                                     std::string("ERROR: ") + sanitized_error);
     failure_msg.action_type = core::ActionType::TASK_FAILED;
     failure_msg.msg_id = msg.msg_id;
 

--- a/src/agents/task_agent.cpp
+++ b/src/agents/task_agent.cpp
@@ -79,7 +79,18 @@ concurrency::Task<core::Response> TaskAgent::processMessage(const core::Keystone
     // FIX P3-08: Sanitize error message to prevent information disclosure
     std::string sanitized_error = core::sanitizeErrorMessage(e.what());
     auto response = core::Response::createError(msg, agent_id_, sanitized_error);
-    sendResponseMessage(msg, std::string("ERROR: ") + sanitized_error);
+
+    // Issue #87: Send TASK_FAILED so parent Lead Agent can unblock the DAG
+    auto failure_msg =
+        core::KeystoneMessage::create(agent_id_,
+                                      msg.sender_id,
+                                      "response",
+                                      std::string("ERROR: ") + sanitized_error);
+    failure_msg.action_type = core::ActionType::TASK_FAILED;
+    failure_msg.msg_id = msg.msg_id;
+
+    sendMessage(failure_msg);
+
     co_return response;
   }
 }

--- a/tests/unit/test_coordination_state.cpp
+++ b/tests/unit/test_coordination_state.cpp
@@ -638,6 +638,89 @@ TEST_F(CoordinationStateTest, RequesterId) {
 }
 
 // ============================================================================
+// Category 7: Failure Tracking Tests — Issue #87 (DAG deadlock prevention)
+// ============================================================================
+
+TEST_F(CoordinationStateTest, HasNoFailuresInitially) {
+  state_.initializeCoordination(3);
+  EXPECT_FALSE(state_.hasFailures());
+  EXPECT_EQ(state_.getFailureCount(), 0u);
+  EXPECT_TRUE(state_.getFailureMessages().empty());
+}
+
+TEST_F(CoordinationStateTest, RecordFailureCountsAsTerminal) {
+  state_.initializeCoordination(1);
+  bool all_done = state_.recordFailure("task execution error");
+  EXPECT_TRUE(all_done);
+  EXPECT_TRUE(state_.hasFailures());
+  EXPECT_EQ(state_.getFailureCount(), 1u);
+}
+
+TEST_F(CoordinationStateTest, RecordFailurePreservesMessage) {
+  state_.initializeCoordination(2);
+  state_.recordFailure("first error");
+  state_.recordFailure("second error");
+
+  auto msgs = state_.getFailureMessages();
+  ASSERT_EQ(msgs.size(), 2u);
+  EXPECT_EQ(msgs[0], "first error");
+  EXPECT_EQ(msgs[1], "second error");
+}
+
+TEST_F(CoordinationStateTest, MixedSuccessAndFailureReachesCompletion) {
+  state_.initializeCoordination(3);
+  EXPECT_FALSE(state_.recordResult("ok_result"));
+  EXPECT_FALSE(state_.recordFailure("subtask failed"));
+  EXPECT_TRUE(state_.recordResult("another_ok"));
+
+  EXPECT_TRUE(state_.isComplete());
+  EXPECT_TRUE(state_.hasFailures());
+  EXPECT_EQ(state_.getFailureCount(), 1u);
+  EXPECT_EQ(state_.getResults().size(), 2u);
+}
+
+TEST_F(CoordinationStateTest, AllFailuresReachCompletion) {
+  state_.initializeCoordination(3);
+  EXPECT_FALSE(state_.recordFailure("err1"));
+  EXPECT_FALSE(state_.recordFailure("err2"));
+  EXPECT_TRUE(state_.recordFailure("err3"));
+
+  EXPECT_TRUE(state_.isComplete());
+  EXPECT_EQ(state_.getFailureCount(), 3u);
+  EXPECT_EQ(state_.getResults().size(), 0u);
+}
+
+TEST_F(CoordinationStateTest, InitializeClearsPreviousFailures) {
+  state_.initializeCoordination(1);
+  state_.recordFailure("old error");
+
+  EXPECT_TRUE(state_.hasFailures());
+
+  state_.initializeCoordination(2);
+  EXPECT_FALSE(state_.hasFailures());
+  EXPECT_EQ(state_.getFailureCount(), 0u);
+  EXPECT_TRUE(state_.getFailureMessages().empty());
+}
+
+TEST_F(CoordinationStateTest, RecordFailureThreadSafety) {
+  constexpr int NUM_THREADS = 10;
+  state_.initializeCoordination(NUM_THREADS);
+
+  std::vector<std::thread> threads;
+  for (int32_t i = 0; i < NUM_THREADS; ++i) {
+    threads.emplace_back([this, i]() {
+      state_.recordFailure("error_" + std::to_string(i));
+    });
+  }
+  for (auto& t : threads) {
+    t.join();
+  }
+
+  EXPECT_TRUE(state_.isComplete());
+  EXPECT_EQ(state_.getFailureCount(), NUM_THREADS);
+}
+
+// ============================================================================
 // Test Summary
 // ============================================================================
 
@@ -649,12 +732,7 @@ TEST_F(CoordinationStateTest, RequesterId) {
  * - Category 4: Integration (4 tests)
  * - Category 5: gRPC (6 tests - optional, 2 disabled)
  * - Category 6: Context (2 tests)
+ * - Category 7: Failure Tracking — Issue #87 (7 tests)
  *
- * Total: 36 tests (32 always enabled, 4 gRPC-conditional)
- *
- * Coverage:
- * - All public methods of CoordinationState tested
- * - Thread safety verified
- * - Integration workflows validated
- * - gRPC features tested (if enabled)
+ * Total: 43 tests (39 always enabled, 4 gRPC-conditional)
  */

--- a/tests/unit/test_coordination_state.cpp
+++ b/tests/unit/test_coordination_state.cpp
@@ -708,9 +708,8 @@ TEST_F(CoordinationStateTest, RecordFailureThreadSafety) {
 
   std::vector<std::thread> threads;
   for (int32_t i = 0; i < NUM_THREADS; ++i) {
-    threads.emplace_back([this, i]() {
-      state_.recordFailure("error_" + std::to_string(i));
-    });
+    threads.emplace_back(
+        [this, i]() { state_.recordFailure("error_" + std::to_string(i)); });
   }
   for (auto& t : threads) {
     t.join();

--- a/tests/unit/test_coordination_state.cpp
+++ b/tests/unit/test_coordination_state.cpp
@@ -15,21 +15,28 @@
  * Coverage Target: 100% of CoordinationState public methods
  */
 
-#include "agents/coordination_state.hpp"
+#include <gtest/gtest.h>
 
 #include <thread>
 #include <vector>
 
-#include <gtest/gtest.h>
+#include "agents/coordination_state.hpp"
 
 #ifdef ENABLE_GRPC
-#  include "fixtures/grpc_test_fixture.hpp"
+#include "fixtures/grpc_test_fixture.hpp"
 #endif
 
 using namespace keystone::agents;
 
 // Test state enum matching ComponentLead/ModuleLead patterns
-enum class TestState { IDLE, PLANNING, WAITING, SYNTHESIZING, AGGREGATING, ERROR };
+enum class TestState {
+  IDLE,
+  PLANNING,
+  WAITING,
+  SYNTHESIZING,
+  AGGREGATING,
+  ERROR
+};
 
 // ============================================================================
 // Test Fixture
@@ -128,7 +135,8 @@ TEST_F(CoordinationStateTest, ThreadSafeStateTransitions) {
   // 10 threads concurrently transition states
   for (int32_t i = 0; i < NUM_THREADS; ++i) {
     threads.emplace_back([this, i]() {
-      TestState target = (i % 2 == 0) ? TestState::PLANNING : TestState::WAITING;
+      TestState target =
+          (i % 2 == 0) ? TestState::PLANNING : TestState::WAITING;
       std::string name = (i % 2 == 0) ? "PLANNING" : "WAITING";
       state_.transitionTo(target, name);
     });
@@ -140,7 +148,8 @@ TEST_F(CoordinationStateTest, ThreadSafeStateTransitions) {
 
   // Final state should be valid (no crash = success)
   auto final_state = state_.getCurrentState();
-  EXPECT_TRUE(final_state == TestState::PLANNING || final_state == TestState::WAITING);
+  EXPECT_TRUE(final_state == TestState::PLANNING ||
+              final_state == TestState::WAITING);
 }
 
 /**
@@ -252,7 +261,8 @@ TEST_F(CoordinationStateTest, RecordResultThreadSafety) {
 
   std::vector<std::thread> threads;
   for (int32_t i = 0; i < NUM_THREADS; ++i) {
-    threads.emplace_back([this, i]() { state_.recordResult("result_" + std::to_string(i)); });
+    threads.emplace_back(
+        [this, i]() { state_.recordResult("result_" + std::to_string(i)); });
   }
 
   for (auto& t : threads) {
@@ -526,7 +536,8 @@ TEST_F(CoordinationStateTest, ConcurrentWorkflows) {
 #ifdef ENABLE_GRPC
 
 /**
- * @brief Test 29: Initialize gRPC with valid config (uses in-process test servers)
+ * @brief Test 29: Initialize gRPC with valid config (uses in-process test
+ * servers)
  */
 class GrpcCoordinationStateTest : public test::GrpcTestFixture {
  protected:
@@ -538,8 +549,9 @@ TEST_F(GrpcCoordinationStateTest, InitializeGrpcWithValidConfig) {
   auto coord_addr = getCoordinatorAddress();
   auto registry_addr = getRegistryAddress();
 
-  EXPECT_NO_THROW(state_.initializeGrpc(
-      "test_agent", coord_addr, registry_addr, "TestAgent", 2, {"capability1", "capability2"}, 10));
+  EXPECT_NO_THROW(state_.initializeGrpc("test_agent", coord_addr, registry_addr,
+                                        "TestAgent", 2,
+                                        {"capability1", "capability2"}, 10));
 }
 
 /**
@@ -551,10 +563,7 @@ TEST_F(CoordinationStateTest, InitializeGrpcWithInvalidConfig) {
   EXPECT_NO_THROW(state_.initializeGrpc("test_agent",
                                         "",  // Empty coordinator address
                                         "",  // Empty registry address
-                                        "TestAgent",
-                                        2,
-                                        {},
-                                        10));
+                                        "TestAgent", 2, {}, 10));
 }
 
 /**
@@ -566,7 +575,8 @@ TEST_F(CoordinationStateTest, QueryAvailableChildrenWithoutInit) {
 }
 
 /**
- * @brief Test 32: Query available children by type (uses in-process test servers)
+ * @brief Test 32: Query available children by type (uses in-process test
+ * servers)
  */
 TEST_F(GrpcCoordinationStateTest, QueryAvailableChildrenByType) {
   // Use in-process test servers from fixture
@@ -574,15 +584,15 @@ TEST_F(GrpcCoordinationStateTest, QueryAvailableChildrenByType) {
   auto registry_addr = getRegistryAddress();
 
   // Initialize gRPC with in-process servers
-  state_.initializeGrpc(
-      "test_component", coord_addr, registry_addr, "ComponentLead", 1, {"coordination"}, 5);
+  state_.initializeGrpc("test_component", coord_addr, registry_addr,
+                        "ComponentLead", 1, {"coordination"}, 5);
 
   // Register some test agents in the ServiceRegistry
   auto registry = getRegistry();
-  registry->registerAgent(
-      "module_lead_1", "ModuleLead", 2, "localhost:60001", {"task_coordination"});
-  registry->registerAgent(
-      "module_lead_2", "ModuleLead", 2, "localhost:60002", {"task_coordination"});
+  registry->registerAgent("module_lead_1", "ModuleLead", 2, "localhost:60001",
+                          {"task_coordination"});
+  registry->registerAgent("module_lead_2", "ModuleLead", 2, "localhost:60002",
+                          {"task_coordination"});
 
   auto children = state_.queryAvailableChildren("ModuleLead");
   // Should find the 2 registered ModuleLead agents

--- a/tests/unit/test_coordination_state.cpp
+++ b/tests/unit/test_coordination_state.cpp
@@ -15,28 +15,21 @@
  * Coverage Target: 100% of CoordinationState public methods
  */
 
-#include <gtest/gtest.h>
+#include "agents/coordination_state.hpp"
 
 #include <thread>
 #include <vector>
 
-#include "agents/coordination_state.hpp"
+#include <gtest/gtest.h>
 
 #ifdef ENABLE_GRPC
-#include "fixtures/grpc_test_fixture.hpp"
+#  include "fixtures/grpc_test_fixture.hpp"
 #endif
 
 using namespace keystone::agents;
 
 // Test state enum matching ComponentLead/ModuleLead patterns
-enum class TestState {
-  IDLE,
-  PLANNING,
-  WAITING,
-  SYNTHESIZING,
-  AGGREGATING,
-  ERROR
-};
+enum class TestState { IDLE, PLANNING, WAITING, SYNTHESIZING, AGGREGATING, ERROR };
 
 // ============================================================================
 // Test Fixture
@@ -135,8 +128,7 @@ TEST_F(CoordinationStateTest, ThreadSafeStateTransitions) {
   // 10 threads concurrently transition states
   for (int32_t i = 0; i < NUM_THREADS; ++i) {
     threads.emplace_back([this, i]() {
-      TestState target =
-          (i % 2 == 0) ? TestState::PLANNING : TestState::WAITING;
+      TestState target = (i % 2 == 0) ? TestState::PLANNING : TestState::WAITING;
       std::string name = (i % 2 == 0) ? "PLANNING" : "WAITING";
       state_.transitionTo(target, name);
     });
@@ -148,8 +140,7 @@ TEST_F(CoordinationStateTest, ThreadSafeStateTransitions) {
 
   // Final state should be valid (no crash = success)
   auto final_state = state_.getCurrentState();
-  EXPECT_TRUE(final_state == TestState::PLANNING ||
-              final_state == TestState::WAITING);
+  EXPECT_TRUE(final_state == TestState::PLANNING || final_state == TestState::WAITING);
 }
 
 /**
@@ -261,8 +252,7 @@ TEST_F(CoordinationStateTest, RecordResultThreadSafety) {
 
   std::vector<std::thread> threads;
   for (int32_t i = 0; i < NUM_THREADS; ++i) {
-    threads.emplace_back(
-        [this, i]() { state_.recordResult("result_" + std::to_string(i)); });
+    threads.emplace_back([this, i]() { state_.recordResult("result_" + std::to_string(i)); });
   }
 
   for (auto& t : threads) {
@@ -549,9 +539,8 @@ TEST_F(GrpcCoordinationStateTest, InitializeGrpcWithValidConfig) {
   auto coord_addr = getCoordinatorAddress();
   auto registry_addr = getRegistryAddress();
 
-  EXPECT_NO_THROW(state_.initializeGrpc("test_agent", coord_addr, registry_addr,
-                                        "TestAgent", 2,
-                                        {"capability1", "capability2"}, 10));
+  EXPECT_NO_THROW(state_.initializeGrpc(
+      "test_agent", coord_addr, registry_addr, "TestAgent", 2, {"capability1", "capability2"}, 10));
 }
 
 /**
@@ -563,7 +552,10 @@ TEST_F(CoordinationStateTest, InitializeGrpcWithInvalidConfig) {
   EXPECT_NO_THROW(state_.initializeGrpc("test_agent",
                                         "",  // Empty coordinator address
                                         "",  // Empty registry address
-                                        "TestAgent", 2, {}, 10));
+                                        "TestAgent",
+                                        2,
+                                        {},
+                                        10));
 }
 
 /**
@@ -584,15 +576,15 @@ TEST_F(GrpcCoordinationStateTest, QueryAvailableChildrenByType) {
   auto registry_addr = getRegistryAddress();
 
   // Initialize gRPC with in-process servers
-  state_.initializeGrpc("test_component", coord_addr, registry_addr,
-                        "ComponentLead", 1, {"coordination"}, 5);
+  state_.initializeGrpc(
+      "test_component", coord_addr, registry_addr, "ComponentLead", 1, {"coordination"}, 5);
 
   // Register some test agents in the ServiceRegistry
   auto registry = getRegistry();
-  registry->registerAgent("module_lead_1", "ModuleLead", 2, "localhost:60001",
-                          {"task_coordination"});
-  registry->registerAgent("module_lead_2", "ModuleLead", 2, "localhost:60002",
-                          {"task_coordination"});
+  registry->registerAgent(
+      "module_lead_1", "ModuleLead", 2, "localhost:60001", {"task_coordination"});
+  registry->registerAgent(
+      "module_lead_2", "ModuleLead", 2, "localhost:60002", {"task_coordination"});
 
   auto children = state_.queryAvailableChildren("ModuleLead");
   // Should find the 2 registered ModuleLead agents
@@ -718,8 +710,7 @@ TEST_F(CoordinationStateTest, RecordFailureThreadSafety) {
 
   std::vector<std::thread> threads;
   for (int32_t i = 0; i < NUM_THREADS; ++i) {
-    threads.emplace_back(
-        [this, i]() { state_.recordFailure("error_" + std::to_string(i)); });
+    threads.emplace_back([this, i]() { state_.recordFailure("error_" + std::to_string(i)); });
   }
   for (auto& t : threads) {
     t.join();

--- a/tests/unit/test_module_lead_agent.cpp
+++ b/tests/unit/test_module_lead_agent.cpp
@@ -235,6 +235,110 @@ TEST_F(ModuleLeadAgentTest, StateTransitionFlow) {
   (void)trace;  // Suppress unused variable warning
 }
 
+// ============================================================================
+// Issue #87: DAG Deadlock Prevention — Failure Handling Tests (4 tests)
+// ============================================================================
+
+TEST_F(ModuleLeadAgentTest, SingleTaskFailureTransitionsToError) {
+  auto module = std::make_shared<agents::ModuleLeadAgent>("module_1");
+  module->setMessageBus(bus_.get());
+  bus_->registerAgent(module->getAgentId(), module);
+
+  std::vector<std::string> task_ids = {"task_1"};
+  module->setAvailableTaskAgents(task_ids);
+
+  // Simulate receiving a TASK_FAILED message from a TaskAgent
+  auto failure_msg =
+      core::KeystoneMessage::create("task_1", "module_1", "response", "command not found");
+  failure_msg.action_type = core::ActionType::TASK_FAILED;
+
+  // Initialize coordination for 1 expected result
+  module->processMessage(
+      core::KeystoneMessage::create("chief", "module_1", "Calculate: 10 + 20")).get();
+
+  // Deliver failure
+  module->processMessage(failure_msg).get();
+
+  // Agent must be in ERROR state — DAG is not deadlocked
+  EXPECT_EQ(module->getCurrentState(), agents::ModuleLeadAgent::State::ERROR);
+}
+
+TEST_F(ModuleLeadAgentTest, SynthesizeAfterFailureReturnsErrorMessage) {
+  auto module = std::make_shared<agents::ModuleLeadAgent>("module_1");
+  module->setMessageBus(bus_.get());
+  bus_->registerAgent(module->getAgentId(), module);
+
+  std::vector<std::string> task_ids = {"task_1", "task_2"};
+  module->setAvailableTaskAgents(task_ids);
+
+  // Process goal to set up coordination for 2 tasks
+  module->processMessage(
+      core::KeystoneMessage::create("chief", "module_1", "Calculate: 10 + 20")).get();
+
+  // One success, one failure
+  auto success_msg = core::KeystoneMessage::create("task_1", "module_1", "response", "10");
+  module->processMessage(success_msg).get();
+
+  auto failure_msg =
+      core::KeystoneMessage::create("task_2", "module_1", "response", "exec failed");
+  failure_msg.action_type = core::ActionType::TASK_FAILED;
+  module->processMessage(failure_msg).get();
+
+  EXPECT_EQ(module->getCurrentState(), agents::ModuleLeadAgent::State::ERROR);
+
+  auto result = module->synthesizeResults();
+  EXPECT_NE(result.find("ERROR"), std::string::npos);
+}
+
+TEST_F(ModuleLeadAgentTest, FailureBeforeAllResultsDoesNotDeadlock) {
+  auto module = std::make_shared<agents::ModuleLeadAgent>("module_1");
+  module->setMessageBus(bus_.get());
+  bus_->registerAgent(module->getAgentId(), module);
+
+  std::vector<std::string> task_ids = {"task_1", "task_2", "task_3"};
+  module->setAvailableTaskAgents(task_ids);
+
+  // Goal decomposes into 3 tasks (numbers extracted from "10 + 20 + 30")
+  module->processMessage(
+      core::KeystoneMessage::create("chief", "module_1", "Calculate sum of: 10 + 20 + 30")).get();
+
+  // First task fails — must not leave the remaining 2 in permanent pending
+  auto failure_msg =
+      core::KeystoneMessage::create("task_1", "module_1", "response", "error");
+  failure_msg.action_type = core::ActionType::TASK_FAILED;
+  module->processMessage(failure_msg).get();
+
+  // State must not be stuck in WAITING after any terminal event
+  auto state = module->getCurrentState();
+  EXPECT_TRUE(state == agents::ModuleLeadAgent::State::ERROR ||
+              state == agents::ModuleLeadAgent::State::WAITING_FOR_TASKS);
+}
+
+TEST_F(ModuleLeadAgentTest, SuccessResultAfterFailureStillCountsTowardCompletion) {
+  auto module = std::make_shared<agents::ModuleLeadAgent>("module_1");
+  module->setMessageBus(bus_.get());
+  bus_->registerAgent(module->getAgentId(), module);
+
+  std::vector<std::string> task_ids = {"task_1", "task_2"};
+  module->setAvailableTaskAgents(task_ids);
+
+  module->processMessage(
+      core::KeystoneMessage::create("chief", "module_1", "Calculate: 10 + 20")).get();
+
+  // Failure first
+  auto failure_msg =
+      core::KeystoneMessage::create("task_1", "module_1", "response", "boom");
+  failure_msg.action_type = core::ActionType::TASK_FAILED;
+  module->processMessage(failure_msg).get();
+
+  // Then success — all results are now terminal, agent must not remain in WAITING
+  auto success_msg = core::KeystoneMessage::create("task_2", "module_1", "response", "20");
+  module->processMessage(success_msg).get();
+
+  auto state = module->getCurrentState();
+  EXPECT_NE(state, agents::ModuleLeadAgent::State::WAITING_FOR_TASKS);
+}
+
 TEST_F(ModuleLeadAgentTest, ConcurrentCoordination) {
   auto module = std::make_shared<agents::ModuleLeadAgent>("module_1");
   module->setMessageBus(bus_.get());

--- a/tests/unit/test_module_lead_agent.cpp
+++ b/tests/unit/test_module_lead_agent.cpp
@@ -253,8 +253,8 @@ TEST_F(ModuleLeadAgentTest, SingleTaskFailureTransitionsToError) {
   failure_msg.action_type = core::ActionType::TASK_FAILED;
 
   // Initialize coordination for 1 expected result
-  module->processMessage(
-      core::KeystoneMessage::create("chief", "module_1", "Calculate: 10 + 20")).get();
+  module->processMessage(core::KeystoneMessage::create("chief", "module_1", "Calculate: 10 + 20"))
+      .get();
 
   // Deliver failure
   module->processMessage(failure_msg).get();
@@ -272,15 +272,14 @@ TEST_F(ModuleLeadAgentTest, SynthesizeAfterFailureReturnsErrorMessage) {
   module->setAvailableTaskAgents(task_ids);
 
   // Process goal to set up coordination for 2 tasks
-  module->processMessage(
-      core::KeystoneMessage::create("chief", "module_1", "Calculate: 10 + 20")).get();
+  module->processMessage(core::KeystoneMessage::create("chief", "module_1", "Calculate: 10 + 20"))
+      .get();
 
   // One success, one failure
   auto success_msg = core::KeystoneMessage::create("task_1", "module_1", "response", "10");
   module->processMessage(success_msg).get();
 
-  auto failure_msg =
-      core::KeystoneMessage::create("task_2", "module_1", "response", "exec failed");
+  auto failure_msg = core::KeystoneMessage::create("task_2", "module_1", "response", "exec failed");
   failure_msg.action_type = core::ActionType::TASK_FAILED;
   module->processMessage(failure_msg).get();
 
@@ -299,12 +298,13 @@ TEST_F(ModuleLeadAgentTest, FailureBeforeAllResultsDoesNotDeadlock) {
   module->setAvailableTaskAgents(task_ids);
 
   // Goal decomposes into 3 tasks (numbers extracted from "10 + 20 + 30")
-  module->processMessage(
-      core::KeystoneMessage::create("chief", "module_1", "Calculate sum of: 10 + 20 + 30")).get();
+  module
+      ->processMessage(
+          core::KeystoneMessage::create("chief", "module_1", "Calculate sum of: 10 + 20 + 30"))
+      .get();
 
   // First task fails — must not leave the remaining 2 in permanent pending
-  auto failure_msg =
-      core::KeystoneMessage::create("task_1", "module_1", "response", "error");
+  auto failure_msg = core::KeystoneMessage::create("task_1", "module_1", "response", "error");
   failure_msg.action_type = core::ActionType::TASK_FAILED;
   module->processMessage(failure_msg).get();
 
@@ -322,12 +322,11 @@ TEST_F(ModuleLeadAgentTest, SuccessResultAfterFailureStillCountsTowardCompletion
   std::vector<std::string> task_ids = {"task_1", "task_2"};
   module->setAvailableTaskAgents(task_ids);
 
-  module->processMessage(
-      core::KeystoneMessage::create("chief", "module_1", "Calculate: 10 + 20")).get();
+  module->processMessage(core::KeystoneMessage::create("chief", "module_1", "Calculate: 10 + 20"))
+      .get();
 
   // Failure first
-  auto failure_msg =
-      core::KeystoneMessage::create("task_1", "module_1", "response", "boom");
+  auto failure_msg = core::KeystoneMessage::create("task_1", "module_1", "response", "boom");
   failure_msg.action_type = core::ActionType::TASK_FAILED;
   module->processMessage(failure_msg).get();
 


### PR DESCRIPTION
## Summary

- Adds `ActionType::TASK_FAILED` to the KIM protocol so subordinate agents can explicitly signal failure to their parent
- `CoordinationState` now tracks failures separately via `recordFailure()` — failures count toward the all-received threshold so deadlocked WAITING states are impossible
- `LeadAgentBase::processMessage()` dispatches `TASK_FAILED` messages to a new `processSubordinateFailure()` hook (with default implementation that transitions to ERROR)
- `TaskAgent` sets `action_type = TASK_FAILED` instead of plain `response` when an exception occurs during command execution
- `synthesizeResults()` / `synthesizeComponentResult()` return descriptive error messages when in ERROR state

## Test plan

- [x] 7 new `CoordinationState` failure-tracking tests (Category 7 in `test_coordination_state.cpp`)
- [x] 4 new `ModuleLeadAgent` DAG-deadlock-prevention tests in `test_module_lead_agent.cpp`
- [x] All changed headers pass `-fsyntax-only` with no errors
- [ ] Full test suite blocked by pre-existing `spdlog/fmt/fmt.h` not found — this is fixed on `main` (commit `fix(cmake): split combined target_link_libraries and fix spdlog visibility`) but not yet merged into this branch

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)