### PR TITLE
ci: make security scan failures blocking

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -28,7 +28,6 @@ jobs:
         uses: gitleaks/gitleaks-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        continue-on-error: true
 
       - name: Upload Gitleaks results
         if: always()
@@ -53,7 +52,6 @@ jobs:
             p/cpp
             p/docker
             p/cmake
-        continue-on-error: true
 
       - name: Upload Semgrep SARIF
         if: always() && hashFiles('semgrep.sarif') != ''
@@ -133,7 +131,6 @@ jobs:
       - name: Build Docker image for scanning
         run: |
           docker build --target production -t projectkeystone:scan .
-        continue-on-error: true
 
       - name: Run Trivy vulnerability scanner (table format)
         uses: aquasecurity/trivy-action@master
@@ -142,7 +139,6 @@ jobs:
           format: 'table'
           exit-code: '0'  # Don't fail on vulnerabilities (report only)
           severity: 'CRITICAL,HIGH,MEDIUM'
-        continue-on-error: true
 
       - name: Run Trivy vulnerability scanner (SARIF format)
         uses: aquasecurity/trivy-action@master
@@ -151,7 +147,7 @@ jobs:
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH,MEDIUM,LOW'
-        continue-on-error: true
+        continue-on-error: true  # SARIF upload can fail on GitHub API issues without being a security concern
 
       - name: Upload Trivy results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v4
@@ -167,7 +163,6 @@ jobs:
           format: 'json'
           output: 'trivy-results.json'
           severity: 'CRITICAL,HIGH,MEDIUM,LOW'
-        continue-on-error: true
 
       - name: Parse Trivy results
         id: trivy-summary
@@ -216,12 +211,12 @@ jobs:
 
           if [ "$CRITICAL" -gt 0 ]; then
             echo "::error::Found $CRITICAL critical vulnerabilities in Docker image"
-            echo "::warning::Review the Trivy scan results in the Security tab"
-            # Don't fail - let security team review
+            exit 1
           fi
 
           if [ "$HIGH" -gt 10 ]; then
-            echo "::warning::Found $HIGH high-severity vulnerabilities in Docker image"
+            echo "::error::Found $HIGH high-severity vulnerabilities in Docker image (threshold: 10)"
+            exit 1
           fi
 
   supply-chain-scanning:


### PR DESCRIPTION
## Summary

- Remove `continue-on-error: true` from Gitleaks (secret scanning) and Semgrep (SAST) — these are critical scanners and failures must block the pipeline
- Remove `continue-on-error: true` from Docker build step and Trivy JSON scanner so the downstream vulnerability check receives real data
- Keep `continue-on-error: true` only on the Trivy SARIF step, which can fail due to GitHub API quota/connectivity issues that are unrelated to actual security findings
- Fix the `Check for critical vulnerabilities` step to actually `exit 1` on CRITICAL vulns or HIGH > 10, instead of just emitting `::warning::` annotations that were silently ignored

## Test plan

- [ ] Verify Gitleaks step now blocks the `secret-scanning` job on findings
- [ ] Verify Semgrep step now blocks the `sast-scanning` job on findings
- [ ] Verify Docker build failures block `docker-image-scanning` (no scan runs on a broken image)
- [ ] Verify Trivy SARIF step still has `continue-on-error: true` (GitHub API failures don't block)
- [ ] Verify `Check for critical vulnerabilities` exits non-zero on CRITICAL or HIGH > 10

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)