### PR TITLE
fix(dag): fix agent availability filtering to check current task assignment

### DIFF
--- a/src/keystone/dag_walker.py
+++ b/src/keystone/dag_walker.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from .models import Agent, Task, TERMINAL_STATUSES
+from .maestro_client import MaestroClient
+
+
+class DAGWalker:
+    """Walks a task DAG and assigns ready tasks to available agents."""
+
+    def __init__(
+        self,
+        tasks: list[Task],
+        agents: list[Agent],
+        client: Optional[MaestroClient] = None,
+    ) -> None:
+        self.tasks = tasks
+        self.agents = agents
+        self.client = client
+
+    def get_available_agents(self) -> list[Agent]:
+        """Return agents that are active, online, and not currently assigned a task."""
+        return [
+            a
+            for a in self.agents
+            if a.status == "active"
+            and a.session_status == "online"
+            and a.current_task_id is None
+        ]
+
+    def get_ready_tasks(self) -> list[Task]:
+        """Return tasks whose dependencies are all in terminal status."""
+        completed_ids = {
+            t.id for t in self.tasks if t.status in TERMINAL_STATUSES
+        }
+        return [
+            t
+            for t in self.tasks
+            if t.status == "pending"
+            and t.assigned_agent_id is None
+            and all(dep in completed_ids for dep in t.dependencies)
+        ]
+
+    async def advance_dag(self) -> list[tuple[Task, Agent]]:
+        """Assign ready tasks to available agents, returning the assignments made.
+
+        Agents are marked busy immediately upon selection so a single call cannot
+        double-assign the same agent even if the local list is stale.
+        """
+        assignments: list[tuple[Task, Agent]] = []
+        available = self.get_available_agents()
+
+        for task in self.get_ready_tasks():
+            if not available:
+                break
+
+            agent = available.pop(0)
+            # Mark agent busy immediately — guards against double-assignment within
+            # this call if the list was stale when we entered.
+            agent.current_task_id = task.id
+            task.assigned_agent_id = agent.id
+
+            if self.client is not None:
+                await self.client.assign_task(task.id, agent.id)
+
+            assignments.append((task, agent))
+
+        return assignments

--- a/src/keystone/maestro_client.py
+++ b/src/keystone/maestro_client.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from .models import Agent, Task, TERMINAL_STATUSES
+
+
+def _agent_from_api(data: dict[str, Any]) -> Agent:
+    """Parse an Agent from AI Maestro API response payload."""
+    agent = data.get("agent", data)
+    session = agent.get("session", {})
+    return Agent(
+        id=agent["id"],
+        name=agent.get("name", ""),
+        host=agent.get("hostId", ""),
+        status=agent.get("status", "active"),
+        session_status=session.get("status", "unknown"),
+        task_description=agent.get("taskDescription", ""),
+        program=agent.get("program", ""),
+        current_task_id=agent.get("currentTaskId"),
+    )
+
+
+def _task_from_api(data: dict[str, Any]) -> Task:
+    """Parse a Task from AI Maestro API response payload."""
+    return Task(
+        id=data["id"],
+        title=data.get("title", ""),
+        status=data.get("status", "pending"),
+        dependencies=data.get("dependencies", []),
+        assigned_agent_id=data.get("assignedAgentId"),
+    )
+
+
+class MaestroClient:
+    """Async HTTP client for the AI Maestro REST API."""
+
+    def __init__(self, http_client: Any) -> None:
+        self._client = http_client
+
+    async def _with_retries(self, fn: Any) -> Any:
+        return await fn()
+
+    @staticmethod
+    def _extract_key(body: Any, key: str, context: str) -> list[Any]:
+        if isinstance(body, list):
+            return body
+        if isinstance(body, dict) and key in body:
+            return body[key]
+        raise ValueError(f"Unexpected response shape for {context}: {body!r}")
+
+    async def get_agents(self) -> list[Agent]:
+        """Fetch active (non-soft-deleted) agents from the API."""
+        resp = await self._with_retries(
+            lambda: self._client.get("/api/agents/unified")
+        )
+        body = resp.json()
+        raw_agents = self._extract_key(body, "agents", "GET /api/agents/unified")
+        return [
+            _agent_from_api(entry)
+            for entry in raw_agents
+            if entry.get("agent", entry).get("deletedAt") is None
+        ]
+
+    async def get_tasks(self) -> list[Task]:
+        """Fetch all tasks from the API."""
+        resp = await self._with_retries(
+            lambda: self._client.get("/api/tasks")
+        )
+        body = resp.json()
+        raw_tasks = self._extract_key(body, "tasks", "GET /api/tasks")
+        return [_task_from_api(t) for t in raw_tasks]
+
+    async def assign_task(self, task_id: str, agent_id: str) -> None:
+        """Assign a task to an agent via the API."""
+        await self._with_retries(
+            lambda: self._client.put(
+                f"/api/tasks/{task_id}/assign",
+                json={"agentId": agent_id},
+            )
+        )

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from src.keystone.models import Agent, Task
+
+
+def make_agent(
+    id: str = "agent-1",
+    name: str = "Agent 1",
+    host: str = "host-1",
+    status: str = "active",
+    session_status: str = "online",
+    task_description: str = "",
+    program: str = "",
+    current_task_id: Optional[str] = None,
+) -> Agent:
+    return Agent(
+        id=id,
+        name=name,
+        host=host,
+        status=status,
+        session_status=session_status,
+        task_description=task_description,
+        program=program,
+        current_task_id=current_task_id,
+    )
+
+
+def make_task(
+    id: str = "task-1",
+    title: str = "Task 1",
+    status: str = "pending",
+    dependencies: Optional[list[str]] = None,
+    assigned_agent_id: Optional[str] = None,
+) -> Task:
+    return Task(
+        id=id,
+        title=title,
+        status=status,
+        dependencies=dependencies or [],
+        assigned_agent_id=assigned_agent_id,
+    )

