### PR TITLE
refactor(models): extract resolve_event_status as standalone utility

### DIFF
--- a/src/keystone/models.py
+++ b/src/keystone/models.py
@@ -9,6 +9,23 @@ from pydantic import BaseModel, model_validator
 TERMINAL_STATUSES: frozenset[str] = frozenset({"completed", "failed", "error", "cancelled"})
 
 
+def resolve_event_status(
+    status: str | None,
+    data: dict | None,
+    new_status: str | None,
+) -> str | None:
+    """Resolve effective status from three possible sources in priority order.
+
+    Priority: status > data["status"] > new_status
+    """
+    resolved = status
+    if not resolved and data:
+        resolved = data.get("status")
+    if not resolved:
+        resolved = new_status
+    return resolved
+
+
 @dataclass
 class Task:
     id: str
@@ -51,10 +68,5 @@ class TaskEvent(BaseModel):
 
     @model_validator(mode="after")
     def _resolve_effective_status(self) -> TaskEvent:
-        resolved = self.status
-        if not resolved and self.data:
-            resolved = self.data.get("status")
-        if not resolved:
-            resolved = self.newStatus
-        self.effective_status = resolved
+        self.effective_status = resolve_event_status(self.status, self.data, self.newStatus)
         return self

--- a/tests/test_task_event.py
+++ b/tests/test_task_event.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
-from src.keystone.models import TaskEvent
+from src.keystone.models import TaskEvent, resolve_event_status
 
 
 class TestTaskEventFlatStatus:
@@ -122,3 +122,22 @@ class TestTaskEventResolutionPriority:
     def test_none_status_falls_through(self) -> None:
         event = TaskEvent.model_validate({"status": None, "newStatus": "completed"})
         assert event.effective_status == "completed"
+
+
+class TestResolveEventStatus:
+    """Unit tests for the standalone resolve_event_status utility function."""
+
+    def test_status_returned_when_set(self) -> None:
+        assert resolve_event_status("done", None, None) == "done"
+
+    def test_data_status_used_when_status_absent(self) -> None:
+        assert resolve_event_status(None, {"status": "done"}, None) == "done"
+
+    def test_new_status_used_as_final_fallback(self) -> None:
+        assert resolve_event_status(None, None, "done") == "done"
+
+    def test_status_takes_priority_over_data_and_new_status(self) -> None:
+        assert resolve_event_status("top", {"status": "nested"}, "new") == "top"
+
+    def test_all_none_returns_none(self) -> None:
+        assert resolve_event_status(None, None, None) is None


### PR DESCRIPTION
## Summary
- Adds module-level `resolve_event_status(status, data, new_status)` function in `src/keystone/models.py` that encapsulates the three-source status priority logic
- Updates `TaskEvent._resolve_effective_status` model validator to delegate to `resolve_event_status` instead of inlining the logic
- Adds 5 unit tests in `tests/test_task_event.py` covering all priority branches and the `None` case for the standalone function

## Test plan
- [x] All 29 tests in `tests/test_task_event.py` pass (24 existing + 5 new)
- [x] No regressions in existing TaskEvent behavior

Closes #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)