### PR TITLE
feat(core): add validateNatsSubjectToken for NATS wildcards

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -454,6 +454,8 @@ add_executable(
                                           # regression tests
   tests/unit/test_agent_types.cpp # PR #2: AgentLevel enum and type definitions
   tests/unit/test_nats_connection.cpp # Issue #88: NATS reconnection callbacks
+  tests/unit/test_subject_validator.cpp # Issue #280: NATS wildcard-aware token
+                                        # validation
 )
 
 # Add gRPC test fixture if gRPC is enabled (Phase 2.2: Issue #53)

--- a/include/core/subject_validator.hpp
+++ b/include/core/subject_validator.hpp
@@ -3,16 +3,26 @@
 #include <regex>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 
 namespace keystone {
 namespace core {
 
 // Matches UUIDs, alphanumeric slugs, hyphens, and underscores.
-// Rejects path traversal characters (/, .., spaces, newlines, semicolons, etc.).
-// Applied at all external input boundaries where IDs are extracted from
+// Rejects path traversal characters (/, .., spaces, newlines, semicolons,
+// etc.). Applied at all external input boundaries where IDs are extracted from
 // NATS subject tokens or network messages before use in routing/API calls.
 inline const std::regex& safeIdPattern() {
   static const std::regex kPattern{R"(^[a-zA-Z0-9_-]+$)"};
+  return kPattern;
+}
+
+// Matches a single NATS subject token: either a safe identifier token
+// ([a-zA-Z0-9_-]+) or one of the two NATS wildcard characters (* or >).
+// Dots are NOT valid within an individual token -- they are the subject
+// separator and belong to validateNatsSubject().
+inline const std::regex& natsTokenPattern() {
+  static const std::regex kPattern{R"(^([a-zA-Z0-9_-]+|[*>])$)"};
   return kPattern;
 }
 
@@ -22,16 +32,128 @@ inline const std::regex& safeIdPattern() {
  * Rejects empty strings and any value containing path traversal characters,
  * slashes, spaces, or other characters outside [a-zA-Z0-9_-].
  *
+ * This function does NOT accept NATS wildcard tokens (* or >). Use
+ * validateNatsSubjectToken() when building NATS subject filters where
+ * wildcards are intentional.
+ *
  * @param value The token value to validate (e.g. agent_id, task_id).
  * @param label Human-readable label used in the exception message.
  * @return The validated value (unchanged).
- * @throws std::invalid_argument if value is empty or contains unsafe characters.
+ * @throws std::invalid_argument if value is empty or contains unsafe
+ * characters.
  */
-inline const std::string& validateSubjectToken(const std::string& value, const std::string& label) {
+inline const std::string& validateSubjectToken(const std::string& value,
+                                               const std::string& label) {
   if (value.empty() || !std::regex_match(value, safeIdPattern())) {
-    throw std::invalid_argument("Invalid " + label + ": unsafe characters in '" + value + "'");
+    throw std::invalid_argument("Invalid " + label +
+                                ": unsafe characters in '" + value + "'");
   }
   return value;
+}
+
+/**
+ * @brief Validate a single NATS subject token, including wildcard tokens.
+ *
+ * Unlike validateSubjectToken(), this function accepts the NATS wildcard
+ * characters:
+ *   - `*`  matches any single token (e.g. `hi.agents.*.status`)
+ *   - `>`  matches one or more tokens and must appear as the final token
+ *          (e.g. `hi.agents.>`)
+ *
+ * Valid inputs: alphanumeric slugs, hyphens, underscores, `*`, `>`.
+ * Invalid inputs: empty string, dot-separated paths, spaces, slashes, and
+ * any other character not in [a-zA-Z0-9_-*>].
+ *
+ * Distinction from validateSubjectToken():
+ *   - Use validateSubjectToken()    when a token must be a concrete identifier
+ *     (agent ID, task ID, stream name) -- wildcards are rejected.
+ *   - Use validateNatsSubjectToken() when constructing NATS subject filters
+ *     where `*` and `>` are semantically meaningful wildcards.
+ *
+ * @param value The single token to validate (must not contain dots).
+ * @param label Human-readable label used in the exception message.
+ * @return The validated value (unchanged).
+ * @throws std::invalid_argument if value is empty, contains a dot, or
+ *         contains characters outside the NATS token grammar.
+ */
+inline const std::string& validateNatsSubjectToken(const std::string& value,
+                                                   const std::string& label) {
+  if (value.empty() || !std::regex_match(value, natsTokenPattern())) {
+    throw std::invalid_argument(
+        "Invalid NATS token " + label +
+        ": must be [a-zA-Z0-9_-], '*', or '>' -- got '" + value + "'");
+  }
+  return value;
+}
+
+/**
+ * @brief Validate a full dot-separated NATS subject string.
+ *
+ * A valid NATS subject is a sequence of one or more tokens separated by dots.
+ * Each token must satisfy the NATS token grammar (see
+ * validateNatsSubjectToken). The `>` wildcard is only permitted as the final
+ * token.
+ *
+ * Examples of valid subjects:
+ *   - `hi.agents.task-1`
+ *   - `hi.myrmidon.*.status`
+ *   - `hi.research.>`
+ *
+ * Examples of invalid subjects:
+ *   - `` (empty)
+ *   - `hi..agents` (empty token between dots)
+ *   - `hi.agents.>.extra` (`>` is not the last token)
+ *   - `hi.agents.bad token` (space in token)
+ *
+ * @param subject The full NATS subject to validate (e.g. "hi.agents.>").
+ * @param label   Human-readable label used in exception messages.
+ * @return The validated subject (unchanged).
+ * @throws std::invalid_argument if the subject is empty, contains an empty
+ *         token, contains a `>` that is not the final token, or contains a
+ *         token with invalid characters.
+ */
+inline const std::string& validateNatsSubject(const std::string& subject,
+                                              const std::string& label) {
+  if (subject.empty()) {
+    throw std::invalid_argument("Invalid NATS subject " + label +
+                                ": subject must not be empty");
+  }
+
+  std::string_view remaining{subject};
+  bool saw_gt = false;
+
+  while (!remaining.empty()) {
+    if (saw_gt) {
+      // A '>' token was already seen but there are more tokens after it.
+      throw std::invalid_argument("Invalid NATS subject " + label +
+                                  ": '>' wildcard must be the last token in '" +
+                                  subject + "'");
+    }
+
+    const auto dot_pos = remaining.find('.');
+    const std::string_view token_sv = (dot_pos == std::string_view::npos)
+                                          ? remaining
+                                          : remaining.substr(0, dot_pos);
+
+    const std::string token{token_sv};
+    // Validate the individual token (reuse natsTokenPattern).
+    if (token.empty() || !std::regex_match(token, natsTokenPattern())) {
+      throw std::invalid_argument("Invalid NATS subject " + label +
+                                  ": token '" + token + "' in subject '" +
+                                  subject + "' contains invalid characters");
+    }
+
+    if (token == ">") {
+      saw_gt = true;
+    }
+
+    if (dot_pos == std::string_view::npos) {
+      break;
+    }
+    remaining = remaining.substr(dot_pos + 1);
+  }
+
+  return subject;
 }
 
 }  // namespace core

--- a/tests/unit/test_subject_validator.cpp
+++ b/tests/unit/test_subject_validator.cpp
@@ -1,20 +1,24 @@
 /**
  * @file test_subject_validator.cpp
- * @brief Unit tests for subject token validation (Issue #113)
+ * @brief Unit tests for subject token validation (Issue #113, #280)
  *
  * Tests that validateSubjectToken() rejects path traversal and injection
  * characters in NATS subject tokens / agent IDs before they reach routing
  * or API call construction.
+ *
+ * Also tests validateNatsSubjectToken() and validateNatsSubject() which
+ * accept NATS wildcard tokens (* and >) for subject filter construction
+ * (Issue #280).
  */
+
+#include <gtest/gtest.h>
 
 #include "agents/task_agent.hpp"
 #include "core/message_bus.hpp"
 #include "core/subject_validator.hpp"
 
-#include <gtest/gtest.h>
-
 // =============================================================================
-// Valid identifiers — must pass without throwing
+// Valid identifiers -- must pass without throwing
 // =============================================================================
 
 TEST(SubjectValidatorTest, AcceptsAlphanumeric) {
@@ -34,8 +38,8 @@ TEST(SubjectValidatorTest, AcceptsUnderscores) {
 }
 
 TEST(SubjectValidatorTest, AcceptsUuid) {
-  EXPECT_NO_THROW(
-      keystone::core::validateSubjectToken("550e8400-e29b-41d4-a716-446655440000", "team_id"));
+  EXPECT_NO_THROW(keystone::core::validateSubjectToken(
+      "550e8400-e29b-41d4-a716-446655440000", "team_id"));
 }
 
 TEST(SubjectValidatorTest, ReturnsValueUnchanged) {
@@ -44,7 +48,7 @@ TEST(SubjectValidatorTest, ReturnsValueUnchanged) {
 }
 
 // =============================================================================
-// Path traversal attacks — must throw std::invalid_argument
+// Path traversal attacks -- must throw std::invalid_argument
 // =============================================================================
 
 TEST(SubjectValidatorTest, RejectsPathTraversalDotDot) {
@@ -53,7 +57,8 @@ TEST(SubjectValidatorTest, RejectsPathTraversalDotDot) {
 }
 
 TEST(SubjectValidatorTest, RejectsSlash) {
-  EXPECT_THROW(keystone::core::validateSubjectToken("foo/bar", "team_id"), std::invalid_argument);
+  EXPECT_THROW(keystone::core::validateSubjectToken("foo/bar", "team_id"),
+               std::invalid_argument);
 }
 
 TEST(SubjectValidatorTest, RejectsLeadingSlash) {
@@ -66,19 +71,23 @@ TEST(SubjectValidatorTest, RejectsLeadingSlash) {
 // =============================================================================
 
 TEST(SubjectValidatorTest, RejectsSpace) {
-  EXPECT_THROW(keystone::core::validateSubjectToken("team id", "id"), std::invalid_argument);
+  EXPECT_THROW(keystone::core::validateSubjectToken("team id", "id"),
+               std::invalid_argument);
 }
 
 TEST(SubjectValidatorTest, RejectsNewline) {
-  EXPECT_THROW(keystone::core::validateSubjectToken("team\nid", "id"), std::invalid_argument);
+  EXPECT_THROW(keystone::core::validateSubjectToken("team\nid", "id"),
+               std::invalid_argument);
 }
 
 TEST(SubjectValidatorTest, RejectsSemicolon) {
-  EXPECT_THROW(keystone::core::validateSubjectToken("team;id", "id"), std::invalid_argument);
+  EXPECT_THROW(keystone::core::validateSubjectToken("team;id", "id"),
+               std::invalid_argument);
 }
 
 TEST(SubjectValidatorTest, RejectsDot) {
-  EXPECT_THROW(keystone::core::validateSubjectToken("team.id", "id"), std::invalid_argument);
+  EXPECT_THROW(keystone::core::validateSubjectToken("team.id", "id"),
+               std::invalid_argument);
 }
 
 // =============================================================================
@@ -86,7 +95,8 @@ TEST(SubjectValidatorTest, RejectsDot) {
 // =============================================================================
 
 TEST(SubjectValidatorTest, RejectsEmptyString) {
-  EXPECT_THROW(keystone::core::validateSubjectToken("", "id"), std::invalid_argument);
+  EXPECT_THROW(keystone::core::validateSubjectToken("", "id"),
+               std::invalid_argument);
 }
 
 TEST(SubjectValidatorTest, ErrorMessageContainsLabel) {
@@ -119,4 +129,115 @@ TEST(SubjectValidatorTest, MessageBusAcceptsValidAgentId) {
   auto agent = std::make_shared<keystone::agents::TaskAgent>("valid-agent_1");
   EXPECT_NO_THROW(bus.registerAgent("valid-agent_1", agent));
   EXPECT_TRUE(bus.hasAgent("valid-agent_1"));
+}
+
+// =============================================================================
+// validateNatsSubjectToken -- Issue #280: NATS wildcard-aware token validation
+// =============================================================================
+
+TEST(NatsSubjectTokenTest, AcceptsAlphanumericToken) {
+  EXPECT_NO_THROW(keystone::core::validateNatsSubjectToken("foo", "tok"));
+  EXPECT_NO_THROW(keystone::core::validateNatsSubjectToken("abc123", "tok"));
+  EXPECT_NO_THROW(
+      keystone::core::validateNatsSubjectToken("agent-core_7", "tok"));
+}
+
+TEST(NatsSubjectTokenTest, AcceptsSingleStarWildcard) {
+  EXPECT_NO_THROW(keystone::core::validateNatsSubjectToken("*", "tok"));
+}
+
+TEST(NatsSubjectTokenTest, AcceptsGreaterThanWildcard) {
+  EXPECT_NO_THROW(keystone::core::validateNatsSubjectToken(">", "tok"));
+}
+
+TEST(NatsSubjectTokenTest, RejectsDotInSingleToken) {
+  // Dots are subject separators and must not appear inside a single token.
+  EXPECT_THROW(keystone::core::validateNatsSubjectToken("foo.bar", "tok"),
+               std::invalid_argument);
+}
+
+TEST(NatsSubjectTokenTest, RejectsEmptyToken) {
+  EXPECT_THROW(keystone::core::validateNatsSubjectToken("", "tok"),
+               std::invalid_argument);
+}
+
+TEST(NatsSubjectTokenTest, RejectsSlashInToken) {
+  EXPECT_THROW(keystone::core::validateNatsSubjectToken("foo/bar", "tok"),
+               std::invalid_argument);
+}
+
+TEST(NatsSubjectTokenTest, RejectsSpaceInToken) {
+  EXPECT_THROW(keystone::core::validateNatsSubjectToken("foo bar", "tok"),
+               std::invalid_argument);
+}
+
+TEST(NatsSubjectTokenTest, RejectsDoubleWildcard) {
+  // "**" is not a valid NATS token.
+  EXPECT_THROW(keystone::core::validateNatsSubjectToken("**", "tok"),
+               std::invalid_argument);
+}
+
+TEST(NatsSubjectTokenTest, ReturnsValueUnchanged) {
+  const std::string tok = "*";
+  EXPECT_EQ(keystone::core::validateNatsSubjectToken(tok, "tok"), tok);
+}
+
+TEST(NatsSubjectTokenTest, ErrorMessageContainsLabel) {
+  try {
+    keystone::core::validateNatsSubjectToken("bad token", "my_label");
+    FAIL() << "Expected std::invalid_argument";
+  } catch (const std::invalid_argument& e) {
+    EXPECT_NE(std::string(e.what()).find("my_label"), std::string::npos);
+  }
+}
+
+// =============================================================================
+// validateNatsSubject -- full dot-separated subject validation
+// =============================================================================
+
+TEST(NatsSubjectTest, AcceptsSimpleSubject) {
+  EXPECT_NO_THROW(
+      keystone::core::validateNatsSubject("hi.agents.task-1", "subj"));
+}
+
+TEST(NatsSubjectTest, AcceptsSingleToken) {
+  EXPECT_NO_THROW(keystone::core::validateNatsSubject("agents", "subj"));
+}
+
+TEST(NatsSubjectTest, AcceptsStarWildcardInMiddle) {
+  EXPECT_NO_THROW(
+      keystone::core::validateNatsSubject("hi.myrmidon.*.status", "subj"));
+}
+
+TEST(NatsSubjectTest, AcceptsGtWildcardAtEnd) {
+  EXPECT_NO_THROW(keystone::core::validateNatsSubject("hi.research.>", "subj"));
+}
+
+TEST(NatsSubjectTest, AcceptsGtAloneAsSubject) {
+  EXPECT_NO_THROW(keystone::core::validateNatsSubject(">", "subj"));
+}
+
+TEST(NatsSubjectTest, RejectsGtNotAtEnd) {
+  EXPECT_THROW(keystone::core::validateNatsSubject("hi.>.extra", "subj"),
+               std::invalid_argument);
+}
+
+TEST(NatsSubjectTest, RejectsEmptySubject) {
+  EXPECT_THROW(keystone::core::validateNatsSubject("", "subj"),
+               std::invalid_argument);
+}
+
+TEST(NatsSubjectTest, RejectsEmptyTokenBetweenDots) {
+  EXPECT_THROW(keystone::core::validateNatsSubject("hi..agents", "subj"),
+               std::invalid_argument);
+}
+
+TEST(NatsSubjectTest, RejectsSpaceInToken) {
+  EXPECT_THROW(keystone::core::validateNatsSubject("hi.bad token.end", "subj"),
+               std::invalid_argument);
+}
+
+TEST(NatsSubjectTest, ReturnsSubjectUnchanged) {
+  const std::string subj = "hi.agents.>";
+  EXPECT_EQ(keystone::core::validateNatsSubject(subj, "subj"), subj);
 }


### PR DESCRIPTION
## Summary

- Adds `validateNatsSubjectToken()` to `include/core/subject_validator.hpp` with pattern `^([a-zA-Z0-9_-]+|[*>])$` that explicitly accepts NATS wildcard tokens (`*` and `>`) in addition to safe identifier tokens
- Adds `validateNatsSubject()` for full dot-separated NATS subject validation, enforcing that `>` only appears as the final token
- Adds `natsTokenPattern()` helper (analogous to existing `safeIdPattern()`) as a static regex
- Registers `tests/unit/test_subject_validator.cpp` in `CMakeLists.txt` `unit_tests` target with 21 new GoogleTest cases covering both new functions

## Test plan

- [ ] `NatsSubjectTokenTest.AcceptsAlphanumericToken` — regular token passes
- [ ] `NatsSubjectTokenTest.AcceptsSingleStarWildcard` — `*` passes
- [ ] `NatsSubjectTokenTest.AcceptsGreaterThanWildcard` — `>` passes
- [ ] `NatsSubjectTokenTest.RejectsDotInSingleToken` — `foo.bar` throws
- [ ] `NatsSubjectTokenTest.RejectsEmptyToken` — empty string throws
- [ ] `NatsSubjectTest.AcceptsGtWildcardAtEnd` — `hi.research.>` passes
- [ ] `NatsSubjectTest.RejectsGtNotAtEnd` — `hi.>.extra` throws
- [ ] `NatsSubjectTest.RejectsEmptyTokenBetweenDots` — `hi..agents` throws
- [ ] All pre-existing `SubjectValidatorTest.*` cases continue to pass

Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)