### PR TITLE
docs(security): add credit policy for responsible disclosers

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,6 +36,12 @@ The following are in scope:
 - CI/CD pipeline configurations
 - Kubernetes deployment manifests
 
+### Credit policy
+
+Researchers who responsibly disclose security vulnerabilities will be credited in the
+release notes and/or security advisory for the fix, unless they prefer to remain
+anonymous. Please indicate your preference when reporting.
+
 ### Security measures in place
 
 - Static analysis: Semgrep, CodeQL, cppcheck


### PR DESCRIPTION
## Summary

- `SECURITY.md` already existed on `main` (added 2026-03-28 in `6fbb180`) with reporting channel, response timeline, and scope
- This PR adds the missing **credit policy** section documenting that responsible disclosers will be credited in release notes/security advisories unless they prefer anonymity

## Changes

- `SECURITY.md`: Added `### Credit policy` section between the scope and security-measures sections

## Test plan

- [ ] Verify `SECURITY.md` renders correctly on GitHub
- [ ] Confirm all four required disclosure policy elements are present: reporting channel, response timeline, scope, credit policy

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)