### PR TITLE
feat(models): add TaskEvent Pydantic model for type-safe NATS payload parsing

### DIFF
--- a/src/keystone/__init__.py
+++ b/src/keystone/__init__.py
@@ -1,0 +1,1 @@
+# ProjectKeystone Python transport layer

--- a/src/keystone/models.py
+++ b/src/keystone/models.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+from pydantic import BaseModel, model_validator
+
+TERMINAL_STATUSES: frozenset[str] = frozenset({"completed", "failed", "error", "cancelled"})
+
+
+@dataclass
+class Task:
+    id: str
+    title: str
+    status: str
+    dependencies: list[str] = field(default_factory=list)
+    assigned_agent_id: Optional[str] = None
+
+
+@dataclass
+class Agent:
+    id: str
+    name: str
+    host: str = ""
+    status: str = "active"
+    session_status: str = "online"
+    task_description: str = ""
+    program: str = ""
+    current_task_id: Optional[str] = None
+
+
+class TaskEvent(BaseModel):
+    """Validated NATS task event payload.
+
+    Normalizes status from three possible locations:
+    1. Top-level ``status`` field
+    2. Nested ``data.status`` (Hermes format per issue #107)
+    3. ``newStatus`` field
+
+    All fields are optional — NATS payloads can be sparse or use different
+    schemas depending on the emitting component.
+    """
+
+    status: str | None = None
+    newStatus: str | None = None  # noqa: N815 — matches camelCase JSON payload
+    data: dict | None = None
+    taskId: str | None = None  # noqa: N815
+    teamId: str | None = None  # noqa: N815
+    effective_status: str | None = None
+
+    @model_validator(mode="after")
+    def _resolve_effective_status(self) -> TaskEvent:
+        resolved = self.status
+        if not resolved and self.data:
+            resolved = self.data.get("status")
+        if not resolved:
+            resolved = self.newStatus
+        self.effective_status = resolved
+        return self

