### PR TITLE
docs: update stale docs/plan/README.md to reflect transport-layer scope

### DIFF
--- a/docs/plan/README.md
+++ b/docs/plan/README.md
@@ -1,402 +1,112 @@
 # ProjectKeystone Implementation Plan
 
+> **Status**: Superseded by ADR-006 — this document has been updated to reflect the
+> current project scope. The original HMAS agent orchestration plan was migrated to
+> **ProjectAgamemnon** when Keystone was decoupled from ai-maestro.
+
 ## Executive Summary
 
-ProjectKeystone is a high-performance C++20 Hierarchical Multi-Agent System (HMAS) designed for orchestrating specialized AI agents in complex, enterprise-grade workloads. The system implements an actor-model architecture with **four distinct hierarchical layers** (L0: Chief Architect, L1: Component Lead, L2: Module Lead, L3: Task Agent), leveraging modern C++20 features including coroutines, modules, and advanced concurrency primitives.
+ProjectKeystone is a C++20 **transport infrastructure library** providing invisible,
+zero-configuration message routing for all HomericIntelligence components. It is not
+an agent system, pipeline stage, or orchestrator — it is the invisible plumbing
+beneath every other component.
 
-## 🚀 Development Approach: TDD with E2E Testing + 4-Layer Architecture
+The system bridges two complementary transports transparently:
 
-**This project follows strict Test-Driven Development (TDD) with End-to-End (E2E) tests as the primary validation method.**
+- **Local transport**: BlazingMQ + lock-free `concurrentqueue` for intra-host routing
+- **Cross-host transport**: NATS JetStream over Tailscale WireGuard mesh
 
-We build incrementally, starting with a **minimal 2-agent system** (Level 0 + Level 3) and progressively adding intermediate layers until we reach the full **4-layer hierarchy**:
+## Architecture Decision Records
 
-- **Level 0**: Chief Architect Agent - Strategic decisions, system-wide coordination
-- **Level 1**: Component Lead Agent - Component-level architecture, module coordination
-- **Level 2**: Module Lead Agent - Task decomposition, result synthesis, code review
-- **Level 3**: Task Agent - Concrete execution, code implementation, testing
+The `adr/` subdirectory contains all architectural decisions:
 
