### PR TITLE
test(conftest): extract shared helpers and add asyncio fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,23 @@
-# PYTHONPATH configured in pyproject.toml [tool.pytest.ini_options]
+"""Shared pytest fixtures and configuration for ProjectKeystone tests.
+
+asyncio_mode = "auto" is configured in pyproject.toml [tool.pytest.ini_options],
+so @pytest.mark.asyncio decorators are not required on individual async tests.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tests.helpers import make_agent, make_task
+
+__all__ = ["make_agent", "make_task"]
+
+
+@pytest.fixture
+def mock_http_client() -> MagicMock:
+    """Return a mock HTTP client with an async ``get`` method."""
+    http = MagicMock()
+    http.get = AsyncMock()
+    return http

--- a/tests/test_dag_walker.py
+++ b/tests/test_dag_walker.py
@@ -133,7 +133,6 @@ class TestValidateNoCycles:
 
 
 class TestAdvanceDag:
-    @pytest.mark.asyncio
     async def test_assigns_ready_task_to_available_agent(self) -> None:
         task = make_task()
         agent = make_agent()
@@ -144,7 +143,6 @@ class TestAdvanceDag:
         assert agent.current_task_id == task.id
         assert task.assigned_agent_id == agent.id
 
-    @pytest.mark.asyncio
     async def test_multiple_assignments_use_different_agents(self) -> None:
         task1 = make_task(id="t1")
         task2 = make_task(id="t2")
@@ -156,7 +154,6 @@ class TestAdvanceDag:
         assigned_agents = {a.id for _, a in assignments}
         assert assigned_agents == {"a1", "a2"}
 
-    @pytest.mark.asyncio
     async def test_busy_agent_not_double_assigned(self) -> None:
         """A single idle agent with two ready tasks should only get one assignment."""
         task1 = make_task(id="t1")
@@ -167,7 +164,6 @@ class TestAdvanceDag:
         assert len(assignments) == 1
         assert agent.current_task_id is not None
 
-    @pytest.mark.asyncio
     async def test_agent_marked_busy_immediately(self) -> None:
         task1 = make_task(id="t1")
         task2 = make_task(id="t2")
@@ -176,7 +172,6 @@ class TestAdvanceDag:
         await walker.advance_dag()
         assert sum(1 for t in walker.tasks if t.assigned_agent_id is not None) == 1
 
-    @pytest.mark.asyncio
     async def test_no_available_agents_no_assignments(self) -> None:
         task = make_task()
         agent = make_agent(current_task_id="other-task")
@@ -184,7 +179,6 @@ class TestAdvanceDag:
         assignments = await walker.advance_dag()
         assert assignments == []
 
-    @pytest.mark.asyncio
     async def test_no_ready_tasks_no_assignments(self) -> None:
         dep = make_task(id="dep", status="in_progress")
         task = make_task(id="t1", dependencies=["dep"])

--- a/tests/test_graceful_shutdown.py
+++ b/tests/test_graceful_shutdown.py
@@ -50,13 +50,11 @@ class SlowTaskClaimer(TaskClaimer):
 
 
 class TestDrainEmpty:
-    @pytest.mark.asyncio
     async def test_drain_returns_true_immediately_when_no_inflight(self) -> None:
         claimer = make_claimer()
         result = await claimer.drain(timeout=5.0)
         assert result is True
 
-    @pytest.mark.asyncio
     async def test_inflight_count_zero_initially(self) -> None:
         claimer = make_claimer()
         assert claimer.in_flight_count == 0
@@ -68,14 +66,12 @@ class TestDrainEmpty:
 
 
 class TestInflightTracking:
-    @pytest.mark.asyncio
     async def test_inflight_count_increases_when_task_dispatched(self) -> None:
         claimer = SlowTaskClaimer(delay=0.1)
         task = claimer.advance_dag_tracked("team-1")
         assert claimer.in_flight_count == 1
         await task
 
-    @pytest.mark.asyncio
     async def test_inflight_count_decreases_after_task_completes(self) -> None:
         claimer = SlowTaskClaimer(delay=0.0)
         task = claimer.advance_dag_tracked("team-1")
@@ -84,7 +80,6 @@ class TestInflightTracking:
         await asyncio.sleep(0)
         assert claimer.in_flight_count == 0
 
-    @pytest.mark.asyncio
     async def test_multiple_inflight_tracked(self) -> None:
         claimer = SlowTaskClaimer(delay=0.1)
         t1 = claimer.advance_dag_tracked("team-1")
@@ -92,7 +87,6 @@ class TestInflightTracking:
         assert claimer.in_flight_count == 2
         await asyncio.gather(t1, t2)
 
-    @pytest.mark.asyncio
     async def test_inflight_removed_after_exception(self) -> None:
         claimer = make_claimer()
 
@@ -113,7 +107,6 @@ class TestInflightTracking:
 
 
 class TestDrainCompletes:
-    @pytest.mark.asyncio
     async def test_inflight_advance_dag_completes_before_drain_returns(self) -> None:
         """Core success criterion: drain() waits for in-flight work to finish."""
         claimer = SlowTaskClaimer(delay=0.05)
@@ -125,7 +118,6 @@ class TestDrainCompletes:
         assert result is True
         assert claimer.in_flight_count == 0
 
-    @pytest.mark.asyncio
     async def test_multiple_inflight_all_complete_before_drain_returns(self) -> None:
         claimer = SlowTaskClaimer(delay=0.05)
         for team_id in ("team-1", "team-2", "team-3"):
@@ -137,7 +129,6 @@ class TestDrainCompletes:
         assert result is True
         assert claimer.in_flight_count == 0
 
-    @pytest.mark.asyncio
     async def test_advance_dag_called_with_correct_team_id(self) -> None:
         claimer = SlowTaskClaimer(delay=0.0)
         claimer.advance_dag_tracked("team-42")
@@ -151,7 +142,6 @@ class TestDrainCompletes:
 
 
 class TestDrainTimeout:
-    @pytest.mark.asyncio
     async def test_drain_timeout_returns_false(self) -> None:
         """drain() returns False when in-flight tasks outlast the timeout."""
         claimer = SlowTaskClaimer(delay=10.0)
@@ -166,7 +156,6 @@ class TestDrainTimeout:
         except (asyncio.CancelledError, Exception):
             pass
 
-    @pytest.mark.asyncio
     async def test_drain_timeout_logs_warning(self) -> None:
         claimer = SlowTaskClaimer(delay=10.0)
         task = claimer.advance_dag_tracked("team-slow")
@@ -203,7 +192,6 @@ class TestNATSListenerShutdown:
         listener.begin_shutdown()
         assert listener.shutting_down is True
 
-    @pytest.mark.asyncio
     async def test_new_events_dropped_after_begin_shutdown(self) -> None:
         """After begin_shutdown(), _on_task_event must not call advance_dag."""
         claimer = SlowTaskClaimer(delay=0.0)
@@ -215,7 +203,6 @@ class TestNATSListenerShutdown:
         assert claimer.in_flight_count == 0
         assert claimer.calls == []
 
-    @pytest.mark.asyncio
     async def test_events_dispatched_before_shutdown(self) -> None:
         claimer = SlowTaskClaimer(delay=0.0)
         listener = NATSListener(claimer)
@@ -225,7 +212,6 @@ class TestNATSListenerShutdown:
 
         assert "team-1" in claimer.calls
 
-    @pytest.mark.asyncio
     async def test_event_dropped_during_shutdown_logs_info(self) -> None:
         claimer = make_claimer()
         listener = NATSListener(claimer)
@@ -239,7 +225,6 @@ class TestNATSListenerShutdown:
             call_args = mock_logger.info.call_args
             assert call_args[0][0] == "nats_event_dropped_during_shutdown"
 
-    @pytest.mark.asyncio
     async def test_inflight_before_shutdown_completes(self) -> None:
         """Events in-flight at shutdown time must still complete."""
         claimer = SlowTaskClaimer(delay=0.05)
@@ -264,7 +249,6 @@ class TestNATSListenerShutdown:
 
 
 class TestShutdownSequence:
-    @pytest.mark.asyncio
     async def test_full_shutdown_sequence_completes_inflight(self) -> None:
         """Full sequence: begin_shutdown → drain → stop, all in-flight complete."""
         claimer = SlowTaskClaimer(delay=0.05)
@@ -290,7 +274,6 @@ class TestShutdownSequence:
         assert claimer.in_flight_count == 0
         assert "team-c" not in claimer.calls
 
-    @pytest.mark.asyncio
     async def test_stop_called_even_when_drain_times_out(self) -> None:
         """listener.stop() must be called even if drain times out."""
         claimer = SlowTaskClaimer(delay=10.0)

--- a/tests/test_maestro_client.py
+++ b/tests/test_maestro_client.py
@@ -1,7 +1,6 @@
 """Tests for MaestroClient._agent_from_api() and get_agents()."""
 from __future__ import annotations
 
-import pytest
 from unittest.mock import AsyncMock, MagicMock
 
 from src.keystone.maestro_client import _agent_from_api, MaestroClient
@@ -92,14 +91,12 @@ class TestGetAgents:
             "deletedAt": deleted_at,
         }
 
-    @pytest.mark.asyncio
     async def test_get_agents_returns_active_agents(self) -> None:
         client = self._make_client([self._raw_entry("a1")])
         agents = await client.get_agents()
         assert len(agents) == 1
         assert agents[0].id == "a1"
 
-    @pytest.mark.asyncio
     async def test_get_agents_filters_soft_deleted(self) -> None:
         client = self._make_client([
             self._raw_entry("a1"),
@@ -109,7 +106,6 @@ class TestGetAgents:
         assert len(agents) == 1
         assert agents[0].id == "a1"
 
-    @pytest.mark.asyncio
     async def test_get_agents_populates_current_task_id(self) -> None:
         client = self._make_client([
             self._raw_entry("a1", current_task_id="task-99"),
@@ -117,7 +113,6 @@ class TestGetAgents:
         agents = await client.get_agents()
         assert agents[0].current_task_id == "task-99"
 
-    @pytest.mark.asyncio
     async def test_get_agents_nested_agent_key_soft_delete(self) -> None:
         """Handles responses where agent data is nested under 'agent' key."""
         inner = self._raw_entry("a1", deleted_at="2026-01-01T00:00:00Z")

--- a/tests/test_nats_listener.py
+++ b/tests/test_nats_listener.py
@@ -1,7 +1,6 @@
 """Tests for NATSListener ID validation in _on_task_event."""
 from __future__ import annotations
 
-import pytest
 from unittest.mock import MagicMock
 
 from src.keystone.nats_listener import NATSListener
@@ -15,13 +14,11 @@ def _make_listener() -> tuple[NATSListener, MagicMock]:
 
 
 class TestOnTaskEventValidIds:
-    @pytest.mark.asyncio
     async def test_valid_ids_dispatches(self) -> None:
         listener, claimer = _make_listener()
         await listener._on_task_event("hi.tasks.team-1.task-42.completed", "team-1", "task-42")
         claimer.advance_dag_tracked.assert_called_once_with("team-1")
 
-    @pytest.mark.asyncio
     async def test_valid_uuid_ids_dispatches(self) -> None:
         listener, claimer = _make_listener()
         team = "550e8400-e29b-41d4-a716-446655440000"
@@ -31,31 +28,26 @@ class TestOnTaskEventValidIds:
 
 
 class TestOnTaskEventInvalidIds:
-    @pytest.mark.asyncio
     async def test_empty_team_id_dropped(self) -> None:
         listener, claimer = _make_listener()
         await listener._on_task_event("hi.tasks...task-1.completed", "", "task-1")
         claimer.advance_dag_tracked.assert_not_called()
 
-    @pytest.mark.asyncio
     async def test_slash_in_team_id_dropped(self) -> None:
         listener, claimer = _make_listener()
         await listener._on_task_event("hi.tasks.../admin.task-1.completed", "../admin", "task-1")
         claimer.advance_dag_tracked.assert_not_called()
 
-    @pytest.mark.asyncio
     async def test_empty_task_id_dropped(self) -> None:
         listener, claimer = _make_listener()
         await listener._on_task_event("hi.tasks.team-1..completed", "team-1", "")
         claimer.advance_dag_tracked.assert_not_called()
 
-    @pytest.mark.asyncio
     async def test_path_traversal_task_id_dropped(self) -> None:
         listener, claimer = _make_listener()
         await listener._on_task_event("hi.tasks.team-1.../etc.completed", "team-1", "../etc")
         claimer.advance_dag_tracked.assert_not_called()
 
-    @pytest.mark.asyncio
     async def test_overlong_team_id_dropped(self) -> None:
         listener, claimer = _make_listener()
         bad_team = "a" * 257
@@ -64,14 +56,12 @@ class TestOnTaskEventInvalidIds:
 
 
 class TestOnTaskEventShutdown:
-    @pytest.mark.asyncio
     async def test_event_dropped_during_shutdown(self) -> None:
         listener, claimer = _make_listener()
         listener.begin_shutdown()
         await listener._on_task_event("hi.tasks.team-1.task-1.completed", "team-1", "task-1")
         claimer.advance_dag_tracked.assert_not_called()
 
-    @pytest.mark.asyncio
     async def test_shutdown_checked_before_validation(self) -> None:
         listener, claimer = _make_listener()
         listener.begin_shutdown()

--- a/tests/test_task_claimer.py
+++ b/tests/test_task_claimer.py
@@ -3,14 +3,10 @@
 from __future__ import annotations
 
 import asyncio
-import sys
-from pathlib import Path
 from unittest.mock import AsyncMock, call
 
 import pytest
 
-# Allow importing from src/keystone without an installed package
-sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 from keystone.task_claimer import TaskClaimer
 
@@ -30,7 +26,6 @@ def _make_claimer(
     return claimer, get_tasks_mock, claim_mock
 
 
-@pytest.mark.asyncio
 async def test_advance_dag_claims_ready_tasks() -> None:
     tasks = [{"id": "t1"}, {"id": "t2"}]
     claimer, get_tasks_mock, claim_mock = _make_claimer({"team-A": tasks})
@@ -44,7 +39,6 @@ async def test_advance_dag_claims_ready_tasks() -> None:
     claim_mock.assert_any_await("team-A", "t2")
 
 
-@pytest.mark.asyncio
 async def test_advance_dag_empty_team_returns_empty() -> None:
     claimer, get_tasks_mock, claim_mock = _make_claimer()
 
@@ -55,7 +49,6 @@ async def test_advance_dag_empty_team_returns_empty() -> None:
     claim_mock.assert_not_awaited()
 
 
-@pytest.mark.asyncio
 async def test_advance_dag_partial_claim_failures() -> None:
     tasks = [{"id": "t1"}, {"id": "t2"}]
 
@@ -72,7 +65,6 @@ async def test_advance_dag_partial_claim_failures() -> None:
     assert result == ["t1"]
 
 
-@pytest.mark.asyncio
 async def test_concurrent_advance_dag_coalesced() -> None:
     """Second advance_dag for same team is skipped while first is in-flight."""
     first_call_started = asyncio.Event()
@@ -107,7 +99,6 @@ async def test_concurrent_advance_dag_coalesced() -> None:
     assert get_tasks_mock.await_count == 1
 
 
-@pytest.mark.asyncio
 async def test_concurrent_advance_dag_different_teams_parallel() -> None:
     """Concurrent calls for different teams both proceed independently."""
     tasks = {"team-A": [{"id": "a1"}], "team-B": [{"id": "b1"}]}
@@ -123,7 +114,6 @@ async def test_concurrent_advance_dag_different_teams_parallel() -> None:
     assert get_tasks_mock.await_count == 2
 
 
-@pytest.mark.asyncio
 async def test_advance_dag_lock_released_on_error() -> None:
     """Lock and _advancing set are cleaned up even when get_tasks raises."""
     call_count = 0
@@ -148,7 +138,6 @@ async def test_advance_dag_lock_released_on_error() -> None:
     assert get_tasks_mock.await_count == 2
 
 
-@pytest.mark.asyncio
 async def test_sequential_calls_same_team_both_execute() -> None:
     """Sequential (non-concurrent) calls for the same team both run normally."""
     tasks = [{"id": "t1"}]


### PR DESCRIPTION
## Summary

- Expand `tests/conftest.py` with a `mock_http_client` fixture and re-export `make_task`/`make_agent` from `tests/helpers.py`
- Remove all `@pytest.mark.asyncio` decorators from test files — covered globally by `asyncio_mode = "auto"` already set in `pyproject.toml`
- Remove redundant `sys.path.insert` in `test_task_claimer.py` — covered by `pythonpath = ["src"]` in `pyproject.toml`
- Remove unused `import pytest` from `test_maestro_client.py` and `test_nats_listener.py`

## Test plan

- [x] All 161 existing tests pass with `PYTHONPATH=src pytest tests/ --ignore=tests/test_daemon.py`
- [x] `asyncio_mode = "auto"` confirmed in `pyproject.toml` — no per-test markers needed
- [x] `conftest.py` provides `mock_http_client` fixture and re-exports `make_task`/`make_agent`

Closes #101
Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)