### PR TITLE
ci: add build caching to CI pipeline

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -44,6 +44,14 @@ jobs:
       - name: Install build dependencies
         uses: ./.github/actions/install-build-deps
 
+      - name: Cache Conan packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.conan2
+          key: conan-${{ runner.os }}-${{ hashFiles('conanfile.py') }}
+          restore-keys: |
+            conan-${{ runner.os }}-
+
       - name: Compute build directory
         id: setup
         run: |
@@ -53,6 +61,23 @@ jobs:
           fi
           echo "build-dir=$BUILD_DIR" >> $GITHUB_OUTPUT
           echo "Building to: $BUILD_DIR"
+
+      - name: Cache FetchContent downloads
+        uses: actions/cache@v5
+        with:
+          path: ${{ steps.setup.outputs.build-dir }}/_deps
+          key: fetchcontent-${{ runner.os }}-${{ hashFiles('CMakeLists.txt') }}
+          restore-keys: |
+            fetchcontent-${{ runner.os }}-
+
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Configure sccache
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+          echo "CMAKE_C_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+          echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
 
       - name: Build with Makefile
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,23 @@ jobs:
           restore-keys: |
             conan-${{ runner.os }}-
 
+      - name: Cache FetchContent downloads
+        uses: actions/cache@v5
+        with:
+          path: build/x86.debug.${{ matrix.sanitizer }}/_deps
+          key: fetchcontent-${{ runner.os }}-${{ hashFiles('CMakeLists.txt') }}
+          restore-keys: |
+            fetchcontent-${{ runner.os }}-
+
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Configure sccache
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+          echo "CMAKE_C_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+          echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+
       - name: Install project dependencies
         run: make deps.native
 
@@ -120,6 +137,23 @@ jobs:
           restore-keys: |
             conan-${{ runner.os }}-
 
+      - name: Cache FetchContent downloads
+        uses: actions/cache@v5
+        with:
+          path: build/x86.release/_deps
+          key: fetchcontent-${{ runner.os }}-${{ hashFiles('CMakeLists.txt') }}
+          restore-keys: |
+            fetchcontent-${{ runner.os }}-
+
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Configure sccache
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+          echo "CMAKE_C_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+          echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+
       - name: Install project dependencies
         run: make deps.native
 
@@ -162,6 +196,23 @@ jobs:
           key: conan-${{ runner.os }}-${{ hashFiles('conanfile.py') }}
           restore-keys: |
             conan-${{ runner.os }}-
+
+      - name: Cache FetchContent downloads
+        uses: actions/cache@v5
+        with:
+          path: build/x86.debug.coverage/_deps
+          key: fetchcontent-${{ runner.os }}-${{ hashFiles('CMakeLists.txt') }}
+          restore-keys: |
+            fetchcontent-${{ runner.os }}-
+
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Configure sccache
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+          echo "CMAKE_C_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+          echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
 
       - name: Install project dependencies
         run: make deps.native

--- a/.github/workflows/profiling-weekly.yml
+++ b/.github/workflows/profiling-weekly.yml
@@ -25,6 +25,20 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Cache FetchContent downloads
+        uses: actions/cache@v5
+        with:
+          path: build/profiling/_deps
+          key: fetchcontent-profiling-${{ runner.os }}-${{ hashFiles('CMakeLists.txt') }}
+          restore-keys: |
+            fetchcontent-profiling-${{ runner.os }}-
+
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Configure sccache
+        run: echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -45,7 +59,9 @@ jobs:
         run: |
           mkdir -p build/profiling
           cd build/profiling
-          cmake -S ../.. -DCMAKE_BUILD_TYPE=Release -DENABLE_PROFILING=ON -G Ninja
+          cmake -S ../.. -DCMAKE_BUILD_TYPE=Release -DENABLE_PROFILING=ON -G Ninja \
+            -DCMAKE_C_COMPILER_LAUNCHER=sccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
           ninja profiling_tests
 
       - name: Run profiling tests

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -95,6 +95,14 @@ jobs:
           conan install . --output-folder=build/conan-deps --build=missing -s build_type=Debug -s compiler.cppstd=20
           conan install . --output-folder=build/conan-deps --build=missing -s build_type=Release -s compiler.cppstd=20
 
+      - name: Cache FetchContent downloads
+        uses: actions/cache@v5
+        with:
+          path: build/codeql/_deps
+          key: fetchcontent-codeql-${{ runner.os }}-${{ hashFiles('CMakeLists.txt') }}
+          restore-keys: |
+            fetchcontent-codeql-${{ runner.os }}-
+
       - name: Build for CodeQL
         run: |
           cmake -S . -B build/codeql -G Ninja -DCMAKE_BUILD_TYPE=Debug \


### PR DESCRIPTION
## Summary

- Add `actions/cache@v5` for Conan packages (`~/.conan2`) and FetchContent downloads (`_deps/`) across all CI jobs that build
- Add `mozilla-actions/sccache-action@v0.0.9` for compiler output caching in all build jobs (except `codeql-analysis` where it would interfere with CodeQL's build tracing)
- Cache keys are keyed on `conanfile.py` (Conan) and `CMakeLists.txt` (FetchContent); `restore-keys` allow partial hits across branches

## Files changed

| File | Change |
|---|---|
| `.github/workflows/ci.yml` | Conan + FetchContent + sccache in `sanitizers`, `benchmarks`, `coverage` jobs |
| `.github/workflows/build-and-test.yml` | Conan + FetchContent + sccache in reusable workflow |
| `.github/workflows/security-scan.yml` | FetchContent cache in `codeql-analysis` job only |
| `.github/workflows/profiling-weekly.yml` | FetchContent + sccache; `-DCMAKE_*_COMPILER_LAUNCHER=sccache` added to cmake invocation |

## Test plan

- [ ] First run after merge: all cache steps show "Cache not found" and populate — build time unchanged
- [ ] Second run on same branch: Conan and FetchContent steps show "Cache restored" — dependency downloads skipped
- [ ] sccache hit rate: check sccache-action summary in job output — target >70% on same-branch pushes
- [ ] `codeql-analysis` job continues to build successfully without sccache
- [ ] Sanitizer matrix (ASan/UBSan/TSan/LSan) all pass with sccache launcher active

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)