### PR TITLE
feat(validation): add validate_id helper and enforce it in MaestroClient and NATSListener

### DIFF
--- a/tests/test_nats_listener.py
+++ b/tests/test_nats_listener.py
@@ -1,0 +1,80 @@
+"""Tests for NATSListener ID validation in _on_task_event."""
+from __future__ import annotations
+
+import pytest
+from unittest.mock import MagicMock
+
+from src.keystone.nats_listener import NATSListener
+
+
+def _make_listener() -> tuple[NATSListener, MagicMock]:
+    claimer = MagicMock()
+    claimer.advance_dag_tracked = MagicMock()
+    listener = NATSListener(claimer)
+    return listener, claimer
+
+
+class TestOnTaskEventValidIds:
+    @pytest.mark.asyncio
+    async def test_valid_ids_dispatches(self) -> None:
+        listener, claimer = _make_listener()
+        await listener._on_task_event("hi.tasks.team-1.task-42.completed", "team-1", "task-42")
+        claimer.advance_dag_tracked.assert_called_once_with("team-1")
+
+    @pytest.mark.asyncio
+    async def test_valid_uuid_ids_dispatches(self) -> None:
+        listener, claimer = _make_listener()
+        team = "550e8400-e29b-41d4-a716-446655440000"
+        task = "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+        await listener._on_task_event(f"hi.tasks.{team}.{task}.completed", team, task)
+        claimer.advance_dag_tracked.assert_called_once_with(team)
+
+
+class TestOnTaskEventInvalidIds:
+    @pytest.mark.asyncio
+    async def test_empty_team_id_dropped(self) -> None:
+        listener, claimer = _make_listener()
+        await listener._on_task_event("hi.tasks...task-1.completed", "", "task-1")
+        claimer.advance_dag_tracked.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_slash_in_team_id_dropped(self) -> None:
+        listener, claimer = _make_listener()
+        await listener._on_task_event("hi.tasks.../admin.task-1.completed", "../admin", "task-1")
+        claimer.advance_dag_tracked.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_empty_task_id_dropped(self) -> None:
+        listener, claimer = _make_listener()
+        await listener._on_task_event("hi.tasks.team-1..completed", "team-1", "")
+        claimer.advance_dag_tracked.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_path_traversal_task_id_dropped(self) -> None:
+        listener, claimer = _make_listener()
+        await listener._on_task_event("hi.tasks.team-1.../etc.completed", "team-1", "../etc")
+        claimer.advance_dag_tracked.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_overlong_team_id_dropped(self) -> None:
+        listener, claimer = _make_listener()
+        bad_team = "a" * 257
+        await listener._on_task_event("hi.tasks.AAA.task-1.completed", bad_team, "task-1")
+        claimer.advance_dag_tracked.assert_not_called()
+
+
+class TestOnTaskEventShutdown:
+    @pytest.mark.asyncio
+    async def test_event_dropped_during_shutdown(self) -> None:
+        listener, claimer = _make_listener()
+        listener.begin_shutdown()
+        await listener._on_task_event("hi.tasks.team-1.task-1.completed", "team-1", "task-1")
+        claimer.advance_dag_tracked.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_shutdown_checked_before_validation(self) -> None:
+        listener, claimer = _make_listener()
+        listener.begin_shutdown()
+        # Even with invalid IDs, no error raised — shutdown takes priority
+        await listener._on_task_event("bad", "", "")
+        claimer.advance_dag_tracked.assert_not_called()

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,96 @@
+"""Unit tests for validate_id() in keystone.validation."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.keystone.validation import validate_id
+
+
+class TestValidateIdAccepts:
+    """validate_id() should return the value unchanged for valid inputs."""
+
+    @pytest.mark.parametrize("value", [
+        "550e8400-e29b-41d4-a716-446655440000",  # standard UUID
+        "team-1",
+        "abc123",
+        "T",
+        "team.alpha",
+        "a" * 256,  # exactly at max length
+    ])
+    def test_valid_ids_pass(self, value: str) -> None:
+        assert validate_id(value, "team_id") == value
+
+    def test_returns_original_string(self) -> None:
+        val = "my-team-42"
+        assert validate_id(val, "team_id") is val
+
+
+class TestValidateIdRejects:
+    """validate_id() should raise ValueError for invalid inputs."""
+
+    def test_empty_string(self) -> None:
+        with pytest.raises(ValueError, match="empty"):
+            validate_id("", "team_id")
+
+    def test_whitespace_only(self) -> None:
+        with pytest.raises(ValueError, match="whitespace"):
+            validate_id("   ", "task_id")
+
+    def test_contains_forward_slash(self) -> None:
+        with pytest.raises(ValueError, match="path separator"):
+            validate_id("team/evil", "team_id")
+
+    def test_contains_backslash(self) -> None:
+        with pytest.raises(ValueError, match="path separator"):
+            validate_id("team\\evil", "team_id")
+
+    def test_path_traversal_with_slash(self) -> None:
+        with pytest.raises(ValueError):
+            validate_id("../admin", "team_id")
+
+    def test_path_traversal_dotdot_no_slash(self) -> None:
+        with pytest.raises(ValueError, match="path traversal"):
+            validate_id("..admin", "team_id")
+
+    def test_path_traversal_embedded(self) -> None:
+        with pytest.raises(ValueError, match="path traversal"):
+            validate_id("team..id", "team_id")
+
+    def test_contains_newline(self) -> None:
+        with pytest.raises(ValueError, match="invalid character"):
+            validate_id("team\nid", "team_id")
+
+    def test_contains_tab(self) -> None:
+        with pytest.raises(ValueError, match="invalid character"):
+            validate_id("team\tid", "team_id")
+
+    def test_contains_null_byte(self) -> None:
+        with pytest.raises(ValueError, match="invalid character"):
+            validate_id("team\x00id", "task_id")
+
+    def test_contains_control_character(self) -> None:
+        with pytest.raises(ValueError, match="invalid character"):
+            validate_id("team\x1fid", "task_id")
+
+    def test_exceeds_max_length(self) -> None:
+        with pytest.raises(ValueError, match="exceeds maximum length"):
+            validate_id("a" * 257, "team_id")
+
+    def test_error_message_includes_field_name(self) -> None:
+        with pytest.raises(ValueError, match="my_field"):
+            validate_id("", "my_field")
+
+
+class TestValidateIdFieldName:
+    """field_name is included in all error messages."""
+
+    @pytest.mark.parametrize("bad_value,field_name", [
+        ("", "team_id"),
+        ("../x", "task_id"),
+        ("x/y", "some_field"),
+        ("a" * 300, "record_id"),
+    ])
+    def test_field_name_in_error(self, bad_value: str, field_name: str) -> None:
+        with pytest.raises(ValueError, match=field_name):
+            validate_id(bad_value, field_name)


### PR DESCRIPTION
## Summary

- Add `src/keystone/validation.py` with `validate_id(value, field_name)` — rejects empty, whitespace-only, path-separator (`/`, `\`), path-traversal (`..`), control-character, and overlong (>256 chars) ID strings
- Add `src/keystone/maestro_client.py` with `get_tasks(team_id)`, `update_task(team_id, task_id)`, and `assign_task(task_id)` — all call `validate_id` before constructing URL paths
- Add `src/keystone/nats_listener.py` with `_on_task_event(subject, team_id, task_id)` that validates both IDs after extraction from NATS subjects; malformed IDs are logged and dropped without crashing the daemon
- Add 48 unit tests covering the validator, client methods, and listener dispatch/rejection/shutdown behavior

## Test plan

- [x] `pytest tests/test_validation.py` — 24 tests: valid UUIDs/slugs, empty, whitespace-only, forward slash, backslash, path traversal, control chars, null byte, overlong inputs
- [x] `pytest tests/test_maestro_client.py` — 15 tests: `get_tasks`, `update_task`, `assign_task` URL construction and validation rejection
- [x] `pytest tests/test_nats_listener.py` — 9 tests: valid dispatch, invalid-ID dropping, shutdown priority
- [x] All 48 tests pass

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)