### PR TITLE
feat(logging): add correlation IDs for cross-service tracing

### DIFF
--- a/include/concurrency/logger.hpp
+++ b/include/concurrency/logger.hpp
@@ -12,13 +12,26 @@ namespace keystone {
 namespace concurrency {
 
 /**
+ * @brief Generate a UUID4-format correlation ID
+ *
+ * Uses thread-local random state for efficiency. Not cryptographically secure
+ * but suitable for log correlation across a single NATS event lifecycle.
+ *
+ * @return std::string UUID4 string (e.g. "550e8400-e29b-41d4-a716-446655440000")
+ */
+std::string generateCorrelationId();
+
+/**
  * @brief LogContext - Thread-local context for distributed logging
  *
- * Provides thread-local context information (agent_id, worker_id, session_id)
- * that is automatically included in all log messages from that thread.
+ * Provides thread-local context information (agent_id, worker_id, session_id,
+ * correlation_id) that is automatically included in all log messages from that
+ * thread. correlation_id ties all log lines within a single logical operation
+ * (e.g. one NATS message receipt → DAG walk → claim) together.
  *
  * Usage:
  *   LogContext::set("agent_123", 5, "session_abc");
+ *   LogContext::setCorrelationId(generateCorrelationId());
  *   Logger::info("Processing message");  // Automatically includes context
  */
 class LogContext {
@@ -33,7 +46,7 @@ class LogContext {
   static void set(const std::string& agent_id, int32_t worker_id, const std::string& session_id);
 
   /**
-   * @brief Clear the thread-local logging context
+   * @brief Clear the thread-local logging context (including correlation ID)
    */
   static void clear();
 
@@ -53,9 +66,31 @@ class LogContext {
   static std::string getSessionId();
 
   /**
+   * @brief Set a correlation ID on the current thread's context
+   *
+   * The correlation ID is propagated into every log line emitted on this
+   * thread until cleared or overwritten. Call this at the entry point of a
+   * logical operation (e.g. on NATS message receipt) and clear it on exit.
+   *
+   * @param correlation_id UUID4 string produced by generateCorrelationId()
+   */
+  static void setCorrelationId(const std::string& correlation_id);
+
+  /**
+   * @brief Clear only the correlation ID, leaving agent/worker/session intact
+   */
+  static void clearCorrelationId();
+
+  /**
+   * @brief Get current correlation ID (empty string if not set)
+   */
+  static std::string getCorrelationId();
+
+  /**
    * @brief Get formatted context string for logging
    *
-   * Returns format: "[agent_id:worker_id:session_id]"
+   * Returns format: "[agent_id:worker_id:session_id:corr=<id>]" when a
+   * correlation ID is set, or "[agent_id:worker_id:session_id]" otherwise.
    */
   static std::string getContextString();
 
@@ -64,9 +99,47 @@ class LogContext {
     std::string agent_id;
     int32_t worker_id = -1;
     std::string session_id;
+    std::string correlation_id;
   };
 
   static thread_local Context context_;
+};
+
+/**
+ * @brief RAII guard that sets a correlation ID for the duration of a scope
+ *
+ * Generates a fresh UUID4 on construction (or accepts a provided one) and
+ * restores the previous correlation ID on destruction. This makes it safe to
+ * nest scopes without losing the outer operation's ID.
+ *
+ * Usage:
+ *   void onNatsMessage(const NatsMsg& msg) {
+ *     CorrelationScope scope;  // new UUID, restored on exit
+ *     Logger::info("Received NATS event");
+ *     advanceDag(msg);         // all logs share scope.id()
+ *   }
+ */
+class CorrelationScope {
+ public:
+  /** Construct with a freshly generated correlation ID */
+  explicit CorrelationScope();
+
+  /** Construct with a caller-supplied correlation ID */
+  explicit CorrelationScope(std::string correlation_id);
+
+  CorrelationScope(const CorrelationScope&) = delete;
+  CorrelationScope& operator=(const CorrelationScope&) = delete;
+  CorrelationScope(CorrelationScope&&) = delete;
+  CorrelationScope& operator=(CorrelationScope&&) = delete;
+
+  ~CorrelationScope();
+
+  /** Return the correlation ID active for this scope */
+  const std::string& id() const noexcept { return current_id_; }
+
+ private:
+  std::string previous_id_;
+  std::string current_id_;
 };
 
 /**

--- a/src/concurrency/logger.cpp
+++ b/src/concurrency/logger.cpp
@@ -5,12 +5,36 @@
 
 #include "concurrency/logger.hpp"
 
+#include <random>
 #include <sstream>
 
 #include <spdlog/sinks/stdout_color_sinks.h>
 
 namespace keystone {
 namespace concurrency {
+
+std::string generateCorrelationId() {
+  // Thread-local Mersenne Twister seeded once per thread via random_device.
+  // Not cryptographically secure, but sufficient for log correlation.
+  thread_local std::random_device rd;
+  thread_local std::mt19937 gen(rd());
+  thread_local std::uniform_int_distribution<uint32_t> dist(0, 0xFFFFFFFF);
+
+  // Produce 128 bits of random data and format as UUID4
+  uint32_t a = dist(gen);
+  uint32_t b = dist(gen);
+  uint32_t c = dist(gen);
+  uint32_t d = dist(gen);
+
+  // Set UUID version (4) and variant (10xx) bits
+  b = (b & 0xFFFF0FFFu) | 0x00004000u;  // version 4
+  c = (c & 0x3FFFFFFFu) | 0x80000000u;  // variant 10xx
+
+  char buf[37];
+  std::snprintf(buf, sizeof(buf), "%08x-%04x-%04x-%04x-%04x%08x", a, (b >> 16) & 0xFFFF,
+                b & 0xFFFF, (c >> 16) & 0xFFFF, c & 0xFFFF, d);
+  return std::string(buf);
+}
 
 // LogContext thread-local storage
 thread_local LogContext::Context LogContext::context_;
@@ -27,6 +51,7 @@ void LogContext::clear() {
   context_.agent_id.clear();
   context_.worker_id = -1;
   context_.session_id.clear();
+  context_.correlation_id.clear();
 }
 
 std::string LogContext::getAgentId() {
@@ -41,14 +66,43 @@ std::string LogContext::getSessionId() {
   return context_.session_id;
 }
 
+void LogContext::setCorrelationId(const std::string& correlation_id) {
+  context_.correlation_id = correlation_id;
+}
+
+void LogContext::clearCorrelationId() {
+  context_.correlation_id.clear();
+}
+
+std::string LogContext::getCorrelationId() {
+  return context_.correlation_id;
+}
+
 std::string LogContext::getContextString() {
   if (context_.agent_id.empty()) {
     return "[no-context]";
   }
 
   std::ostringstream oss;
-  oss << "[" << context_.agent_id << ":" << context_.worker_id << ":" << context_.session_id << "]";
+  oss << "[" << context_.agent_id << ":" << context_.worker_id << ":" << context_.session_id;
+  if (!context_.correlation_id.empty()) {
+    oss << ":corr=" << context_.correlation_id;
+  }
+  oss << "]";
   return oss.str();
+}
+
+// CorrelationScope
+
+CorrelationScope::CorrelationScope() : CorrelationScope(generateCorrelationId()) {}
+
+CorrelationScope::CorrelationScope(std::string correlation_id)
+    : previous_id_(LogContext::getCorrelationId()), current_id_(std::move(correlation_id)) {
+  LogContext::setCorrelationId(current_id_);
+}
+
+CorrelationScope::~CorrelationScope() {
+  LogContext::setCorrelationId(previous_id_);
 }
 
 // Logger static members

--- a/src/concurrency/logger.cpp
+++ b/src/concurrency/logger.cpp
@@ -31,8 +31,15 @@ std::string generateCorrelationId() {
   c = (c & 0x3FFFFFFFu) | 0x80000000u;  // variant 10xx
 
   char buf[37];
-  std::snprintf(buf, sizeof(buf), "%08x-%04x-%04x-%04x-%04x%08x", a, (b >> 16) & 0xFFFF,
-                b & 0xFFFF, (c >> 16) & 0xFFFF, c & 0xFFFF, d);
+  std::snprintf(buf,
+                sizeof(buf),
+                "%08x-%04x-%04x-%04x-%04x%08x",
+                a,
+                (b >> 16) & 0xFFFF,
+                b & 0xFFFF,
+                (c >> 16) & 0xFFFF,
+                c & 0xFFFF,
+                d);
   return std::string(buf);
 }
 

--- a/tests/unit/test_logger.cpp
+++ b/tests/unit/test_logger.cpp
@@ -174,3 +174,151 @@ TEST(LogContextTest, NegativeWorkerId) {
   EXPECT_EQ(LogContext::getWorkerId(), int32_t{-5});
   EXPECT_EQ(LogContext::getContextString(), "[agent:-5:session]");
 }
+
+// ---- Correlation ID tests ----
+
+// Test: generateCorrelationId produces UUID4-format strings
+TEST(CorrelationIdTest, FormatIsUUID4) {
+  std::string id = generateCorrelationId();
+  ASSERT_EQ(id.size(), 36u);
+  EXPECT_EQ(id[8], '-');
+  EXPECT_EQ(id[13], '-');
+  EXPECT_EQ(id[18], '-');
+  EXPECT_EQ(id[23], '-');
+  // Version nibble must be '4'
+  EXPECT_EQ(id[14], '4');
+  // Variant nibble must be '8', '9', 'a', or 'b'
+  char variant = id[19];
+  EXPECT_TRUE(variant == '8' || variant == '9' || variant == 'a' || variant == 'b')
+      << "variant nibble '" << variant << "' is not in {8,9,a,b}";
+}
+
+// Test: generateCorrelationId produces unique IDs
+TEST(CorrelationIdTest, Uniqueness) {
+  std::string id1 = generateCorrelationId();
+  std::string id2 = generateCorrelationId();
+  EXPECT_NE(id1, id2);
+}
+
+// Test: LogContext setCorrelationId / getCorrelationId
+TEST(LogContextTest, SetAndGetCorrelationId) {
+  LogContext::set("agent", 0, "sess");
+  LogContext::setCorrelationId("test-corr-id");
+  EXPECT_EQ(LogContext::getCorrelationId(), "test-corr-id");
+}
+
+// Test: correlation ID appears in context string
+TEST(LogContextTest, ContextStringIncludesCorrelationId) {
+  LogContext::set("agent", 0, "sess");
+  LogContext::setCorrelationId("abc-123");
+  EXPECT_EQ(LogContext::getContextString(), "[agent:0:sess:corr=abc-123]");
+}
+
+// Test: context string without correlation ID is unchanged
+TEST(LogContextTest, ContextStringNoCorrelationId) {
+  LogContext::set("agent", 0, "sess");
+  LogContext::clearCorrelationId();
+  EXPECT_EQ(LogContext::getContextString(), "[agent:0:sess]");
+}
+
+// Test: clear() also clears the correlation ID
+TEST(LogContextTest, ClearAlsoClearsCorrelationId) {
+  LogContext::set("agent", 0, "sess");
+  LogContext::setCorrelationId("some-id");
+  LogContext::clear();
+  EXPECT_EQ(LogContext::getCorrelationId(), "");
+}
+
+// Test: clearCorrelationId leaves other fields intact
+TEST(LogContextTest, ClearCorrelationIdLeavesContextIntact) {
+  LogContext::set("agent", 2, "session");
+  LogContext::setCorrelationId("keep-me-not");
+  LogContext::clearCorrelationId();
+  EXPECT_EQ(LogContext::getAgentId(), "agent");
+  EXPECT_EQ(LogContext::getWorkerId(), int32_t{2});
+  EXPECT_EQ(LogContext::getSessionId(), "session");
+  EXPECT_EQ(LogContext::getCorrelationId(), "");
+}
+
+// Test: CorrelationScope sets a fresh correlation ID
+TEST(CorrelationScopeTest, SetsCorrelationId) {
+  LogContext::set("agent", 0, "sess");
+  LogContext::clearCorrelationId();
+  {
+    CorrelationScope scope;
+    EXPECT_FALSE(scope.id().empty());
+    EXPECT_EQ(LogContext::getCorrelationId(), scope.id());
+  }
+}
+
+// Test: CorrelationScope restores previous correlation ID on destruction
+TEST(CorrelationScopeTest, RestoresPreviousId) {
+  LogContext::set("agent", 0, "sess");
+  LogContext::setCorrelationId("outer-id");
+  {
+    CorrelationScope scope;
+    EXPECT_NE(LogContext::getCorrelationId(), "outer-id");
+  }
+  EXPECT_EQ(LogContext::getCorrelationId(), "outer-id");
+}
+
+// Test: CorrelationScope accepts a caller-supplied ID
+TEST(CorrelationScopeTest, AcceptsSuppliedId) {
+  LogContext::set("agent", 0, "sess");
+  {
+    CorrelationScope scope("my-fixed-id");
+    EXPECT_EQ(scope.id(), "my-fixed-id");
+    EXPECT_EQ(LogContext::getCorrelationId(), "my-fixed-id");
+  }
+}
+
+// Test: nested CorrelationScopes restore correctly
+TEST(CorrelationScopeTest, NestedScopesRestoreCorrectly) {
+  LogContext::set("agent", 0, "sess");
+  LogContext::setCorrelationId("root");
+  {
+    CorrelationScope outer("outer");
+    EXPECT_EQ(LogContext::getCorrelationId(), "outer");
+    {
+      CorrelationScope inner("inner");
+      EXPECT_EQ(LogContext::getCorrelationId(), "inner");
+    }
+    EXPECT_EQ(LogContext::getCorrelationId(), "outer");
+  }
+  EXPECT_EQ(LogContext::getCorrelationId(), "root");
+}
+
+// Test: correlation ID is thread-local (each thread has its own)
+TEST(CorrelationScopeTest, ThreadLocalIsolation) {
+  LogContext::set("main", 0, "main-sess");
+  std::string main_id = generateCorrelationId();
+  LogContext::setCorrelationId(main_id);
+
+  std::string other_thread_id;
+  std::thread t([&other_thread_id]() {
+    // New thread starts with empty correlation ID
+    other_thread_id = LogContext::getCorrelationId();
+    LogContext::set("worker", 1, "worker-sess");
+    CorrelationScope scope;
+    // Doesn't affect main thread
+  });
+  t.join();
+
+  EXPECT_EQ(other_thread_id, "");
+  EXPECT_EQ(LogContext::getCorrelationId(), main_id);
+}
+
+// Test: all log lines in a scope share the same correlation ID
+TEST(CorrelationScopeTest, LogLinesShareId) {
+  Logger::init(spdlog::level::info);
+  LogContext::set("agent", 0, "sess");
+  {
+    CorrelationScope scope;
+    std::string active_id = LogContext::getCorrelationId();
+    Logger::info("First log line, corr={}", active_id);
+    Logger::info("Second log line, corr={}", LogContext::getCorrelationId());
+    EXPECT_EQ(LogContext::getCorrelationId(), active_id);
+  }
+  SUCCEED();
+  Logger::shutdown();
+}


### PR DESCRIPTION
## Summary

- Adds `correlation_id` to `LogContext` (thread-local, zero-cost when unused) so every log line within a single logical operation shares a traceable ID
- Adds `generateCorrelationId()` — UUID4 via thread-local Mersenne Twister with no new dependencies
- Adds `CorrelationScope` RAII guard: auto-generates (or accepts) a UUID, sets it on the calling thread, and restores the previous value on destruction — safe to nest across call boundaries
- `getContextString()` appends `corr=<id>` when a correlation ID is active, e.g. `[agent:0:sess:corr=abb5bc8c-33a4-4849-af2e-68e5fe07d33c]`
- Fixes pre-existing CMake bug: `spdlog::spdlog` and `concurrentqueue::concurrentqueue` were `PRIVATE` on `keystone_concurrency` despite `logger.hpp` being a public header, breaking all downstream test targets

## Test plan

- [x] 13 new tests added to `tests/unit/test_logger.cpp` covering UUID format (version/variant bits), uniqueness, `setCorrelationId`/`clearCorrelationId`/`getCorrelationId`, context string output, RAII scope nesting, and thread-local isolation
- [x] All 104 concurrency unit tests pass under debug build
- [x] No new compiler warnings (`-Werror` enforced)

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)