### PR TITLE
docs(claude): add Test Structure section to Build System docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,6 +172,18 @@ build/
 └── coverage/     # Debug + Coverage
 ```
 
+### Test Structure
+
+```
+tests/
+├── unit/           # Unit tests per component
+├── integration/    # Cross-component integration tests
+├── e2e/            # End-to-end and distributed tests
+├── load/           # Load and throughput tests
+├── fixtures/       # Shared test fixtures
+└── mocks/          # Mock implementations
+```
+
 ---
 
 ## Quality Tooling


### PR DESCRIPTION
## Summary

- Issue #104 reported that `CLAUDE.md` had a stale `tests/` directory listing that omitted `test_nats_listener.py`. After investigation, the current `CLAUDE.md` had no test directory tree at all (it was rewritten as a pure C++20 transport doc with no Python references).
- Rather than closing as invalid, this PR addresses the spirit of the issue by adding an accurate `### Test Structure` subsection to the Build System section, documenting the six C++ test subdirectories that actually exist: `unit/`, `integration/`, `e2e/`, `load/`, `fixtures/`, and `mocks/`.

## Test plan

- [ ] No code changes — documentation only
- [ ] Verify the tree matches actual `tests/` directory layout (`ls tests/`)
- [ ] Confirm no Python test file references were introduced

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)