### PR TITLE
ci: add CHANGELOG.md linting via pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -98,6 +98,19 @@ repos:
         args: [-c=.yamllint.yaml]
 
   # ============================================================================
+  # CHANGELOG Linting (Keep a Changelog format)
+  # ============================================================================
+  - repo: local
+    hooks:
+      - id: changelog-lint
+        name: Lint CHANGELOG.md (Keep a Changelog format)
+        language: python
+        entry: python3 scripts/lint-changelog.py
+        args: [CHANGELOG.md]
+        files: CHANGELOG\.md
+        pass_filenames: false
+
+  # ============================================================================
   # Git Commit Message Linting (Optional)
   # ============================================================================
   - repo: https://github.com/commitizen-tools/commitizen

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,9 @@ Starting from v0.2.0, this file is maintained automatically by
 
 ## [Unreleased]
 
-### Features
-- Migrate dependency management to Conan 2 with CMakePresets ([220326c](../../commit/220326c))
-
 ### Added
+
+- Migrate dependency management to Conan 2 with CMakePresets ([220326c](../../commit/220326c))
 - NATS subject schema documentation and payload envelope contract
 - Pre-commit CI job enforcing all hook checks
 - Dependency vulnerability scanning in CI
@@ -28,18 +27,20 @@ Starting from v0.2.0, this file is maintained automatically by
 - `TASK_FAILED` event handling to prevent DAG deadlocks
 - `test_task_claimer.py` and shared `tests/helpers.py` test utilities
 - `justfile` wrapping Makefile for ecosystem convention
+- Add CODE_OF_CONDUCT.md ([b9d15bc](../../commit/b9d15bc))
+- Rewrite CLAUDE.md for pure transport role, remove HMAS hierarchy ([f442d1a](../../commit/f442d1a))
 
 ### Changed
+
 - License replaced from MIT placeholder to BSD 3-Clause
 - Unsized integers converted to sized types (`int32_t`, `uint32_t`, `size_t`)
 - `CONTRIBUTING.md` rewritten to match current C++20/Conan/just workflow
 - `pixi.toml` and `justfile` aligned with ecosystem conventions
+- Address audit quick wins — security, templates, DX improvements ([6fbb180](../../commit/6fbb180))
+- `ci`: Bump github-actions group across 1 directory with 3 updates ([c916699](../../commit/c916699))
 
-### Documentation
-- Add CODE_OF_CONDUCT.md ([b9d15bc](../../commit/b9d15bc))
-- Rewrite CLAUDE.md for pure transport role, remove HMAS hierarchy ([f442d1a](../../commit/f442d1a))
+### Fixed
 
-### Bug Fixes
 - `monitoring`: Add `.load()` for atomic `server_fd_` and `port_` usages ([4a583ed](../../commit/4a583ed))
 - Resolve CI failures — TSan data races, MSan removal, Dockerfile COPY paths ([412b73c](../../commit/412b73c))
 - `ci`: Apply clang-format-18 and fix Dockerfile COPY for disabled tests ([14e9e42](../../commit/14e9e42))
@@ -53,10 +54,6 @@ Starting from v0.2.0, this file is maintained automatically by
 - `spdlog` and `concurrentqueue` promoted to `PUBLIC` in CMake targets
 - Atomic `server_fd_` and `port_` accesses use `.load()`
 
-### Chores
-- Address audit quick wins — security, templates, DX improvements ([6fbb180](../../commit/6fbb180))
-- `ci`: Bump github-actions group across 1 directory with 3 updates ([c916699](../../commit/c916699))
-
 ---
 
 ## [0.1.0] — 2026-03-15
@@ -65,7 +62,8 @@ Initial tracked release. Establishes the C++20 transport infrastructure for
 ProjectKeystone: intra-host MessageBus (lock-free), NATS JetStream cross-host
 bridge, BlazingMQ integration, and full sanitizer CI.
 
-### Features
+### Added
+
 - `core`: Add `AgentLevel` enum type (Phase 0) ([9906d95](../../commit/9906d95))
 - Enhance build system with new feature flag naming convention ([39dd58d](../../commit/39dd58d))
 - Add sanitizer and build type pattern rules to Makefile ([c690c77](../../commit/c690c77))
