### PR TITLE
chore: add .pixi/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,6 +122,9 @@ credentials*
 # CMake user-specific preset overrides (generated, not shared)
 CMakeUserPresets.json
 
+# Pixi
+.pixi/
+
 # Conan package manager cache and generated files
 .conan/
 conan_provider.cmake


### PR DESCRIPTION
## Summary

- Adds `.pixi/` to `.gitignore` to prevent the pixi environment directory (potentially hundreds of MB) from being accidentally committed.
- Consistent with the pattern already in place in ProjectHermes, ProjectTelemachy, and ProjectHephaestus.

## Test plan

- [ ] No code changes — only `.gitignore` updated.
- [ ] Verify `git status` no longer shows `.pixi/` after running `pixi install`.

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)