### PR TITLE
chore(deps): pin pypi dependency versions with bounded ranges

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -12,6 +12,21 @@ cxx-compiler = "*"
 gtest = "*"
 pkg-config = "*"
 just = ">=1.13"
+python = ">=3.11,<4"
+
+[pypi-dependencies]
+nats-py = ">=2.0,<3"
+httpx = ">=0.27,<1"
+pydantic = ">=2.0,<3"
+pydantic-settings = ">=2.0,<3"
+rich = ">=10.0,<15"
+python-dotenv = ">=1.0,<2"
+
+[feature.dev.pypi-dependencies]
+pytest = ">=7.0,<10"
+pytest-asyncio = ">=0.21,<2"
+ruff = ">=0.1,<1"
+mypy = ">=1.0,<2"
 
 [tasks]
 configure = "cmake -G Ninja -B build-native -S . -DENABLE_GRPC=OFF"

--- a/tests/test_version_bounds.py
+++ b/tests/test_version_bounds.py
@@ -1,0 +1,57 @@
+"""Regression test: all pypi dependencies in pixi.toml must have bounded version specs."""
+
+import tomllib
+from pathlib import Path
+
+import pytest
+
+PIXI_TOML = Path(__file__).resolve().parents[1] / "pixi.toml"
+
+
+def _load_pypi_deps() -> list[tuple[str, str, str]]:
+    """Yield (section, package, spec) for all pypi-dependencies."""
+    with open(PIXI_TOML, "rb") as f:
+        data = tomllib.load(f)
+
+    results: list[tuple[str, str, str]] = []
+
+    for pkg, spec in data.get("pypi-dependencies", {}).items():
+        if isinstance(spec, dict):
+            continue
+        results.append(("pypi-dependencies", pkg, spec))
+
+    dev_deps = data.get("feature", {}).get("dev", {}).get("pypi-dependencies", {})
+    for pkg, spec in dev_deps.items():
+        if isinstance(spec, dict):
+            continue
+        results.append(("feature.dev.pypi-dependencies", pkg, spec))
+
+    return results
+
+
+ALL_DEPS = _load_pypi_deps()
+
+
+@pytest.mark.parametrize(
+    "section,pkg,spec",
+    ALL_DEPS,
+    ids=[f"{s}::{p}" for s, p, _ in ALL_DEPS],
+)
+def test_has_upper_bound(section: str, pkg: str, spec: str) -> None:
+    """Every pypi dependency must declare a major-version upper bound."""
+    assert "<" in spec, (
+        f'{section} :: {pkg} = "{spec}" is missing an upper bound (<). '
+        "All pypi dependencies must have a major-version upper bound."
+    )
+
+
+@pytest.mark.parametrize(
+    "section,pkg,spec",
+    ALL_DEPS,
+    ids=[f"{s}::{p}" for s, p, _ in ALL_DEPS],
+)
+def test_no_wildcard(section: str, pkg: str, spec: str) -> None:
+    """Wildcard version specifiers are not allowed for pypi dependencies."""
+    assert spec.strip() != "*", (
+        f'{section} :: {pkg} = "*" — wildcard specifiers are not allowed.'
+    )


### PR DESCRIPTION
## Summary
- Added `[pypi-dependencies]` and `[feature.dev.pypi-dependencies]` sections to `pixi.toml` with lower-bound + major-version upper-bound version specs (replaces missing/wildcard specs)
- Added `python = ">=3.11,<4"` to conda `[dependencies]` to enable pypi dependency resolution
- Added `tests/test_version_bounds.py` regression test using `tomllib` (stdlib 3.11+) that asserts every pypi dependency has an upper bound and no wildcard spec

## Version bounds chosen

| Package | Spec | Rationale |
|---------|------|-----------|
| nats-py | \`>=2.0,<3\` | JetStream API introduced in 2.0 |
| httpx | \`>=0.27,<1\` | Async client API stable since 0.23; pin below 1.0 |
| pydantic | \`>=2.0,<3\` | v2 syntax (model_validator, etc.) |
| pydantic-settings | \`>=2.0,<3\` | Separate package since v2 |
| rich | \`>=10.0,<15\` | Console/Table/Live APIs stable since 10 |
| python-dotenv | \`>=1.0,<2\` | pydantic-settings requires >=0.19; pin at major 1 |
| pytest | \`>=7.0,<10\` | Modern fixture/parametrize API |
| pytest-asyncio | \`>=0.21,<2\` | auto mode introduced in 0.21 |
| ruff | \`>=0.1,<1\` | Stable linting API |
| mypy | \`>=1.0,<2\` | Type-check API stable at v1 |

## Test plan
- [x] `python3 -m pytest tests/test_version_bounds.py -v` — 20 tests pass (10 upper-bound checks + 10 no-wildcard checks)
- [x] No `"*"` wildcard specifiers remain in `pixi.toml` pypi sections
- [x] All pypi deps have both a lower bound and a major-version upper bound

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)