### PR TITLE
feat(python): add py.typed marker for PEP 561 type checking

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ exclude_lines = [
     "\\.\\.\\.\\s*$",
 ]
 
+[tool.setuptools.package-data]
+keystone = ["py.typed"]
+
 [tool.mypy]
 python_version = "3.9"
 warn_return_any = true


### PR DESCRIPTION
Closes #134

Adds the `py.typed` marker file per PEP 561 to enable type checking support for installed packages.

## Changes
- Created empty `src/keystone/py.typed` marker file
- Added package-data configuration in `pyproject.toml` to include py.typed in distributions