### PR TITLE
fix(ci): guard Trivy image scan on Docker build success; add libssl-dev to builder

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -199,20 +199,28 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Build Docker image for scanning
+        id: docker_build
         run: |
           docker build --target production -t projectkeystone:scan .
         continue-on-error: true
 
+      - name: Warn if Docker build failed
+        if: steps.docker_build.outcome == 'failure'
+        run: |
+          echo "::warning::Docker build failed — skipping image scan. Fix the Dockerfile to enable Trivy container scanning."
+
       - name: Run Trivy vulnerability scanner (table format)
+        if: steps.docker_build.outcome == 'success'
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: 'projectkeystone:scan'
           format: 'table'
-          exit-code: '0'  # Don't fail on vulnerabilities (report only)
+          exit-code: '0'
           severity: 'CRITICAL,HIGH,MEDIUM'
         continue-on-error: true
 
       - name: Run Trivy vulnerability scanner (SARIF format)
+        if: steps.docker_build.outcome == 'success'
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: 'projectkeystone:scan'
@@ -222,13 +230,14 @@ jobs:
         continue-on-error: true
 
       - name: Upload Trivy results to GitHub Security tab
+        if: steps.docker_build.outcome == 'success' && hashFiles('trivy-results.sarif') != ''
         uses: github/codeql-action/upload-sarif@v4
-        if: always()
         with:
           sarif_file: 'trivy-results.sarif'
           category: 'trivy-container-scan'
 
       - name: Run Trivy vulnerability scanner (JSON format)
+        if: steps.docker_build.outcome == 'success'
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: 'projectkeystone:scan'
@@ -242,17 +251,14 @@ jobs:
         if: always()
         run: |
           if [ -f trivy-results.json ]; then
-            # Count vulnerabilities by severity
             CRITICAL=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity=="CRITICAL")] | length' trivy-results.json)
             HIGH=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity=="HIGH")] | length' trivy-results.json)
             MEDIUM=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity=="MEDIUM")] | length' trivy-results.json)
             LOW=$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity=="LOW")] | length' trivy-results.json)
-
             echo "critical=$CRITICAL" >> $GITHUB_OUTPUT
             echo "high=$HIGH" >> $GITHUB_OUTPUT
             echo "medium=$MEDIUM" >> $GITHUB_OUTPUT
             echo "low=$LOW" >> $GITHUB_OUTPUT
-
             echo "### Trivy Scan Summary" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "- **Critical**: $CRITICAL" >> $GITHUB_STEP_SUMMARY
@@ -264,6 +270,8 @@ jobs:
             echo "high=0" >> $GITHUB_OUTPUT
             echo "medium=0" >> $GITHUB_OUTPUT
             echo "low=0" >> $GITHUB_OUTPUT
+            echo "### Trivy Scan Skipped" >> $GITHUB_STEP_SUMMARY
+            echo "Docker build failed — no image to scan." >> $GITHUB_STEP_SUMMARY
           fi
 
       - name: Upload Trivy scan results
@@ -281,13 +289,10 @@ jobs:
         run: |
           CRITICAL="${{ steps.trivy-summary.outputs.critical }}"
           HIGH="${{ steps.trivy-summary.outputs.high }}"
-
           if [ "$CRITICAL" -gt 0 ]; then
             echo "::error::Found $CRITICAL critical vulnerabilities in Docker image"
             echo "::warning::Review the Trivy scan results in the Security tab"
-            # Don't fail - let security team review
           fi
-
           if [ "$HIGH" -gt 10 ]; then
             echo "::warning::Found $HIGH high-severity vulnerabilities in Docker image"
           fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN apt-get update && apt-get install -y \
     bc \
     gcovr \
     python3-pip \
+    libssl-dev \
     && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-18 100 \
     && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-18 100 \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/clang-18 100 \


### PR DESCRIPTION
## Summary

- Add `id: docker_build` to Docker build step; gate all Trivy image-scan steps on `steps.docker_build.outcome == 'success'`
- Replace unconditional `if: always()` on the SARIF upload (which failed with "Path does not exist" when no image was built) with a `hashFiles` guard
- Add `libssl-dev` to Dockerfile builder-stage so the Docker build succeeds when nats.c (which requires `openssl/ssl.h`) is added as a FetchContent dependency

**Root cause of the failure:** `docker build` was failing silently (`continue-on-error: true`) because nats.c needs OpenSSL headers not present in the image. Trivy then tried to scan a non-existent image, produced no SARIF file, and the upload step failed hard — causing `security-report` to see a failed upstream job and emit ❌, which triggered "Check for critical issues" to exit 1.

## Test plan

- [ ] CI passes on this PR (Security Scanning workflow goes green)
- [ ] `docker-image-scanning` job completes successfully even if Docker build fails (shows ⚠️ warning, skips scan)
- [ ] `security-report` job no longer emits ❌ for a skipped image scan

Closes #359
Closes #362

🤖 Generated with [Claude Code](https://claude.com/claude-code)