### PR TITLE
ci: add CodeQL workflow with manual build mode for C++ and Python

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,73 @@
+name: CodeQL Analysis
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Run weekly on Sundays at 3 AM UTC
+    - cron: '0 3 * * 0'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: c-cpp
+            build-mode: manual
+          - language: python
+            build-mode: none
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-and-quality
+
+      # C++ manual build steps -- only run for c-cpp
+      - name: Install build dependencies
+        if: matrix.language == 'c-cpp'
+        run: |
+          sudo apt-get update && sudo apt-get install -y \
+            cmake ninja-build \
+            clang-18 clang++-18 \
+            libc++-18-dev libc++abi-18-dev \
+            libssl-dev
+          pip install conan --break-system-packages
+          conan profile detect --force
+          conan install . \
+            --output-folder=build/conan-deps \
+            --build=missing \
+            -s build_type=Release \
+            -s compiler.cppstd=20
+
+      - name: Build for CodeQL analysis
+        if: matrix.language == 'c-cpp'
+        run: |
+          cmake -S . -B build/codeql \
+            -G Ninja \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_TOOLCHAIN_FILE=build/conan-deps/conan_toolchain.cmake
+          cmake --build build/codeql
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/codeql-analysis.yml` with `build-mode: manual` for C++ so CodeQL's tracer can observe the full pixi/Conan/CMake build
- Uses a matrix strategy to analyze both `c-cpp` (manual build) and `python` (no build needed) in a single job definition
- Triggers on push to main, pull_request to main, and weekly schedule (Sundays at 03:00 UTC)
- Uses `github/codeql-action/init@v3` and `github/codeql-action/analyze@v3`

## Test plan

- [ ] Confirm the Actions tab shows the "CodeQL Analysis" workflow after merge
- [ ] Verify the c-cpp matrix job installs deps, runs `conan install`, and builds via CMake before CodeQL analysis
- [ ] Verify the python matrix job runs CodeQL analysis without any build steps
- [ ] Check GitHub Security tab for CodeQL results after first run

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)