### PR TITLE
chore(cmake): add asan and ubsan presets to CMakePresets.json

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -57,7 +57,30 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
         "ENABLE_COVERAGE": "OFF",
-        "ENABLE_GRPC": "OFF"
+        "ENABLE_GRPC": "OFF",
+        "CMAKE_CXX_FLAGS": "-fsanitize=thread"
+      }
+    },
+    {
+      "name": "asan",
+      "displayName": "Debug + AddressSanitizer",
+      "inherits": "base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "ENABLE_COVERAGE": "OFF",
+        "ENABLE_GRPC": "OFF",
+        "CMAKE_CXX_FLAGS": "-fsanitize=address,undefined"
+      }
+    },
+    {
+      "name": "ubsan",
+      "displayName": "Debug + UndefinedBehaviorSanitizer",
+      "inherits": "base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "ENABLE_COVERAGE": "OFF",
+        "ENABLE_GRPC": "OFF",
+        "CMAKE_CXX_FLAGS": "-fsanitize=undefined"
       }
     }
   ],
@@ -81,6 +104,14 @@
     {
       "name": "tsan",
       "configurePreset": "tsan"
+    },
+    {
+      "name": "asan",
+      "configurePreset": "asan"
+    },
+    {
+      "name": "ubsan",
+      "configurePreset": "ubsan"
     }
   ],
   "testPresets": [
@@ -115,6 +146,20 @@
     {
       "name": "tsan",
       "configurePreset": "tsan",
+      "output": {
+        "outputOnFailure": true
+      }
+    },
+    {
+      "name": "asan",
+      "configurePreset": "asan",
+      "output": {
+        "outputOnFailure": true
+      }
+    },
+    {
+      "name": "ubsan",
+      "configurePreset": "ubsan",
       "output": {
         "outputOnFailure": true
       }


### PR DESCRIPTION
## Summary
- Add `asan` configure/build/test presets with `-fsanitize=address,undefined`
- Add `ubsan` configure/build/test presets with `-fsanitize=undefined`
- Fix existing `tsan` configure preset to include `-fsanitize=thread` in `CMAKE_CXX_FLAGS`

## Test plan
- [ ] Verify `python3 -c "import json; d=json.load(open('CMakePresets.json')); print([p['name'] for p in d['configurePresets']])"` shows `asan` and `ubsan`
- [ ] Run `cmake --preset asan && cmake --build --preset asan && ctest --preset asan`
- [ ] Run `cmake --preset ubsan && cmake --build --preset ubsan && ctest --preset ubsan`
- [ ] Run `cmake --preset tsan && cmake --build --preset tsan && ctest --preset tsan`

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)