### PR TITLE
ci: add include-just input to install-build-deps composite action

### DIFF
--- a/.github/actions/install-build-deps/action.yml
+++ b/.github/actions/install-build-deps/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: Include lcov for coverage builds
     required: false
     default: 'false'
+  include-just:
+    description: Install the just command runner
+    required: false
+    default: 'false'
   include-static-analysis:
     description: Include clang-tidy and cppcheck
     required: false
@@ -50,6 +54,12 @@ runs:
     - name: Install static analysis tools
       if: inputs.include-static-analysis == 'true'
       run: sudo apt-get install -y clang-tidy-18 cppcheck
+      shell: bash
+
+    - name: Install just
+      if: inputs.include-just == 'true'
+      run: |
+        curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
       shell: bash
 
     - name: Set up compiler alternatives

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,8 @@ jobs:
 
       - name: Install build dependencies
         uses: ./.github/actions/install-build-deps
-
-      - name: Install just
-        run: |
-          curl -fsSL https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+        with:
+          include-just: 'true'
 
       - name: Check formatting
         run: just format-check


### PR DESCRIPTION
## Summary

- Adds `include-just` opt-in input (default `'false'`) to the `install-build-deps` composite action
- Adds a conditional step that installs `just` via the official install script when the input is `'true'`
- Updates the `quality` job in `ci.yml` to use `include-just: 'true'` instead of a separate inline curl step

Closes #241

## Test plan

- [ ] Verify `quality` CI job still installs `just` and `just format-check` succeeds
- [ ] Verify other jobs that do not set `include-just` do not install `just`

🤖 Generated with [Claude Code](https://claude.com/claude-code)