--- a/tests/test_dag_walker.py
+++ b/tests/test_dag_walker.py
@@ -1,0 +1,127 @@
+"""Tests for DAGWalker.get_available_agents() and advance_dag()."""
+from __future__ import annotations
+
+import pytest
+
+from src.keystone.dag_walker import DAGWalker
+from tests.helpers import make_agent, make_task
+
+
+class TestGetAvailableAgents:
+    def test_online_active_agent_available(self) -> None:
+        agent = make_agent()
+        walker = DAGWalker(tasks=[], agents=[agent])
+        assert agent in walker.get_available_agents()
+
+    def test_busy_agent_not_available(self) -> None:
+        agent = make_agent(current_task_id="some-task")
+        walker = DAGWalker(tasks=[], agents=[agent])
+        assert agent not in walker.get_available_agents()
+
+    def test_inactive_agent_not_available(self) -> None:
+        agent = make_agent(status="inactive")
+        walker = DAGWalker(tasks=[], agents=[agent])
+        assert agent not in walker.get_available_agents()
+
+    def test_offline_agent_not_available(self) -> None:
+        agent = make_agent(session_status="offline")
+        walker = DAGWalker(tasks=[], agents=[agent])
+        assert agent not in walker.get_available_agents()
+
+    def test_mixed_agents_only_idle_returned(self) -> None:
+        idle = make_agent(id="a1")
+        busy = make_agent(id="a2", current_task_id="t-99")
+        offline = make_agent(id="a3", session_status="offline")
+        walker = DAGWalker(tasks=[], agents=[idle, busy, offline])
+        result = walker.get_available_agents()
+        assert result == [idle]
+
+
+class TestGetReadyTasks:
+    def test_task_with_no_deps_is_ready(self) -> None:
+        task = make_task()
+        walker = DAGWalker(tasks=[task], agents=[])
+        assert task in walker.get_ready_tasks()
+
+    def test_task_with_completed_dep_is_ready(self) -> None:
+        dep = make_task(id="dep-1", status="completed")
+        task = make_task(id="task-2", dependencies=["dep-1"])
+        walker = DAGWalker(tasks=[dep, task], agents=[])
+        assert task in walker.get_ready_tasks()
+
+    def test_task_with_pending_dep_not_ready(self) -> None:
+        dep = make_task(id="dep-1", status="pending")
+        task = make_task(id="task-2", dependencies=["dep-1"])
+        walker = DAGWalker(tasks=[dep, task], agents=[])
+        assert task not in walker.get_ready_tasks()
+
+    def test_already_assigned_task_not_ready(self) -> None:
+        task = make_task(assigned_agent_id="agent-99")
+        walker = DAGWalker(tasks=[task], agents=[])
+        assert task not in walker.get_ready_tasks()
+
+
+class TestAdvanceDag:
+    @pytest.mark.asyncio
+    async def test_assigns_ready_task_to_available_agent(self) -> None:
+        task = make_task()
+        agent = make_agent()
+        walker = DAGWalker(tasks=[task], agents=[agent])
+        assignments = await walker.advance_dag()
+        assert len(assignments) == 1
+        assert assignments[0] == (task, agent)
+        assert agent.current_task_id == task.id
+        assert task.assigned_agent_id == agent.id
+
+    @pytest.mark.asyncio
+    async def test_multiple_assignments_use_different_agents(self) -> None:
+        task1 = make_task(id="t1")
+        task2 = make_task(id="t2")
+        agent1 = make_agent(id="a1")
+        agent2 = make_agent(id="a2")
+        walker = DAGWalker(tasks=[task1, task2], agents=[agent1, agent2])
+        assignments = await walker.advance_dag()
+        assert len(assignments) == 2
+        assigned_agents = {a.id for _, a in assignments}
+        assert assigned_agents == {"a1", "a2"}
+
+    @pytest.mark.asyncio
+    async def test_busy_agent_not_double_assigned(self) -> None:
+        """A single idle agent with two ready tasks should only get one assignment."""
+        task1 = make_task(id="t1")
+        task2 = make_task(id="t2")
+        agent = make_agent(id="a1")
+        walker = DAGWalker(tasks=[task1, task2], agents=[agent])
+        assignments = await walker.advance_dag()
+        assert len(assignments) == 1
+        # Agent is now marked busy
+        assert agent.current_task_id is not None
+
+    @pytest.mark.asyncio
+    async def test_agent_marked_busy_immediately(self) -> None:
+        """Within advance_dag, agent.current_task_id is set before next iteration."""
+        task1 = make_task(id="t1")
+        task2 = make_task(id="t2")
+        agent = make_agent(id="a1")
+        walker = DAGWalker(tasks=[task1, task2], agents=[agent])
+        await walker.advance_dag()
+        # Only one task should be assigned since agent was marked busy after first
+        assert sum(1 for t in walker.tasks if t.assigned_agent_id is not None) == 1
+
+    @pytest.mark.asyncio
+    async def test_no_available_agents_no_assignments(self) -> None:
+        task = make_task()
+        agent = make_agent(current_task_id="other-task")
+        walker = DAGWalker(tasks=[task], agents=[agent])
+        assignments = await walker.advance_dag()
+        assert assignments == []
+
+    @pytest.mark.asyncio
+    async def test_no_ready_tasks_no_assignments(self) -> None:
+        # dep is in-progress (not pending, not terminal) — t1 depends on it and is blocked
+        dep = make_task(id="dep", status="in_progress")
+        task = make_task(id="t1", dependencies=["dep"])
+        agent = make_agent()
+        walker = DAGWalker(tasks=[dep, task], agents=[agent])
+        assignments = await walker.advance_dag()
+        assert assignments == []

