### PR TITLE
docs(security): add out-of-scope section and private reporting instructions

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,7 +3,7 @@
 ## Supported Versions
 
 | Version | Supported          |
-|---------|--------------------|
+|---------|-------------------|
 | 0.1.x   | :white_check_mark: |
 
 ## Reporting a Vulnerability
@@ -12,15 +12,20 @@ If you discover a security vulnerability in ProjectKeystone, please report it re
 
 **Do NOT open a public GitHub issue for security vulnerabilities.**
 
-Instead, please report vulnerabilities by emailing the maintainers directly or by using
-[GitHub's private vulnerability reporting](https://github.com/HomericIntelligence/ProjectKeystone/security/advisories/new).
+### Reporting via GitHub Security Advisories (Recommended)
+
+Private vulnerability reporting via [GitHub Security Advisories](https://github.com/HomericIntelligence/ProjectKeystone/security/advisories/new) is **enabled** for this repository. This is the preferred method for reporting vulnerabilities as it provides a private communication channel between you and the maintainers.
 
 ### What to include
 
-- Description of the vulnerability
-- Steps to reproduce
-- Potential impact
-- Suggested fix (if any)
+When reporting a vulnerability, please provide:
+
+- **Component**: Which component is affected (e.g., `MessageBus`, `NATS client`, `Docker container`)
+- **Version**: The affected version of ProjectKeystone (e.g., 0.1.x)
+- **Description**: A clear description of the vulnerability
+- **Steps to reproduce**: Detailed steps to reproduce the issue
+- **Potential impact**: The security impact and severity (e.g., privilege escalation, data leak, DoS)
+- **Suggested fix**: Any proposed remediation or patch (if available)
 
 ### Response timeline
 
@@ -31,10 +36,24 @@ Instead, please report vulnerabilities by emailing the maintainers directly or b
 ### Scope
 
 The following are in scope:
+
 - C++ source code in `src/` and `include/`
 - Docker/container configurations
 - CI/CD pipeline configurations
 - Kubernetes deployment manifests
+
+### Out of scope
+
+The following items are explicitly **NOT** covered by this security policy:
+
+- Denial of Service via resource exhaustion (e.g., flooding message queues beyond configured limits)
+- Social engineering attacks against maintainers or users
+- Vulnerabilities in third-party dependencies already tracked and monitored by Dependabot
+- Physical security issues requiring direct access to the host machine or network infrastructure
+- Issues in external services or platforms that ProjectKeystone depends on (NATS, BlazingMQ)
+- Attacks involving compromised or untrusted dependencies at build time
+- Security issues in user code or applications that use ProjectKeystone
+- Vulnerabilities in the Tailscale mesh network itself
 
 ### Credit policy
 


### PR DESCRIPTION
Closes #271
Closes #270

## Summary

This PR implements two security policy enhancements:

### Issue #271: Out of Scope Exclusions
Added a new "Out of Scope" section to SECURITY.md that explicitly lists items NOT covered by the security policy:
- Denial of Service via resource exhaustion (message queue flooding)
- Social engineering attacks
- Vulnerabilities in third-party dependencies tracked by Dependabot
- Physical security and access attacks
- Issues in external services (NATS, BlazingMQ)
- Build-time and supply chain attacks
- User code vulnerabilities
- Tailscale mesh vulnerabilities

### Issue #270: GitHub Security Advisories Private Reporting
Enhanced the "Reporting a Vulnerability" section to:
- Explicitly state that GitHub Security Advisories private reporting is **enabled**
- Provide the direct link to the advisory creation form
- Update "What to include" subsection with clearer guidance on component, version, description, reproduction steps, impact/severity, and suggested fixes

## Changes
- Updated SECURITY.md with both enhancements
- Verified pre-commit hooks pass
- Conventional commit message format

Generated with Claude Code