### PR TITLE
chore: align justfile + pixi.toml with ecosystem conventions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,12 @@ jobs:
       - name: Install build dependencies
         uses: ./.github/actions/install-build-deps
 
+      - name: Install just
+        run: |
+          curl -fsSL https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+
       - name: Check formatting
-        run: make format.check.native
+        run: just format-check
 
       # Note: Full static analysis (clang-tidy, cppcheck) takes 30+ minutes
       # and should be run locally or in a separate weekly workflow.

--- a/pixi.toml
+++ b/pixi.toml
@@ -11,12 +11,15 @@ ninja = ">=1.10"
 cxx-compiler = "*"
 gtest = "*"
 pkg-config = "*"
+just = ">=1.13"
 
 [tasks]
 configure = "cmake -G Ninja -B build-native -S . -DENABLE_GRPC=OFF"
 build = { cmd = "ninja -C build-native", depends-on = ["configure"] }
 test = { cmd = "cd build-native && ctest --output-on-failure", depends-on = ["build"] }
 clean = "rm -rf build-native"
+format = "just format"
+format-check = "just format-check"
 
 [tasks.test-phase1]
 cmd = "build-native/basic_delegation_tests"


### PR DESCRIPTION
## Summary

- Add `just = ">=1.13"` to `pixi.toml` `[dependencies]` so pixi provides `just` in the dev environment
- Add `format` and `format-check` pixi tasks that delegate to the existing justfile recipes
- Update CI format check step to install `just` and call `just format-check` instead of `make format.check.native`

The justfile already existed at the repo root with comprehensive CMake-wrapping recipes (`build`, `build-release`, `test`, `lint`, `format`, `format-check`, `ci`, `clean`, etc.). This PR closes the gaps identified in issue #111: pixi now provides `just` as a managed dependency, pixi tasks delegate to just recipes, and CI uses the justfile as the developer-facing entry point for formatting checks.

## Test plan

- [ ] `just --list` lists all recipes correctly
- [ ] `just format-check` runs clang-format check (requires clang-format installed)
- [ ] CI quality job installs `just` and calls `just format-check`
- [ ] `pixi run format-check` delegates to `just format-check`

Closes #111