### PR TITLE
feat(monitoring): add /v1/health endpoint with NATS status tracking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,6 +189,7 @@ add_library(
   # exporter
   src/monitoring/health_check_server.cpp # Phase 6.7: Health check endpoints
   # (C4)
+  src/monitoring/nats_status.cpp # Issue #93: NATS connection state tracker
 )
 
 target_include_directories(
@@ -405,7 +406,7 @@ add_executable(
   tests/unit/test_circuit_breaker.cpp # Phase 5.4: Chaos engineering - circuit
   # breaker
   tests/unit/test_agent_concepts.cpp # Issue #24: Agent concepts type safety
-  tests/unit/test_health_check_server.cpp # Phase 6.7: Health check endpoints (C4)
+  # test_health_check_server.cpp moved to monitoring_unit_tests (Issue #93)
   tests/unit/test_coordination_state.cpp # Stream B Phase B1: CoordinationState template tests (FIX: added mutexes)
   tests/unit/test_task_cancellation.cpp # Phase 1.2 (Issue #52): Task cancellation notification
   tests/unit/test_security_regression.cpp # PR #1: Security vulnerability regression tests
@@ -525,6 +526,20 @@ add_custom_target(
           simulation_unit_tests
           registry_integration_tests
   COMMENT "Running all ProjectKeystone tests with failure output")
+
+# Daemon executable (Issue #93: health check endpoint for Nomad/Argus)
+add_executable(keystone_daemon src/daemon/main.cpp)
+target_link_libraries(keystone_daemon PRIVATE keystone_core)
+
+# Unit Tests - Monitoring (Issue #93: NatsStatusTracker + /v1/health endpoint)
+add_executable(
+  monitoring_unit_tests
+  tests/unit/test_health_check_server.cpp
+  tests/unit/test_nats_status.cpp
+  tests/unit/test_health_v1_endpoint.cpp
+)
+target_link_libraries(monitoring_unit_tests keystone_core GTest::gtest_main)
+gtest_discover_tests(monitoring_unit_tests)
 
 # Benchmarks
 # Phase 3.1: Re-enabled hierarchy benchmarks with unified async API

--- a/include/monitoring/health_check_server.hpp
+++ b/include/monitoring/health_check_server.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "monitoring/nats_status.hpp"
+
 #include <atomic>
 #include <cstdint>
 #include <functional>
@@ -39,8 +41,11 @@ class HealthCheckServer {
    * @brief Construct health check server with configuration
    * @param port HTTP server port (default: 8080 for Kubernetes)
    * @param readiness_check Optional custom readiness check function
+   * @param nats_status Optional NATS status tracker (non-owning); used by /v1/health
    */
-  explicit HealthCheckServer(uint16_t port = 8080, ReadinessCheck readiness_check = nullptr);
+  explicit HealthCheckServer(uint16_t port = 8080,
+                             ReadinessCheck readiness_check = nullptr,
+                             NatsStatusTracker* nats_status = nullptr);
 
   /**
    * @brief Destructor - stops server if running
@@ -105,12 +110,20 @@ class HealthCheckServer {
    */
   static std::string generateReadinessResponse(bool ready);
 
+  /**
+   * @brief Generate /v1/health response JSON body
+   * @param nats_status Optional NATS tracker (may be nullptr)
+   * @return JSON body string
+   */
+  static std::string generateV1HealthResponse(const NatsStatusTracker* nats_status);
+
   std::atomic<uint16_t> port_;
   std::atomic<bool> running_{false};
   std::unique_ptr<std::thread> server_thread_;
   std::atomic<int> server_fd_{-1};
   mutable std::mutex readiness_mutex_;
   ReadinessCheck readiness_check_;
+  NatsStatusTracker* nats_status_{nullptr};  // non-owning
 };
 
 }  // namespace monitoring

--- a/include/monitoring/nats_status.hpp
+++ b/include/monitoring/nats_status.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <mutex>
+
+namespace keystone {
+namespace monitoring {
+
+enum class NatsConnectionState {
+  kConnected,
+  kDisconnected,
+  kReconnecting,
+};
+
+/**
+ * @brief Thread-safe NATS connection state tracker
+ *
+ * Updated by NATS client callbacks; read by HealthCheckServer for /v1/health.
+ * setConnected() records the last-success timestamp; the other setters update
+ * state only (a reconnect or disconnect does not reset the success clock).
+ */
+class NatsStatusTracker {
+ public:
+  NatsStatusTracker() = default;
+
+  // Non-copyable, non-movable (atomic + mutex members)
+  NatsStatusTracker(const NatsStatusTracker&) = delete;
+  NatsStatusTracker& operator=(const NatsStatusTracker&) = delete;
+
+  void setConnected();
+  void setDisconnected();
+  void setReconnecting();
+
+  NatsConnectionState state() const;
+
+  // Returns 0 if setConnected() has never been called.
+  int64_t lastSuccessEpochMs() const;
+
+ private:
+  std::atomic<NatsConnectionState> state_{NatsConnectionState::kDisconnected};
+  mutable std::mutex timestamp_mutex_;
+  std::chrono::system_clock::time_point last_success_time_{};
+  bool has_success_{false};
+};
+
+}  // namespace monitoring
+}  // namespace keystone

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -1,0 +1,39 @@
+#include "monitoring/health_check_server.hpp"
+#include "monitoring/nats_status.hpp"
+
+#include <atomic>
+#include <csignal>
+#include <iostream>
+
+namespace {
+std::atomic<bool> g_stop{false};
+
+void signalHandler(int /*sig*/) {
+  g_stop.store(true, std::memory_order_release);
+}
+}  // namespace
+
+int main() {
+  std::signal(SIGTERM, signalHandler);
+  std::signal(SIGINT, signalHandler);
+
+  keystone::monitoring::NatsStatusTracker nats_status;
+  keystone::monitoring::HealthCheckServer health_server(8080, nullptr, &nats_status);
+
+  if (!health_server.start()) {
+    std::cerr << "keystone-daemon: failed to start health check server\n";
+    return 1;
+  }
+
+  std::cout << "Keystone daemon started. Health endpoint: "
+               "http://0.0.0.0:"
+            << health_server.getPort() << "/v1/health\n";
+
+  while (!g_stop.load(std::memory_order_acquire)) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+
+  health_server.stop();
+  std::cout << "Keystone daemon stopped.\n";
+  return 0;
+}

--- a/src/monitoring/health_check_server.cpp
+++ b/src/monitoring/health_check_server.cpp
@@ -373,9 +373,8 @@ std::string HealthCheckServer::generateV1HealthResponse(const NatsStatusTracker*
   bool healthy = (st == NatsConnectionState::kConnected);
   const char* overall = healthy ? "healthy" : "degraded";
 
-  body << "{\"status\":\"" << overall << "\","
-       << "\"nats\":{\"state\":\"" << state_str << "\","
-       << "\"last_success_epoch_ms\":" << last_ms << "}}";
+  body << "{\"status\":\"" << overall << "\",\"nats\":{\"state\":\"" << state_str
+       << "\",\"last_success_epoch_ms\":" << last_ms << "}}";
   return body.str();
 }
 

--- a/src/monitoring/health_check_server.cpp
+++ b/src/monitoring/health_check_server.cpp
@@ -54,8 +54,13 @@ class SocketHandle {
   int fd_;
 };
 
-HealthCheckServer::HealthCheckServer(uint16_t port, ReadinessCheck readiness_check)
-    : port_(port), server_fd_(-1), readiness_check_(std::move(readiness_check)) {}
+HealthCheckServer::HealthCheckServer(uint16_t port,
+                                     ReadinessCheck readiness_check,
+                                     NatsStatusTracker* nats_status)
+    : port_(port),
+      server_fd_(-1),
+      readiness_check_(std::move(readiness_check)),
+      nats_status_(nats_status) {}
 
 HealthCheckServer::~HealthCheckServer() {
   stop();
@@ -264,8 +269,28 @@ void HealthCheckServer::handleRequest(int client_fd) {
   // Check which endpoint is requested
   bool is_liveness = (request.find("GET /healthz") != std::string::npos);
   bool is_readiness = (request.find("GET /ready") != std::string::npos);
+  bool is_v1_health = (request.find("GET /v1/health ") != std::string::npos);
 
-  if (is_liveness) {
+  if (is_v1_health) {
+    std::string body = generateV1HealthResponse(nats_status_);
+    NatsConnectionState nats_state =
+        nats_status_ ? nats_status_->state() : NatsConnectionState::kDisconnected;
+    bool healthy = (nats_status_ == nullptr) ||
+                   (nats_state == NatsConnectionState::kConnected);
+    std::string status_line =
+        healthy ? "HTTP/1.1 200 OK\r\n" : "HTTP/1.1 503 Service Unavailable\r\n";
+
+    std::ostringstream response;
+    response << status_line;
+    response << "Content-Type: application/json\r\n";
+    response << "Content-Length: " << body.size() << "\r\n";
+    response << "\r\n";
+    response << body;
+
+    std::string response_str = response.str();
+    [[maybe_unused]] auto result = write(client_fd, response_str.c_str(), response_str.size());
+
+  } else if (is_liveness) {
     // Liveness probe - always return 200 OK if process is alive
     std::string body = generateLivenessResponse();
 
@@ -325,6 +350,34 @@ std::string HealthCheckServer::generateReadinessResponse(bool ready) {
   } else {
     return "{\"status\":\"not_ready\"}";
   }
+}
+
+std::string HealthCheckServer::generateV1HealthResponse(const NatsStatusTracker* nats_status) {
+  std::ostringstream body;
+
+  if (nats_status == nullptr) {
+    body << "{\"status\":\"healthy\","
+         << "\"nats\":{\"state\":\"unknown\",\"last_success_epoch_ms\":0}}";
+    return body.str();
+  }
+
+  NatsConnectionState st = nats_status->state();
+  int64_t last_ms = nats_status->lastSuccessEpochMs();
+
+  const char* state_str = "disconnected";
+  if (st == NatsConnectionState::kConnected) {
+    state_str = "connected";
+  } else if (st == NatsConnectionState::kReconnecting) {
+    state_str = "reconnecting";
+  }
+
+  bool healthy = (st == NatsConnectionState::kConnected);
+  const char* overall = healthy ? "healthy" : "degraded";
+
+  body << "{\"status\":\"" << overall << "\","
+       << "\"nats\":{\"state\":\"" << state_str << "\","
+       << "\"last_success_epoch_ms\":" << last_ms << "}}";
+  return body.str();
 }
 
 }  // namespace monitoring

--- a/src/monitoring/health_check_server.cpp
+++ b/src/monitoring/health_check_server.cpp
@@ -273,12 +273,11 @@ void HealthCheckServer::handleRequest(int client_fd) {
 
   if (is_v1_health) {
     std::string body = generateV1HealthResponse(nats_status_);
-    NatsConnectionState nats_state =
-        nats_status_ ? nats_status_->state() : NatsConnectionState::kDisconnected;
-    bool healthy = (nats_status_ == nullptr) ||
-                   (nats_state == NatsConnectionState::kConnected);
-    std::string status_line =
-        healthy ? "HTTP/1.1 200 OK\r\n" : "HTTP/1.1 503 Service Unavailable\r\n";
+    NatsConnectionState nats_state = nats_status_ ? nats_status_->state()
+                                                  : NatsConnectionState::kDisconnected;
+    bool healthy = (nats_status_ == nullptr) || (nats_state == NatsConnectionState::kConnected);
+    std::string status_line = healthy ? "HTTP/1.1 200 OK\r\n"
+                                      : "HTTP/1.1 503 Service Unavailable\r\n";
 
     std::ostringstream response;
     response << status_line;

--- a/src/monitoring/nats_status.cpp
+++ b/src/monitoring/nats_status.cpp
@@ -1,0 +1,35 @@
+#include "monitoring/nats_status.hpp"
+
+namespace keystone {
+namespace monitoring {
+
+void NatsStatusTracker::setConnected() {
+  state_.store(NatsConnectionState::kConnected, std::memory_order_release);
+  std::lock_guard<std::mutex> lock(timestamp_mutex_);
+  last_success_time_ = std::chrono::system_clock::now();
+  has_success_ = true;
+}
+
+void NatsStatusTracker::setDisconnected() {
+  state_.store(NatsConnectionState::kDisconnected, std::memory_order_release);
+}
+
+void NatsStatusTracker::setReconnecting() {
+  state_.store(NatsConnectionState::kReconnecting, std::memory_order_release);
+}
+
+NatsConnectionState NatsStatusTracker::state() const {
+  return state_.load(std::memory_order_acquire);
+}
+
+int64_t NatsStatusTracker::lastSuccessEpochMs() const {
+  std::lock_guard<std::mutex> lock(timestamp_mutex_);
+  if (!has_success_) {
+    return 0;
+  }
+  auto epoch = last_success_time_.time_since_epoch();
+  return std::chrono::duration_cast<std::chrono::milliseconds>(epoch).count();
+}
+
+}  // namespace monitoring
+}  // namespace keystone

--- a/tests/unit/test_health_v1_endpoint.cpp
+++ b/tests/unit/test_health_v1_endpoint.cpp
@@ -1,0 +1,215 @@
+#include "monitoring/health_check_server.hpp"
+#include "monitoring/nats_status.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <arpa/inet.h>
+#include <gtest/gtest.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+using namespace keystone::monitoring;
+
+class HealthV1EndpointTest : public ::testing::Test {
+ protected:
+  void SetUp() override { port_ = 0; }
+
+  void TearDown() override {
+    if (server_) {
+      server_->stop();
+    }
+  }
+
+  std::string sendRequest(const std::string& path) {
+    int32_t sock = socket(AF_INET, SOCK_STREAM, 0);
+    if (sock < 0) {
+      return "";
+    }
+
+    struct sockaddr_in addr;
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(port_);
+    addr.sin_addr.s_addr = inet_addr("127.0.0.1");
+
+    if (connect(sock, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
+      close(sock);
+      return "";
+    }
+
+    std::string request = "GET " + path + " HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    if (write(sock, request.c_str(), request.size()) < 0) {
+      close(sock);
+      return "";
+    }
+
+    char buffer[4096];
+    ssize_t bytes = read(sock, buffer, sizeof(buffer) - 1);
+    close(sock);
+    if (bytes <= 0) {
+      return "";
+    }
+    buffer[bytes] = '\0';
+    return std::string(buffer);
+  }
+
+  int getStatusCode(const std::string& response) {
+    size_t start = response.find("HTTP/1.1 ");
+    if (start == std::string::npos) return 0;
+    start += 9;
+    size_t end = response.find(' ', start);
+    if (end == std::string::npos) return 0;
+    try {
+      return std::stoi(response.substr(start, end - start));
+    } catch (...) {
+      return 0;
+    }
+  }
+
+  std::string getBody(const std::string& response) {
+    size_t pos = response.find("\r\n\r\n");
+    if (pos == std::string::npos) return "";
+    return response.substr(pos + 4);
+  }
+
+  int port_;
+  std::unique_ptr<HealthCheckServer> server_;
+};
+
+TEST_F(HealthV1EndpointTest, NullTrackerReturns200Healthy) {
+  server_ = std::make_unique<HealthCheckServer>(port_, nullptr, nullptr);
+  ASSERT_TRUE(server_->start());
+  port_ = server_->getPort();
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+  std::string response = sendRequest("/v1/health");
+  ASSERT_FALSE(response.empty());
+  EXPECT_EQ(getStatusCode(response), 200);
+
+  std::string body = getBody(response);
+  EXPECT_NE(body.find("\"status\":\"healthy\""), std::string::npos);
+  EXPECT_NE(body.find("\"state\":\"unknown\""), std::string::npos);
+}
+
+TEST_F(HealthV1EndpointTest, ConnectedReturns200) {
+  NatsStatusTracker tracker;
+  tracker.setConnected();
+
+  server_ = std::make_unique<HealthCheckServer>(port_, nullptr, &tracker);
+  ASSERT_TRUE(server_->start());
+  port_ = server_->getPort();
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+  std::string response = sendRequest("/v1/health");
+  ASSERT_FALSE(response.empty());
+  EXPECT_EQ(getStatusCode(response), 200);
+
+  std::string body = getBody(response);
+  EXPECT_NE(body.find("\"status\":\"healthy\""), std::string::npos);
+  EXPECT_NE(body.find("\"state\":\"connected\""), std::string::npos);
+  // last_success_epoch_ms must be non-zero
+  EXPECT_EQ(body.find("\"last_success_epoch_ms\":0"), std::string::npos);
+}
+
+TEST_F(HealthV1EndpointTest, DisconnectedReturns503) {
+  NatsStatusTracker tracker;
+  // tracker starts disconnected — no setDisconnected() needed
+
+  server_ = std::make_unique<HealthCheckServer>(port_, nullptr, &tracker);
+  ASSERT_TRUE(server_->start());
+  port_ = server_->getPort();
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+  std::string response = sendRequest("/v1/health");
+  ASSERT_FALSE(response.empty());
+  EXPECT_EQ(getStatusCode(response), 503);
+
+  std::string body = getBody(response);
+  EXPECT_NE(body.find("\"status\":\"degraded\""), std::string::npos);
+  EXPECT_NE(body.find("\"state\":\"disconnected\""), std::string::npos);
+}
+
+TEST_F(HealthV1EndpointTest, ReconnectingReturns503) {
+  NatsStatusTracker tracker;
+  tracker.setConnected();
+  tracker.setReconnecting();
+
+  server_ = std::make_unique<HealthCheckServer>(port_, nullptr, &tracker);
+  ASSERT_TRUE(server_->start());
+  port_ = server_->getPort();
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+  std::string response = sendRequest("/v1/health");
+  ASSERT_FALSE(response.empty());
+  EXPECT_EQ(getStatusCode(response), 503);
+
+  std::string body = getBody(response);
+  EXPECT_NE(body.find("\"status\":\"degraded\""), std::string::npos);
+  EXPECT_NE(body.find("\"state\":\"reconnecting\""), std::string::npos);
+}
+
+TEST_F(HealthV1EndpointTest, StateTransitionConnectedToDisconnected) {
+  NatsStatusTracker tracker;
+  tracker.setConnected();
+
+  server_ = std::make_unique<HealthCheckServer>(port_, nullptr, &tracker);
+  ASSERT_TRUE(server_->start());
+  port_ = server_->getPort();
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+  // Initially connected → 200
+  EXPECT_EQ(getStatusCode(sendRequest("/v1/health")), 200);
+
+  // Transition to disconnected → 503
+  tracker.setDisconnected();
+  EXPECT_EQ(getStatusCode(sendRequest("/v1/health")), 503);
+
+  // Reconnect → 200
+  tracker.setConnected();
+  EXPECT_EQ(getStatusCode(sendRequest("/v1/health")), 200);
+}
+
+TEST_F(HealthV1EndpointTest, ExistingEndpointsUnaffected) {
+  NatsStatusTracker tracker;
+  tracker.setConnected();
+
+  server_ = std::make_unique<HealthCheckServer>(port_, nullptr, &tracker);
+  ASSERT_TRUE(server_->start());
+  port_ = server_->getPort();
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+  // /healthz still works
+  EXPECT_EQ(getStatusCode(sendRequest("/healthz")), 200);
+  EXPECT_EQ(getBody(sendRequest("/healthz")), "{\"status\":\"healthy\"}");
+
+  // /ready still works
+  EXPECT_EQ(getStatusCode(sendRequest("/ready")), 200);
+}
+
+TEST_F(HealthV1EndpointTest, V1HealthNotFoundWhenPathDiffers) {
+  server_ = std::make_unique<HealthCheckServer>(port_);
+  ASSERT_TRUE(server_->start());
+  port_ = server_->getPort();
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+  EXPECT_EQ(getStatusCode(sendRequest("/v1/healthz")), 404);
+}
+
+TEST_F(HealthV1EndpointTest, LastSuccessEpochMsInBody) {
+  NatsStatusTracker tracker;
+  tracker.setConnected();
+  int64_t expected_ms = tracker.lastSuccessEpochMs();
+  ASSERT_GT(expected_ms, 0);
+
+  server_ = std::make_unique<HealthCheckServer>(port_, nullptr, &tracker);
+  ASSERT_TRUE(server_->start());
+  port_ = server_->getPort();
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+  std::string body = getBody(sendRequest("/v1/health"));
+  EXPECT_NE(body.find(std::to_string(expected_ms)), std::string::npos);
+}

--- a/tests/unit/test_health_v1_endpoint.cpp
+++ b/tests/unit/test_health_v1_endpoint.cpp
@@ -59,10 +59,12 @@ class HealthV1EndpointTest : public ::testing::Test {
 
   int getStatusCode(const std::string& response) {
     size_t start = response.find("HTTP/1.1 ");
-    if (start == std::string::npos) return 0;
+    if (start == std::string::npos)
+      return 0;
     start += 9;
     size_t end = response.find(' ', start);
-    if (end == std::string::npos) return 0;
+    if (end == std::string::npos)
+      return 0;
     try {
       return std::stoi(response.substr(start, end - start));
     } catch (...) {
@@ -72,7 +74,8 @@ class HealthV1EndpointTest : public ::testing::Test {
 
   std::string getBody(const std::string& response) {
     size_t pos = response.find("\r\n\r\n");
-    if (pos == std::string::npos) return "";
+    if (pos == std::string::npos)
+      return "";
     return response.substr(pos + 4);
   }
 

--- a/tests/unit/test_nats_status.cpp
+++ b/tests/unit/test_nats_status.cpp
@@ -1,0 +1,116 @@
+#include "monitoring/nats_status.hpp"
+
+#include <atomic>
+#include <thread>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+using keystone::monitoring::NatsConnectionState;
+using keystone::monitoring::NatsStatusTracker;
+
+TEST(NatsStatusTrackerTest, InitialStateIsDisconnected) {
+  NatsStatusTracker tracker;
+  EXPECT_EQ(tracker.state(), NatsConnectionState::kDisconnected);
+}
+
+TEST(NatsStatusTrackerTest, InitialLastSuccessEpochMsIsZero) {
+  NatsStatusTracker tracker;
+  EXPECT_EQ(tracker.lastSuccessEpochMs(), 0);
+}
+
+TEST(NatsStatusTrackerTest, SetConnectedUpdatesState) {
+  NatsStatusTracker tracker;
+  tracker.setConnected();
+  EXPECT_EQ(tracker.state(), NatsConnectionState::kConnected);
+}
+
+TEST(NatsStatusTrackerTest, SetConnectedUpdatesTimestamp) {
+  NatsStatusTracker tracker;
+  tracker.setConnected();
+  EXPECT_GT(tracker.lastSuccessEpochMs(), 0);
+}
+
+TEST(NatsStatusTrackerTest, SetDisconnectedUpdatesState) {
+  NatsStatusTracker tracker;
+  tracker.setConnected();
+  tracker.setDisconnected();
+  EXPECT_EQ(tracker.state(), NatsConnectionState::kDisconnected);
+}
+
+TEST(NatsStatusTrackerTest, SetDisconnectedDoesNotResetTimestamp) {
+  NatsStatusTracker tracker;
+  tracker.setConnected();
+  int64_t ts = tracker.lastSuccessEpochMs();
+  ASSERT_GT(ts, 0);
+  tracker.setDisconnected();
+  EXPECT_EQ(tracker.lastSuccessEpochMs(), ts);
+}
+
+TEST(NatsStatusTrackerTest, SetReconnectingUpdatesState) {
+  NatsStatusTracker tracker;
+  tracker.setConnected();
+  tracker.setReconnecting();
+  EXPECT_EQ(tracker.state(), NatsConnectionState::kReconnecting);
+}
+
+TEST(NatsStatusTrackerTest, SetReconnectingDoesNotResetTimestamp) {
+  NatsStatusTracker tracker;
+  tracker.setConnected();
+  int64_t ts = tracker.lastSuccessEpochMs();
+  ASSERT_GT(ts, 0);
+  tracker.setReconnecting();
+  EXPECT_EQ(tracker.lastSuccessEpochMs(), ts);
+}
+
+TEST(NatsStatusTrackerTest, MultipleSetConnectedUpdatesTimestamp) {
+  NatsStatusTracker tracker;
+  tracker.setConnected();
+  int64_t ts1 = tracker.lastSuccessEpochMs();
+  // Small sleep to ensure clock advances
+  std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  tracker.setConnected();
+  int64_t ts2 = tracker.lastSuccessEpochMs();
+  EXPECT_GE(ts2, ts1);
+}
+
+TEST(NatsStatusTrackerTest, ConcurrentStateUpdatesAreSafe) {
+  NatsStatusTracker tracker;
+  std::atomic<bool> start{false};
+  constexpr int kThreads = 8;
+  constexpr int kIters = 200;
+
+  std::vector<std::thread> threads;
+  threads.reserve(kThreads);
+  for (int i = 0; i < kThreads; ++i) {
+    threads.emplace_back([&tracker, &start, i]() {
+      while (!start.load()) {
+      }
+      for (int j = 0; j < kIters; ++j) {
+        switch ((i + j) % 3) {
+          case 0:
+            tracker.setConnected();
+            break;
+          case 1:
+            tracker.setDisconnected();
+            break;
+          case 2:
+            tracker.setReconnecting();
+            break;
+        }
+        (void)tracker.state();
+        (void)tracker.lastSuccessEpochMs();
+      }
+    });
+  }
+
+  start.store(true);
+  for (auto& t : threads) {
+    t.join();
+  }
+  // No crash == pass; state must be one of the valid enum values
+  NatsConnectionState st = tracker.state();
+  EXPECT_TRUE(st == NatsConnectionState::kConnected ||
+              st == NatsConnectionState::kDisconnected ||
+              st == NatsConnectionState::kReconnecting);
+}

--- a/tests/unit/test_nats_status.cpp
+++ b/tests/unit/test_nats_status.cpp
@@ -84,8 +84,7 @@ TEST(NatsStatusTrackerTest, ConcurrentStateUpdatesAreSafe) {
   threads.reserve(kThreads);
   for (int i = 0; i < kThreads; ++i) {
     threads.emplace_back([&tracker, &start, i]() {
-      while (!start.load()) {
-      }
+      while (!start.load()) {}
       for (int j = 0; j < kIters; ++j) {
         switch ((i + j) % 3) {
           case 0:
@@ -110,7 +109,6 @@ TEST(NatsStatusTrackerTest, ConcurrentStateUpdatesAreSafe) {
   }
   // No crash == pass; state must be one of the valid enum values
   NatsConnectionState st = tracker.state();
-  EXPECT_TRUE(st == NatsConnectionState::kConnected ||
-              st == NatsConnectionState::kDisconnected ||
+  EXPECT_TRUE(st == NatsConnectionState::kConnected || st == NatsConnectionState::kDisconnected ||
               st == NatsConnectionState::kReconnecting);
 }


### PR DESCRIPTION
## Summary

- Adds `GET /v1/health` HTTP endpoint to `HealthCheckServer` for Nomad liveness probes and Argus alerting
- Returns `200 healthy` when NATS is connected (or no tracker wired), `503 degraded` when disconnected/reconnecting
- Adds `NatsStatusTracker` — a thread-safe state tracker that any future NATS client can update via `setConnected()` / `setDisconnected()` / `setReconnecting()`
- Adds `keystone_daemon` executable that wires `HealthCheckServer` + `NatsStatusTracker` together with `SIGTERM`/`SIGINT` handling

## Response format

```json
// 200 OK — NATS connected
{"status":"healthy","nats":{"state":"connected","last_success_epoch_ms":1745123456789}}

// 503 Service Unavailable — NATS disconnected or reconnecting
{"status":"degraded","nats":{"state":"disconnected","last_success_epoch_ms":1745123456789}}

// 200 OK — no NatsStatusTracker wired (null)
{"status":"healthy","nats":{"state":"unknown","last_success_epoch_ms":0}}
```

## Files changed

| File | Change |
|------|--------|
| `include/monitoring/nats_status.hpp` | New: `NatsStatusTracker` class |
| `src/monitoring/nats_status.cpp` | New: implementation |
| `include/monitoring/health_check_server.hpp` | Extended: optional `NatsStatusTracker*` ctor param, `generateV1HealthResponse()` |
| `src/monitoring/health_check_server.cpp` | Extended: `/v1/health` route |
| `src/daemon/main.cpp` | New: daemon entry point |
| `tests/unit/test_nats_status.cpp` | New: 10 unit tests |
| `tests/unit/test_health_v1_endpoint.cpp` | New: 8 endpoint tests |
| `CMakeLists.txt` | Added `nats_status.cpp` to `keystone_core`; new `monitoring_unit_tests` and `keystone_daemon` targets |

## Test plan

- [x] 29/29 tests pass in `monitoring_unit_tests` (debug build)
- [x] 29/29 tests pass under ASan+UBSan
- [x] `keystone_daemon` binary builds and links cleanly
- [x] Existing `/healthz` and `/ready` endpoints unaffected (regression test `ExistingEndpointsUnaffected`)
- [x] Concurrent-access test (`ConcurrentStateUpdatesAreSafe`) validates thread safety

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)