-This architecture mirrors the agent development structure used to build the system itself, creating a self-similar, fractal-like organization.
-
-👉 **See [TDD_FOUR_LAYER_ROADMAP.md](TDD_FOUR_LAYER_ROADMAP.md) for the complete implementation plan**
-
-## Vision
-
-Build a production-ready, native C++ agent orchestration platform capable of:
-
-- Processing 1M+ messages per second
-- Managing hundreds of concurrent specialized agents
-- Providing sub-millisecond internal communication latency
-- Ensuring graceful degradation and failure recovery
-- Scaling horizontally across distributed systems
-
-## Documentation Structure
-
-### 🔴 Start Here
-
-1. **[TDD_FOUR_LAYER_ROADMAP.md](TDD_FOUR_LAYER_ROADMAP.md)** - **READ THIS FIRST!** Complete TDD roadmap with E2E tests
-2. **[FOUR_LAYER_ARCHITECTURE.md](FOUR_LAYER_ARCHITECTURE.md)** - 4-layer system architecture specification
-3. **README.md** (this file) - Overview and quick start
-
-### 📘 Supporting Documentation
-
-4. **[modules.md](modules.md)** - C++20 module structure and dependencies
-5. **[build-system.md](build-system.md)** - CMake configuration and toolchain setup
-6. **[testing-strategy.md](testing-strategy.md)** - Testing frameworks and tools (GoogleTest, benchmarks)
-7. **[risks.md](risks.md)** - Risk analysis and mitigation strategies
-8. **[MIGRATION_ARCHITECTURE_C2_C3.md](MIGRATION_ARCHITECTURE_C2_C3.md)** - C2/C3 architecture migration guide
-
-### 🏗️ Architecture Decision Records (ADRs)
-
-- **[adr/](adr/)** - Architecture Decision Records documenting key design choices
-  - ADR-001: MessageBus Architecture
-  - ADR-002: Work-Stealing Scheduler Architecture
-  - ADR-003: Async Agent Unification
-  - ADR-010: Architecture Issue Resolution
-  - ADR-011: Phase 6 Architecture Review Fixes
-  - ADR-012: CPack Build System Decisions
+| ADR | Title |
+|-----|-------|
+| [ADR-001](adr/ADR-001-message-bus-architecture.md) | MessageBus Architecture |
+| [ADR-002](adr/ADR-002-work-stealing-scheduler-architecture.md) | Work-Stealing Scheduler Architecture |
+| [ADR-003](adr/ADR-003-priority-queue-anti-starvation-strategy.md) | Priority Queue Anti-Starvation Strategy |
+| [ADR-004](adr/ADR-004-coroutine-integration-with-scheduler.md) | Coroutine Integration with Scheduler |
+| [ADR-005](adr/ADR-005-message-pool-design.md) | Message Pool Design |
+| [ADR-006](adr/ADR-006-agent-interface-type-safety-concepts.md) | Agent Interface Type Safety (Concepts) |
+| [ADR-007](adr/ADR-007-shared-ptr-migration.md) | Shared Pointer Migration |
+| [ADR-008](adr/ADR-008-async-agent-unification.md) | Async Agent Unification |
+| [ADR-009](adr/ADR-009-message-processing-strategy-pattern.md) | Message Processing Strategy Pattern |
+| [ADR-010](adr/ADR-010-architecture-issue-resolution.md) | Architecture Issue Resolution |
+| [ADR-011](adr/ADR-011-phase-6-architecture-review-fixes.md) | Phase 6 Architecture Review Fixes |
+| [ADR-012](adr/ADR-012-cpack-build-system-decisions.md) | CPack Build System Decisions |
+| [ADR-013](adr/ADR-013-coroutine-safety-patterns.md) | Coroutine Safety Patterns |
 
 ## Project Directory Structure
 
 ```
 ProjectKeystone/
-├── docs/
-│   ├── plan/                    # This implementation plan
-│   ├── architecture/            # Architectural Decision Records (ADRs)
-│   ├── api/                     # API documentation
-│   └── guides/                  # User and developer guides
-├── modules/
-│   ├── Keystone.Core/           # Core infrastructure
-│   │   ├── concurrency/         # Thread pool, coroutines, synchronization
-│   │   ├── messaging/           # Message bus, queues, routing
-│   │   └── utilities/           # Common utilities
-│   ├── Keystone.Protocol/       # Communication protocols
-│   │   ├── kim/                 # Keystone Inter-Agent Message
-│   │   ├── serialization/       # Cista, FlatBuffers integration
-│   │   └── grpc/                # gRPC protocol definitions
-│   ├── Keystone.Agents/         # Agent implementations
-│   │   ├── base/                # AgentBase and common infrastructure
-│   │   ├── root/                # Root (L1) agents
-│   │   ├── branch/              # Branch (L2) agents
-│   │   └── leaf/                # Leaf (L3) agents
-│   └── Keystone.Integration/    # External integrations
-│       ├── onnx/                # ONNX Runtime integration
-│       ├── grpc-client/         # gRPC client implementations
-│       └── monitoring/          # APM and metrics
+├── include/                         # Public headers
+│   ├── agents/
+│   ├── concurrency/
+│   ├── core/
+│   ├── monitoring/
+│   ├── network/
+│   └── simulation/
+├── src/                             # Implementation
+│   ├── agents/
+│   ├── concurrency/
+│   ├── core/
+│   ├── monitoring/
+│   ├── network/
+│   └── simulation/
 ├── tests/
-│   ├── unit/                    # Unit tests per module
-│   ├── integration/             # Cross-module integration tests
-│   ├── performance/             # Performance benchmarks
-│   └── stress/                  # Stress and chaos testing
+│   ├── unit/
+│   ├── integration/
+│   ├── e2e/
+│   ├── load/
+│   ├── fixtures/
+│   └── mocks/
+├── benchmarks/
 ├── examples/
-│   ├── basic/                   # Simple usage examples
-│   ├── advanced/                # Complex workflow examples
-│   └── benchmarks/              # Performance demonstration
-├── tools/
-│   ├── generators/              # Code generation tools
-│   ├── analyzers/               # Static analysis scripts
-│   └── profilers/               # Performance profiling tools
-├── third_party/                 # External dependencies
-├── cmake/                       # CMake modules and scripts
-├── .github/
-│   └── workflows/               # CI/CD pipeline definitions
-├── CMakeLists.txt               # Root CMake configuration
-└── vcpkg.json                   # Dependency manifest
+├── docs/
+│   ├── plan/                        # This directory — implementation plans and ADRs
+│   │   └── adr/                     # Architecture Decision Records
+│   ├── phases/                      # Phase completion summaries
+│   ├── profiling/
+│   └── runbooks/
+├── conan/                           # Conan 2 dependency definitions
+├── cmake/                           # CMake modules and scripts
+├── helm/, k8s/                      # Deployment configs
+├── monitoring/, grafana/            # Observability configuration
+├── schemas/, proto/                 # Message schemas
+├── scripts/
+├── CMakeLists.txt
+├── CMakePresets.json                # Preset-based build configuration (v8)
+├── conanfile.py                     # Conan 2 package manifest
+├── justfile                         # Developer workflow shortcuts
+└── Makefile                         # Alternative build entry point
 ```
 