@@ -84,8 +82,6 @@ bridge, BlazingMQ integration, and full sanitizer CI.
 - Stream A Phase A2 — `AgentIdInterning` registry optimization (Issue #43) ([229f40a](../../commit/229f40a))
 - Stream A Phase A1 — MessageBus interface segregation (Issue #46) ([2929bc0](../../commit/2929bc0))
 - Add GitHub issue workflow to all agent configurations ([5525693](../../commit/5525693))
-
-### Added
 - C++20 `MessageBus` with lock-free concurrent queue (`concurrentqueue`)
 - NATS JetStream integration via `nats.c` for cross-host delivery
 - Transparent bridge between local `MessageBus` and NATS JetStream
@@ -105,12 +101,28 @@ bridge, BlazingMQ integration, and full sanitizer CI.
 - NATS listener with JetStream ack/nak support
 - `CODE_OF_CONDUCT.md` and `SECURITY.md`
 - Conan 2 dependency management with `conanfile.py`
+- Add ADR-012 documenting CPack build system decisions ([f3b2769](../../commit/f3b2769))
+- Add ADR-013 coroutine safety patterns (Issue #56) ([895e1a4](../../commit/895e1a4))
+- Update README.md and fix Docker configuration ([9c67473](../../commit/9c67473))
+- Update test framework references from Catch2 v3 to Google Test ([0bcaa5d](../../commit/0bcaa5d))
+- Add comprehensive workflow examples for thread/IPC/network deployment ([2d382db](../../commit/2d382db))
+- Merge implementation summaries into architecture documentation ([bb47483](../../commit/bb47483))
+- Add comprehensive work stealing tests (Issue #55 Task 4.2) ([fdd94e1](../../commit/fdd94e1))
 
 ### Changed
+
 - Migrated from Python prototype to C++20 implementation
 - Migrated dependency management from vcpkg/system packages to Conan 2
+- `concurrency`: Convert logger to `int32_t` worker IDs ([5f9f1e2](../../commit/5f9f1e2))
+- Migrate from justfile to Makefile and consolidate CI/CD ([29713a7](../../commit/29713a7))
+- Simplify Makefile patterns by removing redundant combined rules ([63e390a](../../commit/63e390a))
+- Replace individual `.native` targets with pattern rule ([20fcf09](../../commit/20fcf09))
+- Rename agent base classes for clarity (ARCH-001) ([16987b7](../../commit/16987b7))
+- Implement Template Method Pattern for Lead Agents (Phase 4.1) ([691eb3c](../../commit/691eb3c))
+- P2-06 string allocation profiling and analysis (Phase 1 complete) ([9476453](../../commit/9476453))
 
-### Bug Fixes
+### Fixed
+
 - Switch to sized integers (multiple commits, Dec 2025) ([2aeb9e4](../../commit/2aeb9e4))
 - Get CMake version to work on PureOS 9 ([e775bde](../../commit/e775bde))
 - Cleanup the build directory structure to reduce root spam ([3d1158f](../../commit/3d1158f))
@@ -126,28 +138,6 @@ bridge, BlazingMQ integration, and full sanitizer CI.
 - Configure Docker UID/GID mapping for permission parity ([718f885](../../commit/718f885))
 - `P1/P2`: Resolve profiling deadlock and fairness race condition ([72fc39d](../../commit/72fc39d))
 - `P0`: Resolve critical safety issues — HealthCheckServer hang and coroutine UAF ([ffcc528](../../commit/ffcc528))
-
-### Refactoring
-- `concurrency`: Convert logger to `int32_t` worker IDs ([5f9f1e2](../../commit/5f9f1e2))
-- Migrate from justfile to Makefile and consolidate CI/CD ([29713a7](../../commit/29713a7))
-- Simplify Makefile patterns by removing redundant combined rules ([63e390a](../../commit/63e390a))
-- Replace individual `.native` targets with pattern rule ([20fcf09](../../commit/20fcf09))
-- Rename agent base classes for clarity (ARCH-001) ([16987b7](../../commit/16987b7))
-- Implement Template Method Pattern for Lead Agents (Phase 4.1) ([691eb3c](../../commit/691eb3c))
-
-### Documentation
-- Add ADR-012 documenting CPack build system decisions ([f3b2769](../../commit/f3b2769))
-- Add ADR-013 coroutine safety patterns (Issue #56) ([895e1a4](../../commit/895e1a4))
-- Update README.md and fix Docker configuration ([9c67473](../../commit/9c67473))
-- Update test framework references from Catch2 v3 to Google Test ([0bcaa5d](../../commit/0bcaa5d))
-- Add comprehensive workflow examples for thread/IPC/network deployment ([2d382db](../../commit/2d382db))
-- Merge implementation summaries into architecture documentation ([bb47483](../../commit/bb47483))
-
-### Tests
-- Add comprehensive work stealing tests (Issue #55 Task 4.2) ([fdd94e1](../../commit/fdd94e1))
-
-### Performance
-- P2-06 string allocation profiling and analysis (Phase 1 complete) ([9476453](../../commit/9476453))
 
 [Unreleased]: https://github.com/HomericIntelligence/ProjectKeystone/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/HomericIntelligence/ProjectKeystone/releases/tag/v0.1.0

--- a/pixi.toml
+++ b/pixi.toml
@@ -27,6 +27,7 @@ pytest = ">=7.0,<10"
 pytest-asyncio = ">=0.21,<2"
 ruff = ">=0.1,<1"
 mypy = ">=1.0,<2"
+keepachangelog = ">=2.0,<3"
 
 [tasks]
 configure = "cmake -G Ninja -B build-native -S . -DENABLE_GRPC=OFF"

--- a/scripts/lint-changelog.py
+++ b/scripts/lint-changelog.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Validate CHANGELOG.md follows Keep a Changelog format.
+
+See https://keepachangelog.com/en/1.1.0/ for the specification.
+"""
+
+import re
+import sys
+
+
+# Standard section types defined by Keep a Changelog
+VALID_SECTIONS = {
+    "added",
+    "changed",
+    "deprecated",
+    "removed",
+    "fixed",
+    "security",
+}
+
+# Required header text
+HEADER_PATTERN = re.compile(
+    r"\[Keep a Changelog\]\(https://keepachangelog\.com", re.IGNORECASE
+)
+
+# Version entry patterns
+UNRELEASED_PATTERN = re.compile(r"^## \[Unreleased\]", re.IGNORECASE | re.MULTILINE)
+RELEASE_PATTERN = re.compile(
+    r"^## \[(\d+\.\d+\.\d+(?:-[A-Za-z0-9.]+)?)\]", re.MULTILINE
+)
+SECTION_PATTERN = re.compile(r"^### (.+)$", re.MULTILINE)
+
+# Reference links at bottom
+UNRELEASED_LINK_PATTERN = re.compile(
+    r"^\[Unreleased\]:\s+https?://", re.IGNORECASE | re.MULTILINE
+)
+
+
+def lint(path: str) -> list[str]:
+    """Return a list of lint errors for the given CHANGELOG file."""
+    errors: list[str] = []
+
+    try:
+        content = open(path, encoding="utf-8").read()
+    except OSError as exc:
+        return [f"Cannot read {path}: {exc}"]
+
+    # 1. Must reference Keep a Changelog
+    if not HEADER_PATTERN.search(content):
+        errors.append(
+            "Missing 'Keep a Changelog' reference link "
+            "(https://keepachangelog.com/en/1.1.0/)"
+        )
+
+    # 2. Must have an [Unreleased] section
+    if not UNRELEASED_PATTERN.search(content):
+        errors.append("Missing '## [Unreleased]' section")
+
+    # 3. Must have at least one versioned release
+    releases = RELEASE_PATTERN.findall(content)
+    if not releases:
+        errors.append(
+            "No versioned release found — expected at least one '## [x.y.z]' entry"
+        )
+
+    # 4. All ### subsections must use standard Keep a Changelog names
+    for section in SECTION_PATTERN.findall(content):
+        name = section.strip()
+        if name.lower() not in VALID_SECTIONS:
+            errors.append(
+                f"Non-standard section '### {name}' — "
+                f"valid sections are: {', '.join(sorted(VALID_SECTIONS))}"
+            )
+
+    # 5. Must have a comparison link for [Unreleased]
+    if not UNRELEASED_LINK_PATTERN.search(content):
+        errors.append(
+            "Missing '[Unreleased]: https://...' comparison link at end of file"
+        )
+
+    return errors
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("Usage: lint-changelog.py CHANGELOG.md", file=sys.stderr)
+        return 1
+
+    all_ok = True
+    for path in sys.argv[1:]:
+        errors = lint(path)
+        if errors:
+            all_ok = False
+            print(f"CHANGELOG lint errors in {path}:", file=sys.stderr)
+            for err in errors:
+                print(f"  - {err}", file=sys.stderr)
+        else:
+            print(f"{path}: OK")
+
+    return 0 if all_ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Adds `scripts/lint-changelog.py` — a zero-dependency Python script that validates `CHANGELOG.md` conforms to [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/) by checking for: the keepachangelog.com reference link, an `[Unreleased]` section, at least one versioned release entry, standard subsection names only (`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`), and a comparison URL footnote.
- Registers a `changelog-lint` local pre-commit hook in `.pre-commit-config.yaml` that runs on every commit touching `CHANGELOG.md`; the existing CI `quality` job already runs all pre-commit hooks via `pre-commit/action`, so enforcement is automatic.
- Normalises all non-standard section headings in `CHANGELOG.md` (`Features`, `Bug Fixes`, `Chores`, `Documentation`, `Refactoring`, `Tests`, `Performance`) to the standard names so the file passes the new check immediately.
- Adds `keepachangelog>=2.0` to `pixi.toml` `[feature.dev.pypi-dependencies]` as a dev-time dependency.

## Test plan

- [ ] `pre-commit run changelog-lint --all-files` passes locally
- [ ] Intentionally introduce a non-standard section heading (e.g. `### Features`) — hook should fail
- [ ] CI `quality` job passes on this PR

Closes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)