### PR TITLE
chore(python): pin test deps, fix conftest path, configure pytest-asyncio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,16 +12,18 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "mypy>=1.8.0",
+    "mypy>=1.8.0,<2",
     "conan>=2.27.1",
-    "pytest>=8.0",
+    "pytest>=8.0,<10",
     "pytest-asyncio>=0.23",
-    "pytest-cov>=5.0",
+    "pytest-cov>=5.0,<7",
 ]
 
 [tool.pytest.ini_options]
 addopts = "--cov=src/keystone --cov-report=term-missing --cov-report=xml"
 testpaths = ["tests"]
+pythonpath = ["src"]
+asyncio_mode = "auto"
 
 [tool.coverage.run]
 branch = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,1 @@
-import sys
-import os
-
-# Ensure src/ is on the path for imports
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+# PYTHONPATH configured in pyproject.toml [tool.pytest.ini_options]


### PR DESCRIPTION
## Summary

Resolves issues with pytest configuration and dependency versioning:

- Pin mypy to <2, pytest to <10, pytest-cov to <7 for stability
- Add pythonpath = ["src"] to pyproject.toml pytest.ini_options
- Add asyncio_mode = "auto" to pyproject.toml pytest.ini_options
- Remove sys.path hack from tests/conftest.py in favor of proper pytest config

Closes #238
Closes #237
Closes #231
Closes #215
Closes #201
Closes #191
Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)