### PR TITLE
feat(transport): add NATS TLS configuration for secure connections

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,19 @@ GIT_COMMIT=dev
 # These should match your host user to avoid permission issues
 BUILD_UID=1000
 BUILD_GID=1000
+
+# NATS TLS configuration (issue #122)
+# Enable TLS in code via NatsTlsConfig::enable_tls; these env vars override
+# the corresponding config struct fields at runtime.
+#
+# KEYSTONE_NATS_TLS_CA_PATH     — PEM CA certificate to verify the NATS server.
+#                                  Leave unset to use the system CA bundle.
+# KEYSTONE_NATS_TLS_CERT_PATH   — PEM client certificate for mutual TLS.
+# KEYSTONE_NATS_TLS_KEY_PATH    — PEM private key for mutual TLS.
+#
+# Production deployments on the Tailscale mesh should set enable_tls=true and
+# point KEYSTONE_NATS_TLS_CA_PATH at the internal CA certificate.
+#
+# KEYSTONE_NATS_TLS_CA_PATH=/etc/keystone/tls/ca.pem
+# KEYSTONE_NATS_TLS_CERT_PATH=/etc/keystone/tls/client.pem
+# KEYSTONE_NATS_TLS_KEY_PATH=/etc/keystone/tls/client.key

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,9 +147,11 @@ FetchContent_Declare(
 set(NATS_BUILD_STREAMING OFF CACHE BOOL "" FORCE)
 set(NATS_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
 set(NATS_BUILD_TESTS OFF CACHE BOOL "" FORCE)
-# natsc unconditionally adds test/check_cpp which has unused-param warnings.
-# Temporarily clear add_compile_options before populating so our -Werror
-# does not propagate into natsc's own subdirectories.
+# natsc's test/ and test/check_cpp/ check BUILD_TESTING; turn it off so
+# natsc's own tests (which require a live NATS server) are not compiled or
+# registered with ctest. Also clear COMPILE_OPTIONS so our -Werror does not
+# propagate into any natsc subdirectory that ignores BUILD_TESTING.
+set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
 get_directory_property(_saved_compile_options COMPILE_OPTIONS)
 set_directory_properties(PROPERTIES COMPILE_OPTIONS "")
 FetchContent_MakeAvailable(natsc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,18 @@ FetchContent_Declare(
   GIT_TAG v0.14)
 FetchContent_MakeAvailable(cista)
 
+# nats.c — NATS client library with TLS support (issue #122)
+# NOT on ConanCenter; pulled directly from upstream.
+FetchContent_Declare(
+  natsc
+  GIT_REPOSITORY https://github.com/nats-io/nats.c.git
+  GIT_TAG v3.12.0
+  GIT_SHALLOW TRUE)
+set(NATS_BUILD_STREAMING OFF CACHE BOOL "" FORCE)
+set(NATS_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+set(NATS_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(natsc)
+
 # yaml-cpp — YAML parser for task specifications (Phase 8 only)
 if(ENABLE_GRPC)
   find_package(yaml-cpp REQUIRED)
@@ -501,6 +513,25 @@ target_link_libraries(simulation_unit_tests keystone_simulation
 
 gtest_discover_tests(simulation_unit_tests)
 
+# Transport library — NATS connection with TLS support (issue #122)
+add_library(keystone_transport src/transport/nats_connection.cpp)
+
+target_include_directories(
+  keystone_transport
+  PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include/keystone>
+)
+
+target_link_libraries(keystone_transport PUBLIC nats spdlog::spdlog)
+
+# Unit Tests — NATS transport (issue #122)
+add_executable(transport_unit_tests tests/unit/test_nats_connection.cpp)
+
+target_link_libraries(transport_unit_tests keystone_transport GTest::gtest_main)
+
+gtest_discover_tests(transport_unit_tests)
+
 # Integration Tests (Phase C3: Registry integration tests)
 # DISABLED: keystone_agents moved to ProjectAgamemnon (ADR-006)
 # add_executable(registry_integration_tests tests/integration/test_registry_integration.cpp)
@@ -530,6 +561,7 @@ add_custom_target(
           unit_tests
           concurrency_unit_tests
           simulation_unit_tests
+          transport_unit_tests
           # DISABLED: registry_integration_tests (ADR-006)
           # DISABLED: nats_integration_tests (ADR-006, uses task_agent.hpp)
   COMMENT "Running all ProjectKeystone tests with failure output")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,7 +147,13 @@ FetchContent_Declare(
 set(NATS_BUILD_STREAMING OFF CACHE BOOL "" FORCE)
 set(NATS_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
 set(NATS_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+# natsc unconditionally adds test/check_cpp which has unused-param warnings.
+# Temporarily clear add_compile_options before populating so our -Werror
+# does not propagate into natsc's own subdirectories.
+get_directory_property(_saved_compile_options COMPILE_OPTIONS)
+set_directory_properties(PROPERTIES COMPILE_OPTIONS "")
 FetchContent_MakeAvailable(natsc)
+set_directory_properties(PROPERTIES COMPILE_OPTIONS "${_saved_compile_options}")
 
 # yaml-cpp — YAML parser for task specifications (Phase 8 only)
 if(ENABLE_GRPC)

--- a/include/transport/nats_connection.hpp
+++ b/include/transport/nats_connection.hpp
@@ -12,14 +12,14 @@
 
 #pragma once
 
-#include <nats.h>
-
 #include <atomic>
 #include <chrono>
 #include <cstdint>
 #include <functional>
 #include <mutex>
 #include <string>
+
+#include <nats.h>
 
 namespace keystone {
 namespace transport {
@@ -181,7 +181,9 @@ class NatsConnection {
   // nats.c static callback shims — nats.c passes a void* user data pointer
   // which we cast back to NatsConnection*. Protected to allow test subclasses
   // to invoke them directly without a live nats.c connection.
-  static void onError(natsConnection* nc, natsSubscription* sub, natsStatus err,
+  static void onError(natsConnection* nc,
+                      natsSubscription* sub,
+                      natsStatus err,
                       void* closure) noexcept;
   static void onDisconnected(natsConnection* nc, void* closure) noexcept;
   static void onReconnected(natsConnection* nc, void* closure) noexcept;

--- a/include/transport/nats_connection.hpp
+++ b/include/transport/nats_connection.hpp
@@ -1,0 +1,215 @@
+/**
+ * @file nats_connection.hpp
+ * @brief NATS connection wrapper with TLS, reconnection callbacks, and error handling
+ *
+ * Wraps nats.c to provide:
+ * - Optional TLS with CA certificate, client certificate, and hostname verification
+ * - Configurable reconnection (max attempts, wait interval)
+ * - Error, disconnected, reconnected, and closed callbacks
+ * - Observable connection state for health checks
+ * - Graceful shutdown without crashing the daemon
+ */
+
+#pragma once
+
+#include <nats.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <mutex>
+#include <string>
+
+namespace keystone {
+namespace transport {
+
+/**
+ * @brief NATS connection state observable by health checks
+ */
+enum class NatsConnectionState {
+  DISCONNECTED,  ///< Not connected (initial / after close)
+  CONNECTED,     ///< Active connection established
+  RECONNECTING,  ///< Temporarily disconnected, attempting reconnect
+  CLOSED,        ///< Connection permanently closed
+};
+
+/**
+ * @brief TLS configuration for NatsConnection
+ *
+ * When enable_tls is true, the connection uses TLS. The ca_cert_path,
+ * client_cert_path, and client_key_path fields are optional and override
+ * the corresponding KEYSTONE_NATS_TLS_CA_PATH, KEYSTONE_NATS_TLS_CERT_PATH,
+ * and KEYSTONE_NATS_TLS_KEY_PATH environment variables respectively.
+ *
+ * skip_server_verification disables hostname and certificate chain validation
+ * and must only be used in controlled test environments.
+ */
+struct NatsTlsConfig {
+  bool enable_tls{false};
+
+  /// Path to PEM CA certificate file. Empty = use system CAs.
+  /// Overridden by env var KEYSTONE_NATS_TLS_CA_PATH if that is set.
+  std::string ca_cert_path;
+
+  /// Path to PEM client certificate file (mutual TLS). Empty = no client cert.
+  /// Overridden by env var KEYSTONE_NATS_TLS_CERT_PATH if that is set.
+  std::string client_cert_path;
+
+  /// Path to PEM client private key file (mutual TLS). Empty = no client key.
+  /// Overridden by env var KEYSTONE_NATS_TLS_KEY_PATH if that is set.
+  std::string client_key_path;
+
+  /// Disable server certificate/hostname verification. TEST USE ONLY.
+  bool skip_server_verification{false};
+};
+
+/**
+ * @brief Configuration for NatsConnection
+ */
+struct NatsConfig {
+  std::string url{"nats://localhost:4222"};
+
+  /// Maximum reconnect attempts before giving up (-1 = unlimited)
+  int max_reconnect_attempts{60};
+
+  /// Wait between reconnect attempts
+  std::chrono::milliseconds reconnect_wait{std::chrono::milliseconds{2000}};
+
+  /// Ping interval for keep-alive detection
+  std::chrono::milliseconds ping_interval{std::chrono::milliseconds{20000}};
+
+  /// How many pings may go unacknowledged before the connection is declared dead
+  int max_pings_out{2};
+
+  /// TLS configuration (disabled by default)
+  NatsTlsConfig tls;
+};
+
+/**
+ * @brief Callback types for connection lifecycle events
+ */
+using ErrorCallback = std::function<void(const std::string& error_text)>;
+using DisconnectedCallback = std::function<void()>;
+using ReconnectedCallback = std::function<void()>;
+using ClosedCallback = std::function<void()>;
+
+/**
+ * @brief NATS connection wrapper with TLS, reconnection, and error-handling support
+ *
+ * Owns a natsConnection* and configures it with optional TLS and the four
+ * lifecycle callbacks required for production resilience. The connection state
+ * is tracked atomically so health-check threads can observe it without taking
+ * a lock.
+ *
+ * TLS behaviour:
+ * - When NatsTlsConfig::enable_tls is false, the connection is plaintext.
+ * - When true, natsOptions_SetSecure is called. If ca_cert_path is provided
+ *   (or KEYSTONE_NATS_TLS_CA_PATH is set), that CA is loaded; otherwise the
+ *   nats.c default (system CAs) is used. Client certificates are loaded when
+ *   both client_cert_path and client_key_path are non-empty.
+ *
+ * Thread-safety:
+ * - connect() / disconnect() must be called from a single owner thread.
+ * - All callbacks are invoked on nats.c internal threads; they must not
+ *   block or call back into NatsConnection.
+ * - getState() / isConnected() are lock-free and safe from any thread.
+ *
+ * Example (TLS with CA cert from environment):
+ * @code
+ * NatsConfig cfg;
+ * cfg.url = "tls://nats.example.com:4222";
+ * cfg.tls.enable_tls = true;  // reads KEYSTONE_NATS_TLS_CA_PATH from env
+ * NatsConnection conn(cfg);
+ * conn.connect();
+ * @endcode
+ */
+class NatsConnection {
+ public:
+  explicit NatsConnection(NatsConfig config = {});
+  ~NatsConnection();
+
+  // Non-copyable, non-movable (owns raw nats.c handle)
+  NatsConnection(const NatsConnection&) = delete;
+  NatsConnection& operator=(const NatsConnection&) = delete;
+  NatsConnection(NatsConnection&&) = delete;
+  NatsConnection& operator=(NatsConnection&&) = delete;
+
+  // =========================================================================
+  // Callback registration — must be called before connect()
+  // =========================================================================
+
+  void setErrorCallback(ErrorCallback cb);
+  void setDisconnectedCallback(DisconnectedCallback cb);
+  void setReconnectedCallback(ReconnectedCallback cb);
+  void setClosedCallback(ClosedCallback cb);
+
+  // =========================================================================
+  // Connection lifecycle
+  // =========================================================================
+
+  /**
+   * @brief Establish connection to NATS server
+   * @return true on success, false if nats.c reports an error
+   */
+  bool connect();
+
+  /**
+   * @brief Close connection and release nats.c resources
+   *
+   * Safe to call even if connect() was never called or already disconnected.
+   */
+  void disconnect();
+
+  // =========================================================================
+  // State inspection (lock-free, any thread)
+  // =========================================================================
+
+  NatsConnectionState getState() const noexcept;
+  bool isConnected() const noexcept;
+
+  /**
+   * @brief Return the raw nats.c connection handle
+   *
+   * The caller must NOT close or destroy the returned pointer. Only use it
+   * to publish messages or subscribe. The handle is valid until disconnect()
+   * is called.
+   */
+  natsConnection* handle() const noexcept;
+
+ protected:
+  // nats.c static callback shims — nats.c passes a void* user data pointer
+  // which we cast back to NatsConnection*. Protected to allow test subclasses
+  // to invoke them directly without a live nats.c connection.
+  static void onError(natsConnection* nc, natsSubscription* sub, natsStatus err,
+                      void* closure) noexcept;
+  static void onDisconnected(natsConnection* nc, void* closure) noexcept;
+  static void onReconnected(natsConnection* nc, void* closure) noexcept;
+  static void onClosed(natsConnection* nc, void* closure) noexcept;
+
+ private:
+  /**
+   * @brief Apply TLS options to natsOptions
+   * @return true on success, false on any nats.c error
+   */
+  bool applyTlsOptions(natsOptions* opts) const;
+
+  NatsConfig config_;
+
+  // Callbacks (protected by callbacks_mutex_ during registration only;
+  // nats.c callbacks fire after connect() so no concurrent write is possible)
+  mutable std::mutex callbacks_mutex_;
+  ErrorCallback error_cb_;
+  DisconnectedCallback disconnected_cb_;
+  ReconnectedCallback reconnected_cb_;
+  ClosedCallback closed_cb_;
+
+  // Raw handle — owned by this object
+  natsConnection* conn_{nullptr};
+
+  // Observable state (atomic for lock-free health checks)
+  std::atomic<NatsConnectionState> state_{NatsConnectionState::DISCONNECTED};
+};
+
+}  // namespace transport
+}  // namespace keystone

--- a/src/transport/nats_connection.cpp
+++ b/src/transport/nats_connection.cpp
@@ -6,11 +6,10 @@
 #include "transport/nats_connection.hpp"
 
 #include <nats.h>
+#include <spdlog/spdlog.h>
 
 #include <cstdlib>
 #include <string>
-
-#include <spdlog/spdlog.h>
 
 namespace keystone {
 namespace transport {
@@ -28,7 +27,8 @@ std::string getEnvVar(const char* name) {
 // Construction / destruction
 // ---------------------------------------------------------------------------
 
-NatsConnection::NatsConnection(NatsConfig config) : config_(std::move(config)) {}
+NatsConnection::NatsConnection(NatsConfig config)
+    : config_(std::move(config)) {}
 
 NatsConnection::~NatsConnection() { disconnect(); }
 
@@ -85,13 +85,16 @@ bool NatsConnection::applyTlsOptions(natsOptions* opts) const {
     ca_path = tls.ca_cert_path;
   }
   if (!ca_path.empty()) {
-    if (natsOptions_LoadCATrustedCertificates(opts, ca_path.c_str()) != NATS_OK) {
-      spdlog::error("NatsConnection: failed to load CA certificate from {}", ca_path);
+    if (natsOptions_LoadCATrustedCertificates(opts, ca_path.c_str()) !=
+        NATS_OK) {
+      spdlog::error("NatsConnection: failed to load CA certificate from {}",
+                    ca_path);
       return false;
     }
   }
 
-  // Client certificate (mutual TLS): env vars take precedence over config fields
+  // Client certificate (mutual TLS): env vars take precedence over config
+  // fields
   std::string cert_path = getEnvVar("KEYSTONE_NATS_TLS_CERT_PATH");
   std::string key_path = getEnvVar("KEYSTONE_NATS_TLS_KEY_PATH");
   if (cert_path.empty()) {
@@ -102,15 +105,18 @@ bool NatsConnection::applyTlsOptions(natsOptions* opts) const {
   }
 
   if (!cert_path.empty() && !key_path.empty()) {
-    if (natsOptions_LoadCertificatesChain(opts, cert_path.c_str(), key_path.c_str()) != NATS_OK) {
-      spdlog::error("NatsConnection: failed to load client certificate from {} / {}",
-                    cert_path, key_path);
+    if (natsOptions_LoadCertificatesChain(opts, cert_path.c_str(),
+                                          key_path.c_str()) != NATS_OK) {
+      spdlog::error(
+          "NatsConnection: failed to load client certificate from {} / {}",
+          cert_path, key_path);
       return false;
     }
   } else if (!cert_path.empty() || !key_path.empty()) {
     // Exactly one of cert/key was provided — this is always a misconfiguration
     spdlog::error(
-        "NatsConnection: TLS client certificate requires both cert and key paths; "
+        "NatsConnection: TLS client certificate requires both cert and key "
+        "paths; "
         "cert_path='{}' key_path='{}'",
         cert_path, key_path);
     return false;
@@ -144,7 +150,8 @@ bool NatsConnection::connect() {
   }
 
   // Reconnection policy
-  if (natsOptions_SetMaxReconnect(opts, config_.max_reconnect_attempts) != NATS_OK) {
+  if (natsOptions_SetMaxReconnect(opts, config_.max_reconnect_attempts) !=
+      NATS_OK) {
     return false;
   }
 
@@ -168,16 +175,20 @@ bool NatsConnection::connect() {
   }
 
   // Lifecycle callbacks — pass `this` as closure so static shims can dispatch
-  if (natsOptions_SetErrorHandler(opts, NatsConnection::onError, this) != NATS_OK) {
+  if (natsOptions_SetErrorHandler(opts, NatsConnection::onError, this) !=
+      NATS_OK) {
     return false;
   }
-  if (natsOptions_SetDisconnectedCB(opts, NatsConnection::onDisconnected, this) != NATS_OK) {
+  if (natsOptions_SetDisconnectedCB(opts, NatsConnection::onDisconnected,
+                                    this) != NATS_OK) {
     return false;
   }
-  if (natsOptions_SetReconnectedCB(opts, NatsConnection::onReconnected, this) != NATS_OK) {
+  if (natsOptions_SetReconnectedCB(opts, NatsConnection::onReconnected, this) !=
+      NATS_OK) {
     return false;
   }
-  if (natsOptions_SetClosedCB(opts, NatsConnection::onClosed, this) != NATS_OK) {
+  if (natsOptions_SetClosedCB(opts, NatsConnection::onClosed, this) !=
+      NATS_OK) {
     return false;
   }
 
@@ -233,9 +244,11 @@ void NatsConnection::onError(natsConnection* /*nc*/, natsSubscription* /*sub*/,
   }
 }
 
-void NatsConnection::onDisconnected(natsConnection* /*nc*/, void* closure) noexcept {
+void NatsConnection::onDisconnected(natsConnection* /*nc*/,
+                                    void* closure) noexcept {
   auto* self = static_cast<NatsConnection*>(closure);
-  self->state_.store(NatsConnectionState::RECONNECTING, std::memory_order_release);
+  self->state_.store(NatsConnectionState::RECONNECTING,
+                     std::memory_order_release);
   DisconnectedCallback cb;
   {
     std::lock_guard<std::mutex> lock(self->callbacks_mutex_);
@@ -246,7 +259,8 @@ void NatsConnection::onDisconnected(natsConnection* /*nc*/, void* closure) noexc
   }
 }
 
-void NatsConnection::onReconnected(natsConnection* /*nc*/, void* closure) noexcept {
+void NatsConnection::onReconnected(natsConnection* /*nc*/,
+                                   void* closure) noexcept {
   auto* self = static_cast<NatsConnection*>(closure);
   self->state_.store(NatsConnectionState::CONNECTED, std::memory_order_release);
   ReconnectedCallback cb;

--- a/src/transport/nats_connection.cpp
+++ b/src/transport/nats_connection.cpp
@@ -5,11 +5,11 @@
 
 #include "transport/nats_connection.hpp"
 
-#include <nats.h>
-#include <spdlog/spdlog.h>
-
 #include <cstdlib>
 #include <string>
+
+#include <nats.h>
+#include <spdlog/spdlog.h>
 
 namespace keystone {
 namespace transport {
@@ -27,10 +27,11 @@ std::string getEnvVar(const char* name) {
 // Construction / destruction
 // ---------------------------------------------------------------------------
 
-NatsConnection::NatsConnection(NatsConfig config)
-    : config_(std::move(config)) {}
+NatsConnection::NatsConnection(NatsConfig config) : config_(std::move(config)) {}
 
-NatsConnection::~NatsConnection() { disconnect(); }
+NatsConnection::~NatsConnection() {
+  disconnect();
+}
 
 // ---------------------------------------------------------------------------
 // Callback registration
@@ -85,10 +86,8 @@ bool NatsConnection::applyTlsOptions(natsOptions* opts) const {
     ca_path = tls.ca_cert_path;
   }
   if (!ca_path.empty()) {
-    if (natsOptions_LoadCATrustedCertificates(opts, ca_path.c_str()) !=
-        NATS_OK) {
-      spdlog::error("NatsConnection: failed to load CA certificate from {}",
-                    ca_path);
+    if (natsOptions_LoadCATrustedCertificates(opts, ca_path.c_str()) != NATS_OK) {
+      spdlog::error("NatsConnection: failed to load CA certificate from {}", ca_path);
       return false;
     }
   }
@@ -105,11 +104,10 @@ bool NatsConnection::applyTlsOptions(natsOptions* opts) const {
   }
 
   if (!cert_path.empty() && !key_path.empty()) {
-    if (natsOptions_LoadCertificatesChain(opts, cert_path.c_str(),
-                                          key_path.c_str()) != NATS_OK) {
-      spdlog::error(
-          "NatsConnection: failed to load client certificate from {} / {}",
-          cert_path, key_path);
+    if (natsOptions_LoadCertificatesChain(opts, cert_path.c_str(), key_path.c_str()) != NATS_OK) {
+      spdlog::error("NatsConnection: failed to load client certificate from {} / {}",
+                    cert_path,
+                    key_path);
       return false;
     }
   } else if (!cert_path.empty() || !key_path.empty()) {
@@ -118,7 +116,8 @@ bool NatsConnection::applyTlsOptions(natsOptions* opts) const {
         "NatsConnection: TLS client certificate requires both cert and key "
         "paths; "
         "cert_path='{}' key_path='{}'",
-        cert_path, key_path);
+        cert_path,
+        key_path);
     return false;
   }
 
@@ -150,8 +149,7 @@ bool NatsConnection::connect() {
   }
 
   // Reconnection policy
-  if (natsOptions_SetMaxReconnect(opts, config_.max_reconnect_attempts) !=
-      NATS_OK) {
+  if (natsOptions_SetMaxReconnect(opts, config_.max_reconnect_attempts) != NATS_OK) {
     return false;
   }
 
@@ -175,20 +173,16 @@ bool NatsConnection::connect() {
   }
 
   // Lifecycle callbacks — pass `this` as closure so static shims can dispatch
-  if (natsOptions_SetErrorHandler(opts, NatsConnection::onError, this) !=
-      NATS_OK) {
+  if (natsOptions_SetErrorHandler(opts, NatsConnection::onError, this) != NATS_OK) {
     return false;
   }
-  if (natsOptions_SetDisconnectedCB(opts, NatsConnection::onDisconnected,
-                                    this) != NATS_OK) {
+  if (natsOptions_SetDisconnectedCB(opts, NatsConnection::onDisconnected, this) != NATS_OK) {
     return false;
   }
-  if (natsOptions_SetReconnectedCB(opts, NatsConnection::onReconnected, this) !=
-      NATS_OK) {
+  if (natsOptions_SetReconnectedCB(opts, NatsConnection::onReconnected, this) != NATS_OK) {
     return false;
   }
-  if (natsOptions_SetClosedCB(opts, NatsConnection::onClosed, this) !=
-      NATS_OK) {
+  if (natsOptions_SetClosedCB(opts, NatsConnection::onClosed, this) != NATS_OK) {
     return false;
   }
 
@@ -223,15 +217,19 @@ bool NatsConnection::isConnected() const noexcept {
   return getState() == NatsConnectionState::CONNECTED;
 }
 
-natsConnection* NatsConnection::handle() const noexcept { return conn_; }
+natsConnection* NatsConnection::handle() const noexcept {
+  return conn_;
+}
 
 // ---------------------------------------------------------------------------
 // Static callback shims
 // ---------------------------------------------------------------------------
 
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
-void NatsConnection::onError(natsConnection* /*nc*/, natsSubscription* /*sub*/,
-                             natsStatus err, void* closure) noexcept {
+void NatsConnection::onError(natsConnection* /*nc*/,
+                             natsSubscription* /*sub*/,
+                             natsStatus err,
+                             void* closure) noexcept {
   auto* self = static_cast<NatsConnection*>(closure);
   ErrorCallback cb;
   {
@@ -244,11 +242,9 @@ void NatsConnection::onError(natsConnection* /*nc*/, natsSubscription* /*sub*/,
   }
 }
 
-void NatsConnection::onDisconnected(natsConnection* /*nc*/,
-                                    void* closure) noexcept {
+void NatsConnection::onDisconnected(natsConnection* /*nc*/, void* closure) noexcept {
   auto* self = static_cast<NatsConnection*>(closure);
-  self->state_.store(NatsConnectionState::RECONNECTING,
-                     std::memory_order_release);
+  self->state_.store(NatsConnectionState::RECONNECTING, std::memory_order_release);
   DisconnectedCallback cb;
   {
     std::lock_guard<std::mutex> lock(self->callbacks_mutex_);
@@ -259,8 +255,7 @@ void NatsConnection::onDisconnected(natsConnection* /*nc*/,
   }
 }
 
-void NatsConnection::onReconnected(natsConnection* /*nc*/,
-                                   void* closure) noexcept {
+void NatsConnection::onReconnected(natsConnection* /*nc*/, void* closure) noexcept {
   auto* self = static_cast<NatsConnection*>(closure);
   self->state_.store(NatsConnectionState::CONNECTED, std::memory_order_release);
   ReconnectedCallback cb;

--- a/src/transport/nats_connection.cpp
+++ b/src/transport/nats_connection.cpp
@@ -1,0 +1,276 @@
+/**
+ * @file nats_connection.cpp
+ * @brief NATS connection wrapper implementation with TLS support
+ */
+
+#include "transport/nats_connection.hpp"
+
+#include <nats.h>
+
+#include <cstdlib>
+#include <string>
+
+#include <spdlog/spdlog.h>
+
+namespace keystone {
+namespace transport {
+
+namespace {
+
+std::string getEnvVar(const char* name) {
+  const char* value = std::getenv(name);  // NOLINT(concurrency-mt-unsafe)
+  return value != nullptr ? std::string(value) : std::string{};
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Construction / destruction
+// ---------------------------------------------------------------------------
+
+NatsConnection::NatsConnection(NatsConfig config) : config_(std::move(config)) {}
+
+NatsConnection::~NatsConnection() { disconnect(); }
+
+// ---------------------------------------------------------------------------
+// Callback registration
+// ---------------------------------------------------------------------------
+
+void NatsConnection::setErrorCallback(ErrorCallback cb) {
+  std::lock_guard<std::mutex> lock(callbacks_mutex_);
+  error_cb_ = std::move(cb);
+}
+
+void NatsConnection::setDisconnectedCallback(DisconnectedCallback cb) {
+  std::lock_guard<std::mutex> lock(callbacks_mutex_);
+  disconnected_cb_ = std::move(cb);
+}
+
+void NatsConnection::setReconnectedCallback(ReconnectedCallback cb) {
+  std::lock_guard<std::mutex> lock(callbacks_mutex_);
+  reconnected_cb_ = std::move(cb);
+}
+
+void NatsConnection::setClosedCallback(ClosedCallback cb) {
+  std::lock_guard<std::mutex> lock(callbacks_mutex_);
+  closed_cb_ = std::move(cb);
+}
+
+// ---------------------------------------------------------------------------
+// TLS configuration
+// ---------------------------------------------------------------------------
+
+bool NatsConnection::applyTlsOptions(natsOptions* opts) const {
+  const NatsTlsConfig& tls = config_.tls;
+
+  if (!tls.enable_tls) {
+    return true;
+  }
+
+  if (natsOptions_SetSecure(opts, true) != NATS_OK) {
+    spdlog::error("NatsConnection: failed to enable TLS on natsOptions");
+    return false;
+  }
+
+  if (tls.skip_server_verification) {
+    if (natsOptions_SkipServerVerification(opts, true) != NATS_OK) {
+      spdlog::error("NatsConnection: failed to set skip_server_verification");
+      return false;
+    }
+  }
+
+  // CA certificate: env var takes precedence over config field
+  std::string ca_path = getEnvVar("KEYSTONE_NATS_TLS_CA_PATH");
+  if (ca_path.empty()) {
+    ca_path = tls.ca_cert_path;
+  }
+  if (!ca_path.empty()) {
+    if (natsOptions_LoadCATrustedCertificates(opts, ca_path.c_str()) != NATS_OK) {
+      spdlog::error("NatsConnection: failed to load CA certificate from {}", ca_path);
+      return false;
+    }
+  }
+
+  // Client certificate (mutual TLS): env vars take precedence over config fields
+  std::string cert_path = getEnvVar("KEYSTONE_NATS_TLS_CERT_PATH");
+  std::string key_path = getEnvVar("KEYSTONE_NATS_TLS_KEY_PATH");
+  if (cert_path.empty()) {
+    cert_path = tls.client_cert_path;
+  }
+  if (key_path.empty()) {
+    key_path = tls.client_key_path;
+  }
+
+  if (!cert_path.empty() && !key_path.empty()) {
+    if (natsOptions_LoadCertificatesChain(opts, cert_path.c_str(), key_path.c_str()) != NATS_OK) {
+      spdlog::error("NatsConnection: failed to load client certificate from {} / {}",
+                    cert_path, key_path);
+      return false;
+    }
+  } else if (!cert_path.empty() || !key_path.empty()) {
+    // Exactly one of cert/key was provided — this is always a misconfiguration
+    spdlog::error(
+        "NatsConnection: TLS client certificate requires both cert and key paths; "
+        "cert_path='{}' key_path='{}'",
+        cert_path, key_path);
+    return false;
+  }
+
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Connection lifecycle
+// ---------------------------------------------------------------------------
+
+bool NatsConnection::connect() {
+  natsOptions* opts = nullptr;
+
+  if (natsOptions_Create(&opts) != NATS_OK) {
+    return false;
+  }
+
+  // RAII guard: always destroy opts on exit from this function, whether we
+  // succeed or fail. natsConnection_Connect() internally reference-counts
+  // the options, so destroying them here is safe.
+  struct OptsGuard {
+    natsOptions* ptr;
+    ~OptsGuard() { natsOptions_Destroy(ptr); }
+  } opts_guard{opts};
+
+  // Server URL
+  if (natsOptions_SetURL(opts, config_.url.c_str()) != NATS_OK) {
+    return false;
+  }
+
+  // Reconnection policy
+  if (natsOptions_SetMaxReconnect(opts, config_.max_reconnect_attempts) != NATS_OK) {
+    return false;
+  }
+
+  int64_t wait_ms = static_cast<int64_t>(config_.reconnect_wait.count());
+  if (natsOptions_SetReconnectWait(opts, wait_ms) != NATS_OK) {
+    return false;
+  }
+
+  // Keep-alive
+  int64_t ping_ms = static_cast<int64_t>(config_.ping_interval.count());
+  if (natsOptions_SetPingInterval(opts, ping_ms) != NATS_OK) {
+    return false;
+  }
+  if (natsOptions_SetMaxPingsOut(opts, config_.max_pings_out) != NATS_OK) {
+    return false;
+  }
+
+  // TLS
+  if (!applyTlsOptions(opts)) {
+    return false;
+  }
+
+  // Lifecycle callbacks — pass `this` as closure so static shims can dispatch
+  if (natsOptions_SetErrorHandler(opts, NatsConnection::onError, this) != NATS_OK) {
+    return false;
+  }
+  if (natsOptions_SetDisconnectedCB(opts, NatsConnection::onDisconnected, this) != NATS_OK) {
+    return false;
+  }
+  if (natsOptions_SetReconnectedCB(opts, NatsConnection::onReconnected, this) != NATS_OK) {
+    return false;
+  }
+  if (natsOptions_SetClosedCB(opts, NatsConnection::onClosed, this) != NATS_OK) {
+    return false;
+  }
+
+  natsConnection* conn = nullptr;
+  if (natsConnection_Connect(&conn, opts) != NATS_OK) {
+    return false;
+  }
+
+  conn_ = conn;
+  state_.store(NatsConnectionState::CONNECTED, std::memory_order_release);
+  return true;
+}
+
+void NatsConnection::disconnect() {
+  if (conn_ != nullptr) {
+    natsConnection_Close(conn_);
+    natsConnection_Destroy(conn_);
+    conn_ = nullptr;
+  }
+  state_.store(NatsConnectionState::DISCONNECTED, std::memory_order_release);
+}
+
+// ---------------------------------------------------------------------------
+// State inspection
+// ---------------------------------------------------------------------------
+
+NatsConnectionState NatsConnection::getState() const noexcept {
+  return state_.load(std::memory_order_acquire);
+}
+
+bool NatsConnection::isConnected() const noexcept {
+  return getState() == NatsConnectionState::CONNECTED;
+}
+
+natsConnection* NatsConnection::handle() const noexcept { return conn_; }
+
+// ---------------------------------------------------------------------------
+// Static callback shims
+// ---------------------------------------------------------------------------
+
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+void NatsConnection::onError(natsConnection* /*nc*/, natsSubscription* /*sub*/,
+                             natsStatus err, void* closure) noexcept {
+  auto* self = static_cast<NatsConnection*>(closure);
+  ErrorCallback cb;
+  {
+    std::lock_guard<std::mutex> lock(self->callbacks_mutex_);
+    cb = self->error_cb_;
+  }
+  if (cb) {
+    const char* text = natsStatus_GetText(err);
+    cb(text != nullptr ? text : "unknown nats error");
+  }
+}
+
+void NatsConnection::onDisconnected(natsConnection* /*nc*/, void* closure) noexcept {
+  auto* self = static_cast<NatsConnection*>(closure);
+  self->state_.store(NatsConnectionState::RECONNECTING, std::memory_order_release);
+  DisconnectedCallback cb;
+  {
+    std::lock_guard<std::mutex> lock(self->callbacks_mutex_);
+    cb = self->disconnected_cb_;
+  }
+  if (cb) {
+    cb();
+  }
+}
+
+void NatsConnection::onReconnected(natsConnection* /*nc*/, void* closure) noexcept {
+  auto* self = static_cast<NatsConnection*>(closure);
+  self->state_.store(NatsConnectionState::CONNECTED, std::memory_order_release);
+  ReconnectedCallback cb;
+  {
+    std::lock_guard<std::mutex> lock(self->callbacks_mutex_);
+    cb = self->reconnected_cb_;
+  }
+  if (cb) {
+    cb();
+  }
+}
+
+void NatsConnection::onClosed(natsConnection* /*nc*/, void* closure) noexcept {
+  auto* self = static_cast<NatsConnection*>(closure);
+  self->state_.store(NatsConnectionState::CLOSED, std::memory_order_release);
+  ClosedCallback cb;
+  {
+    std::lock_guard<std::mutex> lock(self->callbacks_mutex_);
+    cb = self->closed_cb_;
+  }
+  if (cb) {
+    cb();
+  }
+}
+
+}  // namespace transport
+}  // namespace keystone

--- a/tests/unit/test_nats_connection.cpp
+++ b/tests/unit/test_nats_connection.cpp
@@ -35,9 +35,7 @@ class NatsConnectionTestPeer : public NatsConnection {
  public:
   using NatsConnection::NatsConnection;
 
-  void fireError() {
-    NatsConnection::onError(nullptr, nullptr, static_cast<natsStatus>(0), this);
-  }
+  void fireError() { NatsConnection::onError(nullptr, nullptr, static_cast<natsStatus>(0), this); }
 
   void fireDisconnected() { NatsConnection::onDisconnected(nullptr, this); }
   void fireReconnected() { NatsConnection::onReconnected(nullptr, this); }

--- a/tests/unit/test_nats_connection.cpp
+++ b/tests/unit/test_nats_connection.cpp
@@ -1,0 +1,322 @@
+/**
+ * @file test_nats_connection.cpp
+ * @brief Unit tests for NatsConnection (issue #122 — NATS TLS configuration)
+ *
+ * Tests cover:
+ * - Default construction and initial state
+ * - Callback registration before connect()
+ * - Config field validation (reconnect attempts, wait interval, ping settings)
+ * - TLS configuration fields (enable_tls, ca_cert_path, client cert/key, skip_verify)
+ * - State transitions via the public callback shims (simulated without a live server)
+ * - disconnect() is safe to call without a prior connect()
+ * - isConnected() reflects getState()
+ * - Null-safety of unregistered callbacks
+ * - Callback replacement semantics
+ *
+ * Tests do NOT exercise connect() against a live NATS server because the CI
+ * environment has no NATS process. The callback dispatch path is exercised via
+ * the NatsConnectionTestPeer helper below.
+ */
+
+#include "transport/nats_connection.hpp"
+
+#include <atomic>
+#include <string>
+
+#include <gtest/gtest.h>
+
+using namespace keystone::transport;
+
+// ---------------------------------------------------------------------------
+// Test peer — fires static callback shims without a live connection
+// ---------------------------------------------------------------------------
+
+class NatsConnectionTestPeer : public NatsConnection {
+ public:
+  using NatsConnection::NatsConnection;
+
+  void fireError() {
+    NatsConnection::onError(nullptr, nullptr, static_cast<natsStatus>(0), this);
+  }
+
+  void fireDisconnected() { NatsConnection::onDisconnected(nullptr, this); }
+  void fireReconnected() { NatsConnection::onReconnected(nullptr, this); }
+  void fireClosed() { NatsConnection::onClosed(nullptr, this); }
+};
+
+// ---------------------------------------------------------------------------
+// NatsConnectionStateTest — initial state and disconnect safety
+// ---------------------------------------------------------------------------
+
+class NatsConnectionStateTest : public ::testing::Test {};
+
+TEST_F(NatsConnectionStateTest, InitialStateIsDisconnected) {
+  NatsConnection conn;
+  EXPECT_EQ(conn.getState(), NatsConnectionState::DISCONNECTED);
+}
+
+TEST_F(NatsConnectionStateTest, IsConnectedReturnsFalseWhenDisconnected) {
+  NatsConnection conn;
+  EXPECT_FALSE(conn.isConnected());
+}
+
+TEST_F(NatsConnectionStateTest, HandleIsNullBeforeConnect) {
+  NatsConnection conn;
+  EXPECT_EQ(conn.handle(), nullptr);
+}
+
+TEST_F(NatsConnectionStateTest, DisconnectWithoutConnectIsNoOp) {
+  NatsConnection conn;
+  EXPECT_NO_THROW(conn.disconnect());
+  EXPECT_EQ(conn.getState(), NatsConnectionState::DISCONNECTED);
+}
+
+TEST_F(NatsConnectionStateTest, DoubleDisconnectIsNoOp) {
+  NatsConnection conn;
+  conn.disconnect();
+  EXPECT_NO_THROW(conn.disconnect());
+}
+
+// ---------------------------------------------------------------------------
+// NatsConfigTest — configuration fields
+// ---------------------------------------------------------------------------
+
+class NatsConfigTest : public ::testing::Test {};
+
+TEST_F(NatsConfigTest, DefaultConfigValues) {
+  NatsConfig cfg;
+  EXPECT_EQ(cfg.url, "nats://localhost:4222");
+  EXPECT_EQ(cfg.max_reconnect_attempts, 60);
+  EXPECT_EQ(cfg.reconnect_wait, std::chrono::milliseconds{2000});
+  EXPECT_EQ(cfg.ping_interval, std::chrono::milliseconds{20000});
+  EXPECT_EQ(cfg.max_pings_out, 2);
+}
+
+TEST_F(NatsConfigTest, DefaultTlsDisabled) {
+  NatsConfig cfg;
+  EXPECT_FALSE(cfg.tls.enable_tls);
+  EXPECT_TRUE(cfg.tls.ca_cert_path.empty());
+  EXPECT_TRUE(cfg.tls.client_cert_path.empty());
+  EXPECT_TRUE(cfg.tls.client_key_path.empty());
+  EXPECT_FALSE(cfg.tls.skip_server_verification);
+}
+
+TEST_F(NatsConfigTest, CustomConfigPreserved) {
+  NatsConfig cfg;
+  cfg.url = "nats://myserver:4222";
+  cfg.max_reconnect_attempts = 10;
+  cfg.reconnect_wait = std::chrono::milliseconds{500};
+  cfg.ping_interval = std::chrono::milliseconds{5000};
+  cfg.max_pings_out = 5;
+  NatsConnectionTestPeer conn(cfg);
+  EXPECT_EQ(conn.getState(), NatsConnectionState::DISCONNECTED);
+}
+
+TEST_F(NatsConfigTest, UnlimitedReconnectAttempts) {
+  NatsConfig cfg;
+  cfg.max_reconnect_attempts = -1;
+  EXPECT_EQ(cfg.max_reconnect_attempts, -1);
+}
+
+// ---------------------------------------------------------------------------
+// NatsTlsConfigTest — TLS configuration fields
+// ---------------------------------------------------------------------------
+
+class NatsTlsConfigTest : public ::testing::Test {};
+
+TEST_F(NatsTlsConfigTest, TlsCanBeEnabled) {
+  NatsTlsConfig tls;
+  tls.enable_tls = true;
+  EXPECT_TRUE(tls.enable_tls);
+}
+
+TEST_F(NatsTlsConfigTest, TlsWithCaCertPath) {
+  NatsTlsConfig tls;
+  tls.enable_tls = true;
+  tls.ca_cert_path = "/etc/ssl/certs/ca.pem";
+  EXPECT_EQ(tls.ca_cert_path, "/etc/ssl/certs/ca.pem");
+}
+
+TEST_F(NatsTlsConfigTest, TlsWithClientCertAndKey) {
+  NatsTlsConfig tls;
+  tls.enable_tls = true;
+  tls.client_cert_path = "/etc/ssl/certs/client.pem";
+  tls.client_key_path = "/etc/ssl/private/client.key";
+  EXPECT_EQ(tls.client_cert_path, "/etc/ssl/certs/client.pem");
+  EXPECT_EQ(tls.client_key_path, "/etc/ssl/private/client.key");
+}
+
+TEST_F(NatsTlsConfigTest, SkipServerVerificationDefaultFalse) {
+  NatsTlsConfig tls;
+  EXPECT_FALSE(tls.skip_server_verification);
+}
+
+TEST_F(NatsTlsConfigTest, SkipServerVerificationCanBeEnabled) {
+  NatsTlsConfig tls;
+  tls.skip_server_verification = true;
+  EXPECT_TRUE(tls.skip_server_verification);
+}
+
+TEST_F(NatsTlsConfigTest, TlsConfigStoredInNatsConfig) {
+  NatsConfig cfg;
+  cfg.tls.enable_tls = true;
+  cfg.tls.ca_cert_path = "/path/to/ca.pem";
+  cfg.tls.client_cert_path = "/path/to/cert.pem";
+  cfg.tls.client_key_path = "/path/to/key.pem";
+
+  NatsConnectionTestPeer conn(cfg);
+  // Construction must not throw — TLS is only applied during connect()
+  EXPECT_EQ(conn.getState(), NatsConnectionState::DISCONNECTED);
+}
+
+TEST_F(NatsTlsConfigTest, TlsUrlSchemeAccepted) {
+  NatsConfig cfg;
+  cfg.url = "tls://nats.example.com:4222";
+  cfg.tls.enable_tls = true;
+  EXPECT_EQ(cfg.url, "tls://nats.example.com:4222");
+  EXPECT_TRUE(cfg.tls.enable_tls);
+}
+
+// ---------------------------------------------------------------------------
+// NatsCallbackTest — callback registration and dispatch
+// ---------------------------------------------------------------------------
+
+class NatsCallbackTest : public ::testing::Test {
+ protected:
+  NatsConnectionTestPeer conn_;
+};
+
+TEST_F(NatsCallbackTest, ErrorCallbackFiredOnError) {
+  std::atomic<int> call_count{0};
+  conn_.setErrorCallback([&](const std::string& /*err*/) { ++call_count; });
+
+  conn_.fireError();
+
+  EXPECT_EQ(call_count.load(), 1);
+}
+
+TEST_F(NatsCallbackTest, DisconnectedCallbackFiredOnDisconnect) {
+  std::atomic<int> call_count{0};
+  conn_.setDisconnectedCallback([&]() { ++call_count; });
+
+  conn_.fireDisconnected();
+
+  EXPECT_EQ(call_count.load(), 1);
+}
+
+TEST_F(NatsCallbackTest, ReconnectedCallbackFiredOnReconnect) {
+  std::atomic<int> call_count{0};
+  conn_.setReconnectedCallback([&]() { ++call_count; });
+
+  conn_.fireReconnected();
+
+  EXPECT_EQ(call_count.load(), 1);
+}
+
+TEST_F(NatsCallbackTest, ClosedCallbackFiredOnClose) {
+  std::atomic<int> call_count{0};
+  conn_.setClosedCallback([&]() { ++call_count; });
+
+  conn_.fireClosed();
+
+  EXPECT_EQ(call_count.load(), 1);
+}
+
+// ---------------------------------------------------------------------------
+// NatsStateTransitionTest — state machine driven by callbacks
+// ---------------------------------------------------------------------------
+
+class NatsStateTransitionTest : public ::testing::Test {
+ protected:
+  NatsConnectionTestPeer conn_;
+};
+
+TEST_F(NatsStateTransitionTest, DisconnectedCallbackSetsReconnectingState) {
+  conn_.fireDisconnected();
+  EXPECT_EQ(conn_.getState(), NatsConnectionState::RECONNECTING);
+  EXPECT_FALSE(conn_.isConnected());
+}
+
+TEST_F(NatsStateTransitionTest, ReconnectedCallbackSetsConnectedState) {
+  conn_.fireDisconnected();
+  conn_.fireReconnected();
+
+  EXPECT_EQ(conn_.getState(), NatsConnectionState::CONNECTED);
+  EXPECT_TRUE(conn_.isConnected());
+}
+
+TEST_F(NatsStateTransitionTest, ClosedCallbackSetsClosedState) {
+  conn_.fireClosed();
+  EXPECT_EQ(conn_.getState(), NatsConnectionState::CLOSED);
+  EXPECT_FALSE(conn_.isConnected());
+}
+
+TEST_F(NatsStateTransitionTest, IsConnectedOnlyTrueInConnectedState) {
+  EXPECT_FALSE(conn_.isConnected());
+
+  conn_.fireDisconnected();  // → RECONNECTING
+  EXPECT_FALSE(conn_.isConnected());
+
+  conn_.fireReconnected();  // → CONNECTED
+  EXPECT_TRUE(conn_.isConnected());
+
+  conn_.fireClosed();  // → CLOSED
+  EXPECT_FALSE(conn_.isConnected());
+}
+
+TEST_F(NatsStateTransitionTest, DisconnectResetsStateToDisconnected) {
+  conn_.fireReconnected();
+  ASSERT_TRUE(conn_.isConnected());
+
+  conn_.disconnect();
+
+  EXPECT_EQ(conn_.getState(), NatsConnectionState::DISCONNECTED);
+  EXPECT_FALSE(conn_.isConnected());
+}
+
+// ---------------------------------------------------------------------------
+// NatsCallbackNullSafetyTest — no crash when callbacks are not set
+// ---------------------------------------------------------------------------
+
+class NatsCallbackNullSafetyTest : public ::testing::Test {
+ protected:
+  NatsConnectionTestPeer conn_;
+};
+
+TEST_F(NatsCallbackNullSafetyTest, ErrorWithNoCallbackDoesNotCrash) {
+  EXPECT_NO_THROW(conn_.fireError());
+}
+
+TEST_F(NatsCallbackNullSafetyTest, DisconnectedWithNoCallbackDoesNotCrash) {
+  EXPECT_NO_THROW(conn_.fireDisconnected());
+}
+
+TEST_F(NatsCallbackNullSafetyTest, ReconnectedWithNoCallbackDoesNotCrash) {
+  EXPECT_NO_THROW(conn_.fireReconnected());
+}
+
+TEST_F(NatsCallbackNullSafetyTest, ClosedWithNoCallbackDoesNotCrash) {
+  EXPECT_NO_THROW(conn_.fireClosed());
+}
+
+// ---------------------------------------------------------------------------
+// NatsCallbackOverrideTest — replacing a callback after initial registration
+// ---------------------------------------------------------------------------
+
+class NatsCallbackOverrideTest : public ::testing::Test {
+ protected:
+  NatsConnectionTestPeer conn_;
+};
+
+TEST_F(NatsCallbackOverrideTest, ReplacedCallbackIsInvokedInsteadOfOriginal) {
+  std::atomic<int> first_count{0};
+  std::atomic<int> second_count{0};
+
+  conn_.setReconnectedCallback([&]() { ++first_count; });
+  conn_.setReconnectedCallback([&]() { ++second_count; });
+
+  conn_.fireReconnected();
+
+  EXPECT_EQ(first_count.load(), 0);
+  EXPECT_EQ(second_count.load(), 1);
+}


### PR DESCRIPTION
## Summary

Closes #122 — NATS connection had no TLS configuration, transmitting task event data in plaintext.

- Add `NatsTlsConfig` struct with `enable_tls`, `ca_cert_path`, `client_cert_path`, `client_key_path`, and `skip_server_verification` fields, embedded in `NatsConfig`
- Implement `applyTlsOptions()` in `NatsConnection::connect()` using nats.c TLS API: `natsOptions_SetSecure`, `natsOptions_LoadCATrustedCertificates`, `natsOptions_LoadCertificatesChain`
- Runtime env var overrides: `KEYSTONE_NATS_TLS_CA_PATH`, `KEYSTONE_NATS_TLS_CERT_PATH`, `KEYSTONE_NATS_TLS_KEY_PATH` (same pattern as existing gRPC TLS env vars)
- Add nats.c v3.12.0 via FetchContent with OpenSSL TLS enabled; restrict `-Wno-dangling-reference` to C++ only to fix compilation of C source files
- Document NATS TLS environment variables in `.env.example`

## Test plan

- [x] 30 unit tests in `tests/unit/test_nats_connection.cpp` covering: TLS config fields and defaults, state machine transitions, callback dispatch, null-safety (unregistered callbacks), callback replacement semantics
- [x] Tests pass: all 30 tests in `transport_unit_tests` pass under debug build
- [x] No regressions to pre-existing test targets (pre-existing `unit_tests` build failure with `spdlog/fmt/fmt.h` is unrelated and predates this branch)
- [x] nats.c builds cleanly with OpenSSL TLS support on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)