### PR TITLE
test(nats_listener): add raw_payload end-to-end tests

### DIFF
--- a/tests/test_nats_listener.py
+++ b/tests/test_nats_listener.py
@@ -1,6 +1,9 @@
 """Tests for NATSListener ID validation in _on_task_event."""
 from __future__ import annotations
 
+import json
+
+import pytest
 from unittest.mock import MagicMock
 
 from src.keystone.nats_listener import NATSListener
@@ -68,3 +71,51 @@ class TestOnTaskEventShutdown:
         # Even with invalid IDs, no error raised — shutdown takes priority
         await listener._on_task_event("bad", "", "")
         claimer.advance_dag_tracked.assert_not_called()
+
+
+class TestOnTaskEventRawPayload:
+    @pytest.mark.asyncio
+    async def test_valid_json_payload_dispatches(self) -> None:
+        listener, claimer = _make_listener()
+        payload = json.dumps({"status": "completed"}).encode()
+        await listener._on_task_event(
+            "hi.tasks.team-1.task-42.completed", "team-1", "task-42", raw_payload=payload
+        )
+        claimer.advance_dag_tracked.assert_called_once_with("team-1")
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_payload_drops_event(self) -> None:
+        listener, claimer = _make_listener()
+        await listener._on_task_event(
+            "hi.tasks.team-1.task-42.completed",
+            "team-1",
+            "task-42",
+            raw_payload=b"not-valid-json",
+        )
+        claimer.advance_dag_tracked.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_payload_missing_status_still_dispatches(self) -> None:
+        listener, claimer = _make_listener()
+        payload = json.dumps({}).encode()
+        await listener._on_task_event(
+            "hi.tasks.team-1.task-42.completed", "team-1", "task-42", raw_payload=payload
+        )
+        claimer.advance_dag_tracked.assert_called_once_with("team-1")
+
+    @pytest.mark.asyncio
+    async def test_nested_data_status_resolves_effective_status(self) -> None:
+        listener, claimer = _make_listener()
+        payload = json.dumps({"data": {"status": "completed"}}).encode()
+        await listener._on_task_event(
+            "hi.tasks.team-1.task-42.completed", "team-1", "task-42", raw_payload=payload
+        )
+        claimer.advance_dag_tracked.assert_called_once_with("team-1")
+
+    @pytest.mark.asyncio
+    async def test_none_payload_dispatches_without_parsing(self) -> None:
+        listener, claimer = _make_listener()
+        await listener._on_task_event(
+            "hi.tasks.team-1.task-42.completed", "team-1", "task-42", raw_payload=None
+        )
+        claimer.advance_dag_tracked.assert_called_once_with("team-1")


### PR DESCRIPTION
## Summary
- Add `TestOnTaskEventRawPayload` class with 5 tests covering the `raw_payload: bytes | None` path in `NATSListener._on_task_event()`
- Tests cover: valid JSON dispatch, invalid JSON drop, empty payload dispatch, nested `data.status` effective_status resolution, and `None` payload passthrough

## Test plan
- [x] `test_valid_json_payload_dispatches` — JSON with `status=completed` dispatches to `advance_dag_tracked`
- [x] `test_invalid_json_payload_drops_event` — `b"not-valid-json"` is dropped without exception
- [x] `test_payload_missing_status_still_dispatches` — Empty JSON `{}` still dispatches (status is optional)
- [x] `test_nested_data_status_resolves_effective_status` — `{"data": {"status": "completed"}}` dispatches via Hermes format
- [x] `test_none_payload_dispatches_without_parsing` — `raw_payload=None` dispatches normally (no parsing attempted)
- [x] All 14 tests pass

Closes #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)