-## TDD Implementation Roadmap (Revised)
-
-### 🎯 Core Principle: E2E Tests Drive Development
-
-Every phase begins with writing **failing E2E tests** that define the desired behavior, then implementing the minimal code to make them pass.
-
-### Phase 0: E2E Test Infrastructure (Week 1)
-
-**Goal**: Set up the ability to write and run E2E tests
-
-**First E2E Test (Even Though Nothing Exists)**:
-
-```cpp
-TEST(E2E_Foundation, CanCreateAndRunTwoAgents) {
-    ThreadPool pool{2};
-    auto agent1 = std::make_unique<MinimalAgent>("agent1");
-    auto agent2 = std::make_unique<MinimalAgent>("agent2");
-
-    agent1->initialize();
-    agent2->initialize();
-
-    EXPECT_TRUE(agent1->isRunning());
-    EXPECT_TRUE(agent2->isRunning());
-}
-```
-
-**Deliverables**:
-
-- ✅ E2E test framework (GoogleTest)
-- ✅ CMake builds and runs E2E tests
-- ✅ First test passes (minimal agent stub)
-- ✅ CI runs E2E tests on every commit
-
-### Phase 1: Core Message Passing (Weeks 2-3)
-
-**Goal**: Two agents can send messages to each other
-
-**E2E Test First**:
-
-```cpp
-TEST(E2E_MessagePassing, AgentCanSendMessageToAnotherAgent) {
-    ThreadPool pool{2};
-    MessageBus bus;
-    auto sender = std::make_unique<TestAgent>("sender");
-    auto receiver = std::make_unique<TestAgent>("receiver");
-
-    sender->send(msg);
-    auto received = receiver->waitForMessage(1s);
-
-    EXPECT_EQ(received->payload, "Hello");
-}
-```
-
-**Deliverables**:
-
-- ✅ KeystoneMessage structure
-- ✅ MessageQueue with concurrentqueue
-- ✅ MessageBus routing
-- ✅ Custom awaitable for async receiving
-- ✅ **E2E test: Bidirectional agent communication**
-
-### Phase 2: Coordinator-Worker Pattern (Weeks 4-5)
-
-**Goal**: Coordinator delegates task to Worker, receives result
-
-**E2E Test First**:
-
-```cpp
-TEST(E2E_Delegation, CoordinatorDelegatesAndAggregates) {
-    auto coordinator = std::make_unique<CoordinatorAgent>();
-    auto worker = std::make_unique<WorkerAgent>();
-
-    auto result = coordinator->processGoal("Calculate: 2+2");
-
-    EXPECT_EQ(result.get(), "Result: 4");
-}
-```
-
-**Deliverables**:
-
-- ✅ CoordinatorAgent with task decomposition
-- ✅ WorkerAgent with execution
-- ✅ Agent state machines
-- ✅ **E2E test: Complete task delegation workflow**
-
-### Phase 3: Performance & Concurrency (Week 6)
-
-**Goal**: Validate performance targets with E2E tests
-
-**E2E Test First**:
-
-```cpp
-TEST(E2E_Performance, ThousandTasksPerSecond) {
-    // Send 1000 tasks, verify completes in <1 second
-    EXPECT_LT(duration_ms, 1000);
-}
-```
-
-**Deliverables**:
-
-- ✅ Performance optimizations
-- ✅ ThreadSanitizer validation
-- ✅ **E2E test: >1000 tasks/second**
-
-### Phase 4: External Integration (Weeks 7-8)
-
-**Goal**: Worker can call external AI services (gRPC)
-
-**E2E Test First**:
-
-```cpp
-TEST(E2E_AIIntegration, WorkerCallsExternalAIService) {
-    MockAIService mock_service("localhost:50051");
-    auto worker = std::make_unique<WorkerAgent>();
-    worker->setAIServiceEndpoint("localhost:50051");
-
-    auto result = coordinator->processGoal("Generate: Hello");
-
-    EXPECT_EQ(result.get(), "AI Response: Hi there!");
-}
-```
-
-**Deliverables**:
-
-- ✅ Mock gRPC AI service
-- ✅ Async gRPC client
-- ✅ Serialization gateway (Cista ↔ Protobuf)
-- ✅ **E2E test: Worker calls external AI**
-
-### Phase 5: Three-Layer Hierarchy (Weeks 9-11)
-
-**Goal**: Expand to full Root → Branch → Leaf
-
-**E2E Test First**:
-
-```cpp
-TEST(E2E_ThreeLayer, ComplexTaskDecomposition) {
-    auto root = createFullHierarchy(/*branches=*/3, /*leaves=*/9);
-
-    auto result = root->processGoal("Complex multi-step task");
-
-    // Verify all layers participated
-    EXPECT_GT(root->getTasksProcessed(), 0);
-    EXPECT_GT(branches[0]->getTasksProcessed(), 0);
-    EXPECT_GT(leaves[0]->getTasksProcessed(), 0);
-}
-```
-
-**Deliverables**:
-
-- ✅ RootAgent (evolved from Coordinator)
-- ✅ BranchAgent (new middle layer)
-- ✅ LeafAgent (evolved from Worker)
-- ✅ **E2E test: 3-layer hierarchy works**
-
-### Phase 6: Production Hardening (Weeks 12-14)
-
-**Goal**: Chaos testing and production readiness
-
-**E2E Test First**:
-
-```cpp
-TEST(E2E_Chaos, SystemRemainsStableUnderFailures) {
-    auto system = createFullHierarchy();
-
-    // Inject random failures while processing 1000 tasks
-    injectChaos(system);
-    auto completed = processTasksBatch(1000);
-
-    EXPECT_GT(completed, 900);  // >90% success despite chaos
-}
-```
-
-**Deliverables**:
-
-- ✅ Graceful shutdown
-- ✅ Failure recovery
-- ✅ **E2E test: 24-hour stability**
-- ✅ **E2E test: Chaos resilience**
-
-## Technology Stack
-
-### Core Technologies
-
-- **Language**: C++20 (GCC 13+, Clang 16+, or MSVC 2022+)
-- **Build System**: CMake 3.28+
-- **Package Manager**: vcpkg or Conan
-- **Version Control**: Git
-
-### Key Libraries
-
-- **Concurrency**: `concurrentqueue` (lock-free queue)
-- **Serialization**: Cista (zero-copy), FlatBuffers
-- **RPC**: gRPC with Protocol Buffers
-- **AI Integration**: ONNX Runtime
-- **Testing**: GoogleTest, Google Benchmark
-- **Logging**: spdlog
-- **Monitoring**: Prometheus C++ client
-
-### Development Tools
-
-- **Static Analysis**: clang-tidy, cppcheck
-- **Formatting**: clang-format
-- **Profiling**: perf, Valgrind, Tracy
-- **Documentation**: Doxygen, Sphinx
-
-## Success Criteria
-
-### Performance Targets
-
-- **Throughput**: 1M+ messages/second on standard hardware
-- **Latency**: <1ms p99 internal message delivery
-- **Scalability**: Linear scaling to 1000+ concurrent agents
-- **Memory**: <100MB overhead for core framework
-
-### Quality Targets
-
-- **Test Coverage**: >95% for Keystone.Core, >90% for agents
-- **Build Time**: <5 minutes for full rebuild
-- **Documentation**: 100% API coverage
-- **Static Analysis**: Zero critical issues
-
-### Reliability Targets
-
-- **Availability**: Graceful shutdown with zero data loss
-- **Recovery**: <100ms failure detection and recovery
-- **Isolation**: Complete session context separation
-- **Supervision**: Automatic recovery from agent failures
-
-## Team Requirements
-
-### Core Team
-
-- **Senior C++ Engineer** (Lead) - 1 FTE
-  - C++20 expertise, coroutines, concurrency
-  - System architecture and design
-
-- **C++ Engineers** - 2-3 FTEs
-  - Modern C++ development
-  - Testing and optimization
-
-- **DevOps Engineer** - 0.5 FTE
-  - CI/CD, build systems
-  - Deployment and monitoring
-
-### Specialized Skills Needed
-
-- C++20 modules and coroutines
-- High-performance concurrent systems
-- Actor-model architecture
-- gRPC and Protocol Buffers
-- ONNX Runtime integration
-- Performance profiling and optimization
-
-## Timeline Summary
-
-- **Total Duration**: 20 weeks (5 months)
-- **Phase 0-1**: Infrastructure (5 weeks)
-- **Phase 2-3**: Agent Framework (6 weeks)
-- **Phase 4-5**: Integration (5 weeks)
-- **Phase 6-7**: Hardening (4 weeks)
-
-## Next Steps
-
-1. **Immediate Actions**:
-   - Review and approve this implementation plan
-   - Assemble the development team
-   - Set up development environment
-   - Create project repository structure
-
-2. **Week 1 Priorities**:
-   - Initialize CMake build system
-   - Configure CI/CD pipeline
-   - Set up dependency management
-   - Create coding standards document
-
-3. **Key Decisions Made**:
-   - ✅ Testing framework: Google Test (GTest)
-   - ✅ Logging library: spdlog
-   - Future decisions needed:
-     - Package manager (vcpkg vs Conan)
-     - Monitoring solution (Prometheus vs alternatives)
-
-## References
-
-- [Architecture Details](architecture.md)
-- [Implementation Phases](phases.md)
-- [Module Structure](modules.md)
-- [Build System](build-system.md)
-- [Testing Strategy](testing-strategy.md)
-- [Risk Analysis](risks.md)
+## Performance Targets
+
+| Metric | Target |
+|--------|--------|
+| Local routing latency | < 500 ns |
+| Local throughput | > 2 M msg/sec |
+| Cross-host delivery | At-least-once via NATS JetStream |
+
+## What Was Moved to ProjectAgamemnon
+
+The following are **no longer part of Keystone**:
+
+- L0 `ChiefArchitectAgent` (Chief Architect)
+- L1 `ComponentLeadAgent` (Component Lead)
+- L2 `ModuleLeadAgent` (Module Lead)
+- L3 `TaskAgent` (Task Agent)
+- HMAS 4-layer hierarchy design and TDD roadmap
+- Delegation and escalation logic
+- Work-stealing scheduler (agent-level)
+
+See CLAUDE.md at the repository root for the authoritative description of the
+current project scope.
 
 ---
 
