### PR TITLE
docs: rewrite CONTRIBUTING.md to match current C++20/Conan/just workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,328 +1,202 @@
 # Contributing to ProjectKeystone
 
-Thank you for contributing to ProjectKeystone! This guide will help you get set up and follow our development practices.
+Thank you for contributing to ProjectKeystone — the invisible transport layer of the
+HomericIntelligence ecosystem. This guide covers everything you need to get started.
 
 ## Prerequisites
 
-Before you start, ensure you have:
+Before you begin, ensure you have:
 
-- **Docker** 20.10+ installed
-- **docker-compose** 1.29+ (recommended)
+- **C++20 compiler** (Clang 17+ or GCC 13+)
+- **CMake** 3.20+
+- **Conan** 2.x (dependency management)
+- **just** (task runner — `cargo install just` or see [just releases](https://github.com/casey/just/releases))
 - **Git** 2.30+
-- **C++20 compiler** (automatically provided in Docker)
-- Basic familiarity with C++20 and CMake
+- **clang-format** and **clang-tidy** (matching the project's `.clang-format` / `.clang-tidy` config)
 
-For detailed technology stack information, see [CLAUDE.md](CLAUDE.md#language-and-technology-stack).
+For the full technology stack, see [CLAUDE.md](CLAUDE.md#language-and-technology-stack).
+
+## Branch Strategy
+
+**Never commit directly to `main`.**
+
+```bash
+# New feature
+git checkout -b feat/short-description
+
+# Bug fix
+git checkout -b fix/issue-description
+
+# Documentation
+git checkout -b docs/description
+
+# Chore / maintenance
+git checkout -b chore/description
+```
+
+Branch names should be lowercase, hyphenated, and describe the change.
 
 ## Development Workflow
 
-We follow a **Test-Driven Development (TDD)** approach:
+ProjectKeystone follows **Test-Driven Development (TDD)**:
 
-1. **Write the test first** (RED phase)
-   - Create E2E tests in `tests/e2e/` or unit tests in appropriate directories
-   - Tests should fail initially
+1. **RED** — write a failing test for the behaviour you're adding
+2. **GREEN** — write the minimum code to make it pass
+3. **REFACTOR** — clean up while keeping tests green
+4. **Commit** using the conventional format below
 
-2. **Implement the minimum code** to make tests pass (GREEN phase)
-   - Add only the code required to pass the tests
-   - No premature optimization or "nice-to-have" features
+## Building the Project
 
-3. **Refactor** while keeping tests green (REFACTOR phase)
-   - Improve code quality, readability, and structure
-   - All tests must continue passing
-
-4. **Commit** when tests pass
-   - Use conventional commit format (see below)
-   - Push to feature branch
-
-For more details, see [CLAUDE.md - Development Workflow](CLAUDE.md#development-workflow).
-
-## C++20 Code Standards
-
-### Core Principles
-
-- **Language**: Exclusively C++20. No Python, Mojo, or other languages
-- **Naming**: `snake_case` for functions/variables, `PascalCase` for types
-- **Memory**: Prefer `std::unique_ptr`, use `std::shared_ptr` only for shared ownership
-- **Async**: Use C++20 coroutines for async operations (no raw threads)
-- **RAII**: Always use Resource Acquisition Is Initialization
-
-### Style Examples
-
-```cpp
-// Functions and variables: snake_case
-void process_message(const KeystoneMessage& msg);
-auto create_agent() -> std::unique_ptr<AgentBase>;
-
-// Types: PascalCase
-class ChiefArchitectAgent;
-struct KeystoneMessage;
-
-// Coroutines for async
-Task<void> handle_message_async(const KeystoneMessage& msg) {
-    co_await delegate_task(msg);
-    co_return;
-}
-
-// Prefer unique_ptr for ownership
-auto agent = std::make_unique<TaskAgent>("task1");
-
-// References for non-owning access
-void update_agent(const AgentBase& agent);
-```
-
-For comprehensive style guidelines, see [CLAUDE.md - Coding Standards](CLAUDE.md#coding-standards).
-
-## Testing Requirements
-
-**All contributions must meet ≥95% code coverage threshold.**
-
-### Running Tests Locally
+Use CMakePresets for all builds:
 
 ```bash
-# Build and run all tests
-docker-compose up test
+# Install dependencies (first time / after conanfile.py changes)
+conan install . --build=missing -pr default
 
-# Run tests with Docker dev environment
-docker-compose up -d dev
-docker-compose exec dev bash
+# Configure and build
+cmake --preset debug
+cmake --build --preset debug
 
-# Inside container:
-cd build
-cmake -G Ninja ..
-ninja
-ctest --output-on-failure
+# Or use the justfile shortcuts
+just build          # debug build
+just build-release  # release build
 ```
 
-### Test Types
-
-1. **Unit Tests** - Test individual components
-   - Location: `tests/unit/`
-   - Framework: Google Test
-   - Example: MessageQueue operations, ThreadPool functionality
-
-2. **E2E Tests** - Test full agent hierarchies
-   - Location: `tests/e2e/`
-   - Framework: Google Test
-   - Example: ChiefArchitect delegating to TaskAgent
-
-3. **Sanitizer Tests** - Catch memory and threading issues
-   - Run with: `docker-compose up test-asan` (AddressSanitizer)
-   - Run with: `docker-compose up test-tsan` (ThreadSanitizer)
-
-### Coverage Check
+## Running Tests
 
 ```bash
-# Generate coverage report
-docker-compose exec dev bash
-cd build
-cmake -G Ninja -DENABLE_COVERAGE=ON ..
-ninja
-ctest
-./scripts/generate_coverage.sh
-# Check report in: build/coverage-report/html/index.html
+just test           # Run all tests (debug build)
+just test-asan      # Run under AddressSanitizer
+just test-tsan      # Run under ThreadSanitizer
 ```
 
-## Commit Message Format
+Tests must pass under **both ASan and TSan** before a PR can be merged.
 
-Follow **Conventional Commits** format:
+To run a specific preset manually:
+
+```bash
+cmake --preset asan && cmake --build --preset asan && ctest --preset asan --output-on-failure
+cmake --preset tsan && cmake --build --preset tsan && ctest --preset tsan --output-on-failure
+```
+
+## Code Standards
+
+### Language
+
+This project is **exclusively C++20**. Do not add Python, Mojo, gRPC, or any other
+language to the implementation.
+
+### Naming Conventions
+
+| Element | Style |
+|---------|-------|
+| Functions / variables | `snake_case` |
+| Types / classes | `PascalCase` |
+| Constants / enums | `kPascalCase` |
+| Private members | `snake_case_` (trailing underscore) |
+
+### Memory Management
+
+- Prefer `std::unique_ptr` for single ownership.
+- Use `std::shared_ptr` only when ownership is genuinely shared.
+- No raw `new` / `delete` — always use RAII wrappers.
+
+### Async
+
+- Use C++20 coroutines for async operations.
+- Prefer `co_await` over raw thread synchronisation primitives.
+
+### Comments
+
+Default to **no comments**. Add one only when the *why* is non-obvious: a hidden
+constraint, a subtle invariant, or a workaround for a specific upstream bug. If
+removing a comment wouldn't confuse a future reader, don't write it.
+
+## Formatting and Linting
+
+All source must pass `clang-format` and `clang-tidy` with zero warnings/errors.
+Both are treated as errors in CI.
+
+```bash
+just format        # Format all source files in-place
+just format-check  # Check formatting without modifying (CI gate)
+just lint          # Run clang-tidy
+```
+
+Fix all formatting and lint issues before pushing. CI will reject PRs with violations.
+
+## Commit Message Format (Conventional Commits)
 
 ```
 <type>(<scope>): <subject>
 
-<body>
+<optional body>
 
-<footer>
+<optional footer>
 ```
 
-### Types
+| Type | When to use |
+|------|-------------|
+| `feat` | New capability |
+| `fix` | Bug fix |
+| `docs` | Documentation only |
+| `test` | Test additions or changes |
+| `refactor` | Internal restructure, no behaviour change |
+| `perf` | Performance improvements |
+| `chore` | Build, deps, CI, tooling |
 
-- `feat` - New feature
-- `fix` - Bug fix
-- `docs` - Documentation only
-- `test` - Test additions or fixes
-- `refactor` - Code refactoring without feature changes
-- `perf` - Performance improvements
-- `chore` - Build, dependencies, or tooling
+Subject line: present tense, ≤72 characters, no trailing period.
 
-### Examples
-
-```
-feat(agents): Add ComponentLeadAgent for Level 1 coordination
-
-Implement ComponentLeadAgent to coordinate multiple ModuleLeadAgents.
-Includes task decomposition and result aggregation across modules.
-
-Closes #123
-```
+**Examples:**
 
 ```
-fix(message-bus): Resolve thread-safety issue in routeMessage()
+feat(bridge): add transparent local-to-NATS promotion
 
-Use mutex lock when accessing agent registry in concurrent scenarios.
-Added test case for concurrent message routing.
+fix(message-bus): resolve data race on shutdown path
 
-Fixes #456
+Fixes #42
 ```
 
-## Pull Request Process
+## Pull Request Checklist
 
-1. **Create a feature branch**
-   ```bash
-   git checkout -b claude/feature-name-<session-id>
-   ```
+Before opening a PR:
 
-2. **Write tests first** (TDD approach)
-   ```bash
-   # Create failing tests
-   git add tests/
-   git commit -m "test: add tests for feature X"
-   ```
+- [ ] On a feature branch (`git branch --show-current`)
+- [ ] All tests pass under ASan: `just test-asan`
+- [ ] All tests pass under TSan: `just test-tsan`
+- [ ] Formatting clean: `just format-check`
+- [ ] clang-tidy clean: `just lint`
+- [ ] No compilation warnings (`-Werror` is enforced)
+- [ ] PR description references the issue (`Closes #N`)
 
-3. **Implement code** to make tests pass
-   ```bash
-   # Implement feature
-   git add src/
-   git commit -m "feat(component): implement feature X"
-   ```
-
-4. **Ensure all quality gates pass** (see below)
-   ```bash
-   docker-compose up test
-   # Verify: all tests pass, no memory leaks, sanitizers clean
-   ```
-
-5. **Push and create PR**
-   ```bash
-   git push origin claude/feature-name-<session-id>
-   gh pr create --issue <issue-number>
-   ```
-
-6. **Verify PR is linked to issue**
-   - Check GitHub issue page - should show PR in Development section
-   - If missing, edit PR description to add "Closes #`issue-number`"
-
-For detailed workflow, see [CLAUDE.md - Git Workflow](CLAUDE.md#git-workflow).
-
-## Quality Gates
-
-ProjectKeystone enforces **5 quality gates** that must pass before merge:
-
-### 1. Code Coverage (≥95%)
-
-**Requirement**: All code must have ≥95% line coverage
-
-```bash
-# Check locally
-docker-compose exec dev bash -c "cd build && ./scripts/generate_coverage.sh"
-```
-
-Tools: `lcov`, `gcov` (requires `-DENABLE_COVERAGE=ON`)
-
-### 2. Static Analysis (Zero Critical Errors)
-
-**Requirement**: No critical issues from static analysis
-
-```bash
-# Run locally
-docker-compose exec dev bash -c "cd build && ./scripts/run_static_analysis.sh"
-```
-
-Tools: `clang-tidy`, `cppcheck`
-
-### 3. Fuzz Testing (1 hour crash-free)
-
-**Requirement**: No crashes in 1 hour of fuzzing
-
-```bash
-# Run locally
-cmake -DENABLE_FUZZING=ON -DCMAKE_CXX_COMPILER=clang++ ..
-ninja
-./fuzz_message_serialization -max_total_time=900
-```
-
-Tools: `libFuzzer` (requires Clang)
-
-### 4. Performance Benchmarks (No >10% regressions)
-
-**Requirement**: No performance regression >10% vs baseline
-
-```bash
-# Run locally (Release build)
-cmake -DCMAKE_BUILD_TYPE=Release ..
-./scripts/run_benchmarks.sh --compare benchmarks/results/baseline.json
-```
-
-Tools: Google Benchmark
-
-### 5. Unit & E2E Tests (All passing)
-
-**Requirement**: All 329+ tests must pass
-
-```bash
-docker-compose up test
-```
-
-For detailed quality gate descriptions, see [docs/CICD_QUALITY_GATES.md](docs/CICD_QUALITY_GATES.md).
-
-## Development Environment
-
-### Using Docker (Recommended)
-
-```bash
-# Start dev environment with mounted source
-docker-compose up -d dev
-
-# Enter container
-docker-compose exec dev bash
-
-# Inside container: build and test
-cd build
-cmake -G Ninja ..
-ninja
-ctest --output-on-failure
-
-# Exit when done
-exit
-docker-compose down
-```
-
-### Project Structure
+## Project Structure
 
 ```
 ProjectKeystone/
-├── CMakeLists.txt           # Build configuration
-├── CLAUDE.md                # Project overview & guidelines
-├── CONTRIBUTING.md          # This file
-├── include/                 # Public headers
-│   ├── agents/              # Agent class definitions
-│   ├── core/                # Message bus, messaging
-│   └── concurrency/         # Thread pool, coroutines
-├── src/                     # Implementation
-├── tests/                   # Test files
-│   ├── unit/                # Unit tests
-│   └── e2e/                 # E2E tests
-└── docs/                    # Documentation & planning
-    ├── plan/                # Architecture decisions (ADRs)
-    └── CICD_QUALITY_GATES.md
+├── CMakeLists.txt        # Root build configuration
+├── CMakePresets.json     # Preset-based build config (v8 schema)
+├── conanfile.py          # Conan 2 dependency manifest
+├── justfile              # Common task shortcuts
+├── include/              # Public headers
+│   └── keystone/         # Transport primitives
+├── src/                  # Implementation
+├── tests/                # GoogleTest unit and integration tests
+│   ├── unit/
+│   └── integration/
+├── benchmarks/           # Google Benchmark suites
+├── docs/                 # Architecture docs and ADRs
+│   └── plan/adr/
+└── CLAUDE.md             # Full project guidelines
 ```
 
 ## Getting Help
 
-- **Project Overview**: See [CLAUDE.md](CLAUDE.md)
-- **Development Details**: See [docs/plan/](docs/plan/)
-- **Architecture Decisions**: See [docs/plan/adr/](docs/plan/adr/)
-- **Quality Standards**: See [docs/CICD_QUALITY_GATES.md](docs/CICD_QUALITY_GATES.md)
-
-## Key Resources
-
-1. **CLAUDE.md** - Complete project overview, architecture, and development workflow
-2. **Testing Strategy** - [docs/plan/testing-strategy.md](docs/plan/testing-strategy.md)
-3. **Architecture Decisions**:
-   - [ADR-001: MessageBus Architecture](docs/plan/adr/ADR-001-message-bus-architecture.md)
-   - [ADR-002: Shared Pointer Migration](docs/plan/adr/ADR-002-shared-ptr-migration.md)
-   - [ADR-003: Async Agent Unification](docs/plan/adr/ADR-003-async-agent-unification.md)
-4. **TDD Roadmap** - [docs/plan/TDD_FOUR_LAYER_ROADMAP.md](docs/plan/TDD_FOUR_LAYER_ROADMAP.md)
+- **Project overview and architecture**: [CLAUDE.md](CLAUDE.md)
+- **Architecture Decision Records**: [docs/plan/adr/](docs/plan/adr/)
+- **Quality gate details**: [docs/CICD_QUALITY_GATES.md](docs/CICD_QUALITY_GATES.md)
+- **CI workflow documentation**: [.github/workflows/README.md](.github/workflows/README.md)
 
 ---
 
-**Questions?** Check [CLAUDE.md](CLAUDE.md) for comprehensive project guidelines and development practices.
+**Questions or concerns?** Open a GitHub Discussion or check [CLAUDE.md](CLAUDE.md) for
+comprehensive project guidelines.


### PR DESCRIPTION
## Summary

- Removes stale Docker-centric setup instructions and HMAS agent references (ChiefArchitectAgent, ComponentLeadAgent, etc.) that were moved to ProjectAgamemnon per ADR-006
- Replaces with accurate prerequisites matching the current stack: Conan 2, `just`, CMakePresets.json, clang-format/tidy
- Adds clear branch strategy, build/test commands, coding standards table, and a PR checklist aligned with CLAUDE.md
- Removes Python/Mojo mentions — this is a pure C++20 project

## Test plan

- [ ] File renders correctly on GitHub
- [ ] All commands in the document are verified against `justfile` and `CMakePresets.json`
- [ ] No references to removed HMAS components remain

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)