### PR TITLE
feat(logging): switch to structured JSON logging for log aggregation

### DIFF
--- a/src/keystone/daemon.py
+++ b/src/keystone/daemon.py
@@ -1,0 +1,75 @@
+"""Keystone daemon — routes messages between publishers and subscribers."""
+
+from __future__ import annotations
+
+import argparse
+import logging as stdlib_logging
+import signal
+import sys
+import time
+from typing import Any
+
+from keystone.logging import KeystoneLogger, configure_logging, get_logger
+
+logger: KeystoneLogger = get_logger(component="daemon")
+
+
+def handle_sigterm(signum: int, frame: Any) -> None:
+    """Handle SIGTERM by raising SystemExit so cleanup runs."""
+    raise SystemExit(0)
+
+
+def run_routing_loop(poll_interval: float = 1.0) -> None:
+    """Run the main message-routing loop until interrupted."""
+    logger.info("routing_loop_started", poll_interval=poll_interval)
+    try:
+        while True:
+            time.sleep(poll_interval)
+    except (KeyboardInterrupt, SystemExit):
+        logger.info("routing_loop_stopped")
+
+
+def assign_task(team_id: str, task_id: str, agent_id: str) -> None:
+    """Record a task assignment in the structured log."""
+    logger.info(
+        "task_assigned",
+        team_id=team_id,
+        task_id=task_id,
+        agent_id=agent_id,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for the Keystone daemon."""
+    parser = argparse.ArgumentParser(description="ProjectKeystone transport daemon")
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        help="Logging verbosity level",
+    )
+    parser.add_argument(
+        "--poll-interval",
+        type=float,
+        default=1.0,
+        help="Routing loop poll interval in seconds",
+    )
+    args = parser.parse_args(argv)
+
+    configure_logging(level=getattr(stdlib_logging, args.log_level))
+    signal.signal(signal.SIGTERM, handle_sigterm)
+
+    logger.info("daemon_starting", log_level=args.log_level)
+    try:
+        run_routing_loop(poll_interval=args.poll_interval)
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("daemon_error", error=str(exc))
+        return 1
+    finally:
+        logger.info("daemon_stopped")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/keystone/logging.py
+++ b/src/keystone/logging.py
@@ -1,0 +1,113 @@
+"""Structured JSON logging for ProjectKeystone using stdlib only."""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+import threading
+from datetime import datetime, timezone
+from typing import Any
+
+# Pre-computed baseline attributes of a LogRecord to detect extra fields.
+_BASELINE_ATTRS: frozenset[str] = frozenset(
+    logging.LogRecord("", 0, "", 0, "", (), None).__dict__
+)
+
+# Reserved top-level field names that would conflict with the log schema.
+_RESERVED_FIELDS = frozenset({"timestamp", "level", "logger", "message", "exception"})
+
+
+class JsonFormatter(logging.Formatter):
+    """Formats log records as single-line JSON objects."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        output: dict[str, Any] = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+
+        # Promote extra fields injected by the caller.
+        for key, value in record.__dict__.items():
+            if key not in _BASELINE_ATTRS:
+                dest_key = f"ctx_{key}" if key in _RESERVED_FIELDS else key
+                output[dest_key] = value
+
+        if record.exc_info:
+            output["exception"] = self.formatException(record.exc_info)
+
+        return json.dumps(output, default=str)
+
+
+class KeystoneLogger:
+    """Thread-safe logger that binds context fields to every log record."""
+
+    def __init__(self, logger: logging.Logger, context: dict[str, Any]) -> None:
+        self._logger = logger
+        self._context: dict[str, Any] = dict(context)
+        self._lock = threading.Lock()
+
+    def _log(self, level: int, msg: str, **kwargs: Any) -> None:
+        with self._lock:
+            ctx = dict(self._context)
+        extra = {**kwargs, **ctx}
+        self._logger.log(level, msg, extra=extra)
+
+    def debug(self, msg: str, **kwargs: Any) -> None:
+        """Log a DEBUG message with optional context fields."""
+        self._log(logging.DEBUG, msg, **kwargs)
+
+    def info(self, msg: str, **kwargs: Any) -> None:
+        """Log an INFO message with optional context fields."""
+        self._log(logging.INFO, msg, **kwargs)
+
+    def warning(self, msg: str, **kwargs: Any) -> None:
+        """Log a WARNING message with optional context fields."""
+        self._log(logging.WARNING, msg, **kwargs)
+
+    def error(self, msg: str, **kwargs: Any) -> None:
+        """Log an ERROR message with optional context fields."""
+        self._log(logging.ERROR, msg, **kwargs)
+
+    def exception(self, msg: str, **kwargs: Any) -> None:
+        """Log an ERROR message with exception info."""
+        extra = {**kwargs}
+        with self._lock:
+            extra.update(self._context)
+        self._logger.exception(msg, extra=extra)
+
+
+def configure_logging(level: int = logging.INFO) -> None:
+    """Configure the root logger with JSON output on stderr.
+
+    Safe to call multiple times — will not add duplicate handlers.
+    """
+    root = logging.getLogger()
+    root.setLevel(level)
+
+    # Avoid adding a second StreamHandler if one already exists.
+    for handler in root.handlers:
+        if isinstance(handler, logging.StreamHandler) and handler.stream is sys.stderr:
+            handler.setLevel(level)
+            return
+
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setLevel(level)
+    handler.setFormatter(JsonFormatter())
+    root.addHandler(handler)
+
+
+def get_logger(*, component: str = "", **context: Any) -> KeystoneLogger:
+    """Return a KeystoneLogger bound to the given component and context.
+
+    Args:
+        component: Appended to the ``keystone.`` logger name prefix.
+        **context: Key-value pairs pre-bound to every log record.
+
+    Returns:
+        A :class:`KeystoneLogger` wrapping ``logging.getLogger(name)``.
+    """
+    name = f"keystone.{component}" if component else "keystone"
+    return KeystoneLogger(logging.getLogger(name), context)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,287 @@
+"""Tests for src/keystone/logging.py."""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+import threading
+from datetime import datetime, timezone
+from io import StringIO
+from unittest.mock import patch
+
+import pytest
+
+from keystone.logging import (
+    JsonFormatter,
+    KeystoneLogger,
+    _BASELINE_ATTRS,
+    _RESERVED_FIELDS,
+    configure_logging,
+    get_logger,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_record(
+    msg: str = "hello",
+    level: int = logging.INFO,
+    name: str = "test",
+    args: tuple = (),
+    **extra: object,
+) -> logging.LogRecord:
+    record = logging.LogRecord(name, level, "", 0, msg, args, None)
+    for key, value in extra.items():
+        setattr(record, key, value)
+    return record
+
+
+def _format(record: logging.LogRecord) -> dict:
+    return json.loads(JsonFormatter().format(record))
+
+
+# ---------------------------------------------------------------------------
+# TestJsonFormatter
+# ---------------------------------------------------------------------------
+
+
+class TestJsonFormatter:
+    def test_output_is_valid_json(self) -> None:
+        raw = JsonFormatter().format(_make_record())
+        assert json.loads(raw) is not None
+
+    def test_required_fields_present(self) -> None:
+        data = _format(_make_record(name="keystone.test"))
+        assert "timestamp" in data
+        assert "level" in data
+        assert "logger" in data
+        assert "message" in data
+
+    def test_logger_name_matches_record(self) -> None:
+        data = _format(_make_record(name="keystone.daemon"))
+        assert data["logger"] == "keystone.daemon"
+
+    def test_level_matches_record(self) -> None:
+        data = _format(_make_record(level=logging.WARNING))
+        assert data["level"] == "WARNING"
+
+    def test_extra_fields_promoted_to_top_level(self) -> None:
+        data = _format(_make_record(team_id="t1", task_id="task-99", agent_id="a3"))
+        assert data["team_id"] == "t1"
+        assert data["task_id"] == "task-99"
+        assert data["agent_id"] == "a3"
+
+    def test_uses_get_message_not_msg(self) -> None:
+        record = _make_record("hello %s", args=("world",))
+        data = _format(record)
+        assert data["message"] == "hello world"
+
+    def test_timestamp_is_iso8601_utc(self) -> None:
+        data = _format(_make_record())
+        ts = datetime.fromisoformat(data["timestamp"])
+        assert ts.tzinfo is not None
+        assert ts.utcoffset().total_seconds() == 0  # type: ignore[union-attr]
+
+    def test_reserved_field_collision_prefixed(self) -> None:
+        data = _format(_make_record(level_custom=5))  # 'level' is reserved
+        # level_custom is NOT reserved, so it appears as-is
+        assert "level_custom" in data
+        # Verify actual collision: inject a field named 'level'
+        record = _make_record()
+        setattr(record, "level", "INJECTED")
+        out = _format(record)
+        assert out.get("ctx_level") == "INJECTED"
+        assert out["level"] != "INJECTED"
+
+    def test_non_serializable_value_uses_str_fallback(self) -> None:
+        class Unserializable:
+            def __repr__(self) -> str:
+                return "<Unserializable>"
+
+        data = _format(_make_record(custom=Unserializable()))
+        assert "custom" in data
+
+    def test_exc_info_adds_exception_field(self) -> None:
+        try:
+            raise ValueError("boom")
+        except ValueError:
+            record = logging.LogRecord("test", logging.ERROR, "", 0, "err", (), sys.exc_info())
+        data = _format(record)
+        assert "exception" in data
+        assert "ValueError" in data["exception"]
+
+
+# ---------------------------------------------------------------------------
+# TestGetLogger
+# ---------------------------------------------------------------------------
+
+
+class TestGetLogger:
+    def test_returns_keystone_logger(self) -> None:
+        lg = get_logger(component="test")
+        assert isinstance(lg, KeystoneLogger)
+
+    def test_component_sets_logger_name(self) -> None:
+        lg = get_logger(component="daemon")
+        assert lg._logger.name == "keystone.daemon"
+
+    def test_no_component_uses_keystone_name(self) -> None:
+        lg = get_logger()
+        assert lg._logger.name == "keystone"
+
+    def test_context_bound_at_construction(self) -> None:
+        records: list[logging.LogRecord] = []
+
+        class CapturingHandler(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                records.append(record)
+
+        handler = CapturingHandler()
+        lg = get_logger(component="ctx_test", team_id="team-42")
+        lg._logger.addHandler(handler)
+        lg._logger.setLevel(logging.DEBUG)
+        lg._logger.propagate = False
+
+        lg.info("event")
+        assert len(records) == 1
+        assert records[0].__dict__.get("team_id") == "team-42"
+
+        # Cleanup
+        lg._logger.removeHandler(handler)
+        lg._logger.propagate = True
+
+
+# ---------------------------------------------------------------------------
+# TestKeystoneLoggerAdapter
+# ---------------------------------------------------------------------------
+
+
+class TestKeystoneLoggerAdapter:
+    def _capturing_logger(self, component: str) -> tuple[KeystoneLogger, list[logging.LogRecord]]:
+        records: list[logging.LogRecord] = []
+
+        class Cap(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                records.append(record)
+
+        cap = Cap()
+        lg = get_logger(component=component)
+        lg._logger.addHandler(cap)
+        lg._logger.setLevel(logging.DEBUG)
+        lg._logger.propagate = False
+        return lg, records
+
+    def test_process_does_not_mutate_caller_extra(self) -> None:
+        lg, records = self._capturing_logger("no_mutate")
+        lg.info("first", foo="bar")
+        lg.info("second", foo="baz")
+        assert records[0].__dict__["foo"] == "bar"
+        assert records[1].__dict__["foo"] == "baz"
+        assert len(records) == 2
+        lg._logger.handlers.clear()
+
+    def test_per_call_extra_merged_with_context(self) -> None:
+        lg = get_logger(component="merge_test", team_id="t1")
+        records: list[logging.LogRecord] = []
+
+        class Cap(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                records.append(record)
+
+        cap = Cap()
+        lg._logger.addHandler(cap)
+        lg._logger.setLevel(logging.DEBUG)
+        lg._logger.propagate = False
+
+        lg.info("event", task_id="task-1")
+        assert records[0].__dict__["team_id"] == "t1"
+        assert records[0].__dict__["task_id"] == "task-1"
+        lg._logger.handlers.clear()
+
+    def test_thread_safe_context_read(self) -> None:
+        lg = get_logger(component="threadsafe", team_id="t1")
+        records: list[logging.LogRecord] = []
+        errors: list[Exception] = []
+        lock = threading.Lock()
+
+        class Cap(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                with lock:
+                    records.append(record)
+
+        cap = Cap()
+        lg._logger.addHandler(cap)
+        lg._logger.setLevel(logging.DEBUG)
+        lg._logger.propagate = False
+
+        def worker() -> None:
+            try:
+                for _ in range(10):
+                    lg.info("ping", task_id="x")
+            except Exception as exc:
+                with lock:
+                    errors.append(exc)
+
+        threads = [threading.Thread(target=worker) for _ in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+        assert len(records) == 50
+        lg._logger.handlers.clear()
+
+
+# ---------------------------------------------------------------------------
+# TestConfigureLogging
+# ---------------------------------------------------------------------------
+
+
+class TestConfigureLogging:
+    def setup_method(self) -> None:
+        # Clear root handlers before each test.
+        root = logging.getLogger()
+        root.handlers = [
+            h
+            for h in root.handlers
+            if not (isinstance(h, logging.StreamHandler) and h.stream is sys.stderr)
+        ]
+
+    def test_no_duplicate_handlers_on_repeated_calls(self) -> None:
+        configure_logging()
+        configure_logging()
+        root = logging.getLogger()
+        stderr_handlers = [
+            h
+            for h in root.handlers
+            if isinstance(h, logging.StreamHandler) and h.stream is sys.stderr
+        ]
+        assert len(stderr_handlers) == 1
+
+    def test_log_level_respected_debug(self) -> None:
+        buf = StringIO()
+        with patch("sys.stderr", buf):
+            configure_logging(level=logging.DEBUG)
+            logging.getLogger("keystone.level_test").debug("dbg_msg")
+        assert "dbg_msg" in buf.getvalue()
+
+    def test_log_level_respected_warning_filters_debug(self) -> None:
+        buf = StringIO()
+        with patch("sys.stderr", buf):
+            configure_logging(level=logging.WARNING)
+            logging.getLogger("keystone.level_test2").debug("should_not_appear")
+        assert "should_not_appear" not in buf.getvalue()
+
+    def test_output_goes_to_stderr(self) -> None:
+        root = logging.getLogger()
+        configure_logging()
+        handler = next(
+            h for h in root.handlers
+            if isinstance(h, logging.StreamHandler) and h.stream is sys.stderr
+        )
+        assert handler.stream is sys.stderr


### PR DESCRIPTION
## Summary

- Implements `src/keystone/logging.py` with `JsonFormatter`, `KeystoneLogger`, `configure_logging`, and `get_logger` using stdlib only (no third-party deps)
- Adds `src/keystone/daemon.py` using the new structured logger with keyword-argument context injection (`team_id`, `task_id`, `agent_id`)
- Each log line is a single JSON object parseable by Argus/Grafana

## Key design decisions

- `JsonFormatter` detects extra fields by diffing `record.__dict__` against a pre-computed `frozenset` of baseline `LogRecord` attributes
- `record.getMessage()` used (not `record.msg`) to resolve `%s`-style lazy args before JSON encoding
- Reserved field collisions prefixed with `ctx_` to avoid schema corruption
- Handler deduplication via `isinstance` check — `configure_logging()` is idempotent
- `KeystoneLogger._log` reads context under `threading.Lock` then spreads into a new dict — never mutates the caller's `extra`
- Timestamps are ISO 8601 UTC via `datetime.now(timezone.utc).isoformat()`

## Test plan

- [x] 21 unit tests in `tests/test_logging.py` — all pass
- [x] `JsonFormatter`: valid JSON, required fields, extra field promotion, `%s` args, UTC ISO 8601, reserved field collision prefix, non-serializable fallback, exc_info
- [x] `get_logger`: name construction, context binding, `KeystoneLogger` type
- [x] `KeystoneLogger`: no dict mutation across calls, per-call extra merge, thread-safety under 5 concurrent threads × 10 calls
- [x] `configure_logging`: idempotent (no duplicate handlers), level filtering, stderr routing
- [x] Smoke test confirms output shape: `{"timestamp": "...", "level": "INFO", "logger": "keystone.daemon", "message": "task_assigned", "team_id": "t1", "task_id": "task-99", "agent_id": "agent-3"}`

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)