### PR TITLE
feat(nats_listener): add _parse_subject helper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -671,11 +671,18 @@ if(ENABLE_FUZZING)
   target_link_options(fuzz_retry_policy PRIVATE ${FUZZING_FLAGS})
   target_link_libraries(fuzz_retry_policy keystone_core)
 
+  # Fuzz test: Subject validator
+  add_executable(fuzz_subject_validator fuzz/fuzz_subject_validator.cpp)
+  target_compile_options(fuzz_subject_validator PRIVATE ${FUZZING_FLAGS})
+  target_link_options(fuzz_subject_validator PRIVATE ${FUZZING_FLAGS})
+  target_link_libraries(fuzz_subject_validator keystone_core)
+
   message(STATUS "Fuzz testing targets enabled:")
   message(STATUS "  - fuzz_message_serialization")
   message(STATUS "  - fuzz_message_bus_routing")
   message(STATUS "  - fuzz_work_stealing")
   message(STATUS "  - fuzz_retry_policy")
+  message(STATUS "  - fuzz_subject_validator")
   message(STATUS "Run with: ./<fuzz_target> -max_len=4096 -runs=1000000")
 endif()
 
@@ -803,7 +810,7 @@ install(TARGETS hmas_load_test RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}/tools
 if(ENABLE_FUZZING)
   install(
     TARGETS fuzz_message_serialization fuzz_message_bus_routing
-            fuzz_work_stealing fuzz_retry_policy
+            fuzz_work_stealing fuzz_retry_policy fuzz_subject_validator
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}/fuzz COMPONENT keystone-misc)
 endif()
 

--- a/fuzz/fuzz_subject_validator.cpp
+++ b/fuzz/fuzz_subject_validator.cpp
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: BSD-3-Clause
+#include "core/subject_validator.hpp"
+#include <cstddef>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  const std::string input(reinterpret_cast<const char*>(data), size);
+  try {
+    keystone::core::validateSubjectToken(input, "fuzz_input");
+  } catch (const std::invalid_argument&) {
+    // Expected — invalid token correctly rejected
+  }
+  return 0;
+}

--- a/src/keystone/nats_listener.py
+++ b/src/keystone/nats_listener.py
@@ -125,6 +125,19 @@ class NATSListener:
         )
         self._task_claimer.advance_dag_tracked(team_id)
 
+    @staticmethod
+    def _parse_subject(subject: str) -> tuple[str, str]:
+        """Parse NATS subject 'hi.tasks.{team_id}.{task_id}.{event}' into (team_id, task_id).
+
+        Raises ValueError if the subject does not have the expected 5-part structure.
+        """
+        parts = subject.split(".")
+        if len(parts) != NATSListener._SUBJECT_PART_COUNT:
+            raise ValueError(
+                f"Expected {NATSListener._SUBJECT_PART_COUNT} subject parts, got {len(parts)}: {subject!r}"
+            )
+        return parts[2], parts[3]  # team_id, task_id
+
     async def stop(self) -> None:
         """Drain the NATS connection and release resources."""
         logger.info("nats_listener_stopped")

--- a/tests/test_nats_listener.py
+++ b/tests/test_nats_listener.py
@@ -55,6 +55,24 @@ class TestOnTaskEventInvalidIds:
         claimer.advance_dag_tracked.assert_not_called()
 
 
+class TestParseSubject:
+    def test_valid_subject_extracts_team_and_task(self) -> None:
+        result = NATSListener._parse_subject("hi.tasks.team-1.task-2.completed")
+        assert result == ("team-1", "task-2")
+
+    def test_short_subject_raises_value_error(self) -> None:
+        with pytest.raises(ValueError):
+            NATSListener._parse_subject("hi.tasks.team-1.task-2")
+
+    def test_long_subject_raises_value_error(self) -> None:
+        with pytest.raises(ValueError):
+            NATSListener._parse_subject("hi.tasks.team-1.task-2.completed.extra")
+
+    def test_empty_subject_raises(self) -> None:
+        with pytest.raises(ValueError):
+            NATSListener._parse_subject("")
+
+
 class TestOnTaskEventShutdown:
     async def test_event_dropped_during_shutdown(self) -> None:
         listener, claimer = _make_listener()


### PR DESCRIPTION
## Summary
- Adds `NATSListener._parse_subject(subject)` static method that splits `hi.tasks.{team_id}.{task_id}.{event}` into `(team_id, task_id)`
- Raises `ValueError` if the subject does not have the expected 5-part structure
- Adds `TestParseSubject` test class covering valid subjects, short/long subjects, and empty strings

Closes #305