--- a/tests/test_maestro_client.py
+++ b/tests/test_maestro_client.py
@@ -1,0 +1,133 @@
+"""Tests for MaestroClient._agent_from_api() and get_agents()."""
+from __future__ import annotations
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from src.keystone.maestro_client import _agent_from_api, MaestroClient
+
+
+class TestAgentFromApi:
+    def _entry(self, **overrides: object) -> dict:
+        base = {
+            "id": "agent-abc",
+            "name": "TestAgent",
+            "hostId": "host-1",
+            "status": "active",
+            "session": {"status": "online"},
+            "taskDescription": "some description",
+            "program": "researcher",
+            "currentTaskId": None,
+            "deletedAt": None,
+        }
+        base.update(overrides)
+        return base
+
+    def test_agent_from_api_basic_fields(self) -> None:
+        agent = _agent_from_api(self._entry())
+        assert agent.id == "agent-abc"
+        assert agent.name == "TestAgent"
+        assert agent.host == "host-1"
+        assert agent.status == "active"
+        assert agent.session_status == "online"
+        assert agent.program == "researcher"
+
+    def test_agent_from_api_current_task_id_populated(self) -> None:
+        agent = _agent_from_api(self._entry(currentTaskId="task-xyz"))
+        assert agent.current_task_id == "task-xyz"
+
+    def test_agent_from_api_null_current_task_id(self) -> None:
+        agent = _agent_from_api(self._entry(currentTaskId=None))
+        assert agent.current_task_id is None
+
+    def test_agent_from_api_missing_current_task_id(self) -> None:
+        data = self._entry()
+        data.pop("currentTaskId")
+        agent = _agent_from_api(data)
+        assert agent.current_task_id is None
+
+    def test_agent_from_api_task_description_populated(self) -> None:
+        agent = _agent_from_api(self._entry(taskDescription="working on task A"))
+        assert agent.task_description == "working on task A"
+
+    def test_agent_from_api_missing_task_description(self) -> None:
+        data = self._entry()
+        data.pop("taskDescription")
+        agent = _agent_from_api(data)
+        assert agent.task_description == ""
+
+    def test_agent_from_api_nested_agent_key(self) -> None:
+        """API may wrap agent data under an 'agent' key."""
+        inner = self._entry(currentTaskId="task-nested")
+        agent = _agent_from_api({"agent": inner})
+        assert agent.current_task_id == "task-nested"
+        assert agent.id == "agent-abc"
+
+    def test_agent_from_api_session_status_from_nested_session(self) -> None:
+        data = self._entry()
+        data["session"] = {"status": "offline"}
+        agent = _agent_from_api(data)
+        assert agent.session_status == "offline"
+
+
+class TestGetAgents:
+    def _make_client(self, raw_agents: list) -> MaestroClient:
+        resp = MagicMock()
+        resp.json.return_value = {"agents": raw_agents}
+        http = MagicMock()
+        http.get = AsyncMock(return_value=resp)
+        client = MaestroClient(http)
+        return client
+
+    def _raw_entry(self, id: str = "a1", deleted_at: object = None, current_task_id: object = None) -> dict:
+        return {
+            "id": id,
+            "name": "Agent",
+            "hostId": "h1",
+            "status": "active",
+            "session": {"status": "online"},
+            "taskDescription": "",
+            "program": "",
+            "currentTaskId": current_task_id,
+            "deletedAt": deleted_at,
+        }
+
+    @pytest.mark.asyncio
+    async def test_get_agents_returns_active_agents(self) -> None:
+        client = self._make_client([self._raw_entry("a1")])
+        agents = await client.get_agents()
+        assert len(agents) == 1
+        assert agents[0].id == "a1"
+
+    @pytest.mark.asyncio
+    async def test_get_agents_filters_soft_deleted(self) -> None:
+        client = self._make_client([
+            self._raw_entry("a1"),
+            self._raw_entry("a2", deleted_at="2026-01-01T00:00:00Z"),
+        ])
+        agents = await client.get_agents()
+        assert len(agents) == 1
+        assert agents[0].id == "a1"
+
+    @pytest.mark.asyncio
+    async def test_get_agents_populates_current_task_id(self) -> None:
+        client = self._make_client([
+            self._raw_entry("a1", current_task_id="task-99"),
+        ])
+        agents = await client.get_agents()
+        assert agents[0].current_task_id == "task-99"
+
+    @pytest.mark.asyncio
+    async def test_get_agents_nested_agent_key_soft_delete(self) -> None:
+        """Handles responses where agent data is nested under 'agent' key."""
+        inner = self._raw_entry("a1", deleted_at="2026-01-01T00:00:00Z")
+        raw = [{"agent": inner}]
+        client = self._make_client(raw)
+        # Patch _make_client to use nested form
+        resp = MagicMock()
+        resp.json.return_value = {"agents": raw}
+        http = MagicMock()
+        http.get = AsyncMock(return_value=resp)
+        client = MaestroClient(http)
+        agents = await client.get_agents()
+        assert agents == []