-**Document Version**: 1.0
-**Last Updated**: 2025-11-17
-**Status**: Draft - Pending Approval
+**Document Version**: 2.0
+**Last Updated**: 2026-04-22
+**Status**: Current — reflects post-ADR-006 transport-only scope


### PR DESCRIPTION
## Summary

- Rewrites `docs/plan/README.md` which was marked `Status: Draft - Pending Approval` and last updated 2025-11-17 (5+ months stale)
- Replaces the outdated HMAS 4-layer agent orchestration plan with an accurate description of Keystone as a pure transport layer per ADR-006
- Updates the directory structure section to match the actual repo layout (`src/`, `include/`, `tests/`, etc.) instead of the old `modules/Keystone.Core`, `modules/Keystone.Agents` layout
- Adds a complete ADR table listing all 13 current ADRs
- Marks document status as current (supersedes the stale "Draft - Pending Approval")

CLAUDE.md was already current (last updated 2026-03-28) and required no changes.

## Test plan

- [ ] Review `docs/plan/README.md` to confirm it no longer references the 4-layer HMAS hierarchy
- [ ] Confirm directory structure in the doc matches `ls src/ include/ tests/`
- [ ] Confirm ADR table matches files in `docs/plan/adr/`
- [ ] No source code changes — documentation only

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)