--- a/src/keystone/nats_listener.py
+++ b/src/keystone/nats_listener.py
@@ -1,0 +1,130 @@
+"""NATS event listener with input validation and graceful shutdown support."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Protocol
+
+from pydantic import ValidationError
+
+from .models import TaskEvent
+from .validation import validate_id
+
+logger = logging.getLogger(__name__)
+
+
+class TaskClaimer(Protocol):
+    """Protocol for objects that can handle advance_dag_tracked calls."""
+
+    def advance_dag_tracked(self, team_id: str) -> None:
+        ...
+
+
+class NATSListener:
+    """Listens for NATS task events and dispatches advance_dag calls.
+
+    Subjects follow the pattern ``hi.tasks.{team_id}.{task_id}.{event}``.
+    Both ``team_id`` and ``task_id`` are validated before dispatch to prevent
+    path traversal or injection from malformed NATS messages.
+
+    Event payloads are parsed through :class:`~keystone.models.TaskEvent` for
+    type-safe, validated deserialization. Both flat (``{"status": "completed"}``)
+    and Hermes-nested (``{"data": {"status": "completed"}}``) formats are handled.
+
+    Once :meth:`begin_shutdown` is called, new events are logged and dropped
+    without being dispatched — allowing in-flight operations started before
+    shutdown to complete undisturbed.
+    """
+
+    _SUBJECT_PART_COUNT = 5
+
+    def __init__(self, task_claimer: TaskClaimer) -> None:
+        self._task_claimer = task_claimer
+        self._shutting_down: bool = False
+
+    @property
+    def shutting_down(self) -> bool:
+        """Return True if this listener is in shutdown mode."""
+        return self._shutting_down
+
+    def begin_shutdown(self) -> None:
+        """Stop accepting new NATS events.
+
+        After this call, :meth:`_on_task_event` will log and drop any incoming
+        events rather than dispatching them to advance_dag.
+        """
+        self._shutting_down = True
+        logger.info("nats_listener_shutdown_started")
+
+    async def _on_task_event(
+        self,
+        subject: str,
+        team_id: str,
+        task_id: str,
+        raw_payload: bytes | None = None,
+    ) -> None:
+        """Handle an incoming NATS task event, validating IDs and payload before dispatch.
+
+        Validates both ``team_id`` and ``task_id`` extracted from the NATS subject.
+        If a raw payload is provided, it is parsed through :class:`~keystone.models.TaskEvent`
+        for type-safe deserialization. Malformed IDs or invalid JSON produce a
+        warning log and the event is dropped without raising.
+
+        Args:
+            subject: The full NATS subject string (used for log context).
+            team_id: The team ID extracted from the subject parts.
+            task_id: The task ID extracted from the subject parts.
+            raw_payload: Optional raw message bytes to parse as a TaskEvent.
+        """
+        if self._shutting_down:
+            logger.info(
+                "nats_event_dropped_during_shutdown",
+                extra={"team_id": team_id, "subject": subject},
+            )
+            return
+
+        try:
+            validate_id(team_id, "team_id")
+            validate_id(task_id, "task_id")
+        except ValueError as exc:
+            logger.warning(
+                "nats_event_dropped_invalid_id",
+                extra={"subject": subject, "error": str(exc)},
+            )
+            return
+
+        event: TaskEvent | None = None
+        if raw_payload is not None:
+            try:
+                payload_dict: Any = json.loads(raw_payload.decode())
+            except Exception as exc:
+                logger.warning(
+                    "nats_event_dropped_invalid_json",
+                    extra={"subject": subject, "error": str(exc)},
+                )
+                return
+
+            try:
+                event = TaskEvent.model_validate(payload_dict)
+            except ValidationError as exc:
+                logger.warning(
+                    "nats_event_dropped_invalid_payload",
+                    extra={"subject": subject, "error": str(exc)},
+                )
+                return
+
+        logger.debug(
+            "nats_event_received",
+            extra={
+                "team_id": team_id,
+                "task_id": task_id,
+                "subject": subject,
+                "effective_status": event.effective_status if event else None,
+            },
+        )
+        self._task_claimer.advance_dag_tracked(team_id)
+
+    async def stop(self) -> None:
+        """Drain the NATS connection and release resources."""
+        logger.info("nats_listener_stopped")

--- a/src/keystone/validation.py
+++ b/src/keystone/validation.py
@@ -1,0 +1,43 @@
+"""Input validation utilities for safe URL path construction."""
+
+from __future__ import annotations
+
+_MAX_ID_LENGTH = 256
+
+
+def validate_id(value: str, field_name: str) -> str:
+    """Validate an ID string for safe use in URL path segments.
+
+    Rejects empty strings, strings containing path separators (``/``, ``\\``,
+    ``..``), whitespace, control characters, and strings longer than 256
+    characters.
+
+    Args:
+        value: The ID string to validate.
+        field_name: Human-readable name of the field (used in error messages).
+
+    Returns:
+        The original ``value`` unchanged if it passes all checks.
+
+    Raises:
+        ValueError: If ``value`` fails any validation check.
+    """
+    if not value or not value.strip():
+        raise ValueError(f"{field_name} must not be empty or whitespace-only")
+
+    if len(value) > _MAX_ID_LENGTH:
+        raise ValueError(
+            f"{field_name} exceeds maximum length of {_MAX_ID_LENGTH} characters"
+        )
+
+    for ch in value:
+        if ch.isspace() or ord(ch) < 32:
+            raise ValueError(f"{field_name} contains invalid character: {ch!r}")
+
+    if "/" in value or "\\" in value:
+        raise ValueError(f"{field_name} contains path separator characters")
+
+    if ".." in value:
+        raise ValueError(f"{field_name} contains path traversal sequence '..'")
+
+    return value

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+import os
+
+# Ensure src/ is on the path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))

--- a/tests/test_task_event.py
+++ b/tests/test_task_event.py
@@ -1,0 +1,124 @@
+"""Unit tests for TaskEvent Pydantic model validation and status normalization."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from src.keystone.models import TaskEvent
+
+
+class TestTaskEventFlatStatus:
+    """TaskEvent resolves effective_status from top-level status field."""
+
+    def test_flat_status_resolved(self) -> None:
+        event = TaskEvent.model_validate({"status": "completed"})
+        assert event.effective_status == "completed"
+
+    def test_flat_status_preserves_value(self) -> None:
+        event = TaskEvent.model_validate({"status": "failed"})
+        assert event.status == "failed"
+        assert event.effective_status == "failed"
+
+    @pytest.mark.parametrize("status", ["completed", "failed", "error", "cancelled", "running"])
+    def test_various_flat_statuses(self, status: str) -> None:
+        event = TaskEvent.model_validate({"status": status})
+        assert event.effective_status == status
+
+
+class TestTaskEventNestedStatus:
+    """TaskEvent resolves effective_status from data.status (Hermes format, issue #107)."""
+
+    def test_nested_data_status_resolved(self) -> None:
+        event = TaskEvent.model_validate({"data": {"status": "completed"}})
+        assert event.effective_status == "completed"
+
+    def test_nested_status_when_top_level_absent(self) -> None:
+        event = TaskEvent.model_validate({"data": {"status": "running", "extra": "value"}})
+        assert event.effective_status == "running"
+
+    def test_top_level_status_takes_precedence_over_nested(self) -> None:
+        event = TaskEvent.model_validate({"status": "completed", "data": {"status": "running"}})
+        assert event.effective_status == "completed"
+
+    def test_data_without_status_key(self) -> None:
+        event = TaskEvent.model_validate({"data": {"other": "value"}})
+        assert event.effective_status is None
+
+    def test_data_none_skipped(self) -> None:
+        event = TaskEvent.model_validate({"data": None})
+        assert event.effective_status is None
+
+
+class TestTaskEventNewStatus:
+    """TaskEvent resolves effective_status from newStatus field as fallback."""
+
+    def test_new_status_resolved_when_status_absent(self) -> None:
+        event = TaskEvent.model_validate({"newStatus": "completed"})
+        assert event.effective_status == "completed"
+
+    def test_status_takes_precedence_over_new_status(self) -> None:
+        event = TaskEvent.model_validate({"status": "failed", "newStatus": "completed"})
+        assert event.effective_status == "failed"
+
+    def test_nested_status_takes_precedence_over_new_status(self) -> None:
+        event = TaskEvent.model_validate({"data": {"status": "running"}, "newStatus": "completed"})
+        assert event.effective_status == "running"
+
+    def test_new_status_fallback_when_flat_and_nested_absent(self) -> None:
+        event = TaskEvent.model_validate({"newStatus": "cancelled", "taskId": "t-1"})
+        assert event.effective_status == "cancelled"
+
+
+class TestTaskEventMissingFields:
+    """TaskEvent handles sparse payloads gracefully — all fields optional."""
+
+    def test_empty_payload_is_valid(self) -> None:
+        event = TaskEvent.model_validate({})
+        assert event.effective_status is None
+        assert event.status is None
+        assert event.newStatus is None
+        assert event.data is None
+        assert event.taskId is None
+        assert event.teamId is None
+
+    def test_unknown_fields_ignored(self) -> None:
+        event = TaskEvent.model_validate({"status": "done", "unknownField": "ignored"})
+        assert event.effective_status == "done"
+
+    def test_task_id_and_team_id_populated(self) -> None:
+        event = TaskEvent.model_validate({"taskId": "t-42", "teamId": "team-1", "status": "completed"})
+        assert event.taskId == "t-42"
+        assert event.teamId == "team-1"
+        assert event.effective_status == "completed"
+
+
+class TestTaskEventResolutionPriority:
+    """Verify the three-way resolution priority: status > data.status > newStatus."""
+
+    def test_all_three_present_top_level_wins(self) -> None:
+        event = TaskEvent.model_validate({
+            "status": "completed",
+            "data": {"status": "running"},
+            "newStatus": "failed",
+        })
+        assert event.effective_status == "completed"
+
+    def test_nested_beats_new_status(self) -> None:
+        event = TaskEvent.model_validate({
+            "data": {"status": "running"},
+            "newStatus": "failed",
+        })
+        assert event.effective_status == "running"
+
+    def test_empty_status_string_falls_through_to_nested(self) -> None:
+        event = TaskEvent.model_validate({"status": "", "data": {"status": "running"}})
+        assert event.effective_status == "running"
+
+    def test_empty_status_string_falls_through_to_new_status(self) -> None:
+        event = TaskEvent.model_validate({"status": "", "newStatus": "completed"})
+        assert event.effective_status == "completed"
+
+    def test_none_status_falls_through(self) -> None:
+        event = TaskEvent.model_validate({"status": None, "newStatus": "completed"})
+        assert event.effective_status == "completed"


### PR DESCRIPTION
## Summary

- Adds `TaskEvent` Pydantic model to `src/keystone/models.py` with fields `status`, `newStatus`, `data` (optional nested dict), `taskId`, `teamId`, and a computed `effective_status`
- `@model_validator(mode="after")` normalizes status from three sources in priority order: top-level `status` → `data.status` (Hermes nested format, per issue #107) → `newStatus`
- Updates `NATSListener._on_task_event()` to accept raw message bytes and parse them through `TaskEvent.model_validate()` instead of raw dict access; invalid JSON and `ValidationError` produce structured warning logs and the event is dropped
- Bootstraps the `src/keystone/` Python package (absent from this branch's base) with `__init__.py`, `validation.py`, and `nats_listener.py`

## Test plan

- [x] 24 unit tests covering all three status resolution paths (flat, nested `data.status`, `newStatus`), priority ordering, empty/missing fields, and arbitrary payload shapes
- [x] All tests pass: `python3 -m pytest tests/test_task_event.py -v` → 24 passed

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)