### PR DESCRIPTION
## Summary

- Adds `current_task_id` and `task_description` fields to the `Agent` dataclass (`models.py`) — these were documented in the API response but never populated
- Fixes `_agent_from_api()` to map `currentTaskId` → `current_task_id` and `taskDescription` → `task_description` from AI Maestro API responses
- Fixes `get_available_agents()` to add `and a.current_task_id is None` — agents with an active assignment are now excluded
- Fixes `get_agents()` to filter agents where `deletedAt is not None` (soft-delete gap)
- `advance_dag()` now marks `agent.current_task_id = task.id` immediately on selection, preventing double-booking of the same agent within a single call when the local agent list is stale

## Test plan

- [x] `TestGetAvailableAgents::test_busy_agent_not_available` — agent with `current_task_id` excluded
- [x] `TestGetAvailableAgents::test_online_active_agent_available` — idle agent still included
- [x] `TestAdvanceDag::test_busy_agent_not_double_assigned` — single agent with two ready tasks gets only one assignment
- [x] `TestAdvanceDag::test_agent_marked_busy_immediately` — `current_task_id` is set before next iteration
- [x] `TestMaestroClient::test_agent_from_api_current_task_id_populated` — `currentTaskId` in response populates field
- [x] `TestMaestroClient::test_agent_from_api_null_current_task_id` — missing key → `None`, not error
- [x] `TestGetAgents::test_get_agents_filters_soft_deleted` — agents with `deletedAt` excluded
- [x] All 27 tests pass

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)