### PR TITLE
chore: add .mypy_cache and .ruff_cache to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,8 @@ wheels/
 htmlcov/
 .tox/
 Testing/
+.mypy_cache/
+.ruff_cache/
 
 # IDEs
 .vscode/


### PR DESCRIPTION
## Summary

- The `.gitignore` already covered most entries from the issue (`.env`, `*.egg-info`, `.pytest_cache`, `htmlcov`, `.vscode`, `.idea`)
- Added the two missing entries: `.mypy_cache/` and `.ruff_cache/`

## Test plan

- No code changes; `.gitignore` update only
- Verified all existing patterns from issue #97 are now present

Closes #97