### PR TITLE
refactor(agents): extract submitFailureResult into LeadAgentBase

### DIFF
--- a/include/agents/component_lead_agent.hpp
+++ b/include/agents/component_lead_agent.hpp
@@ -1,17 +1,17 @@
 #pragma once
 
-#include "agents/async_agent.hpp"
-#include "agents/coordination_state.hpp"
-#include "agents/lead_agent_base.hpp"
-
 #include <map>
 #include <memory>
 #include <string>
 #include <vector>
 
+#include "agents/async_agent.hpp"
+#include "agents/coordination_state.hpp"
+#include "agents/lead_agent_base.hpp"
+
 #ifdef ENABLE_GRPC
-#  include "network/result_aggregator.hpp"
-#  include "network/yaml_parser.hpp"
+#include "network/result_aggregator.hpp"
+#include "network/yaml_parser.hpp"
 #endif
 
 namespace keystone {
@@ -32,7 +32,8 @@ enum class ComponentLeadState {
  * @brief Level 1 Component Lead Agent
  *
  * Coordinates multiple ModuleLeadAgents to accomplish component-level goals.
- * Uses Template Method Pattern from LeadAgentBase to eliminate code duplication.
+ * Uses Template Method Pattern from LeadAgentBase to eliminate code
+ * duplication.
  *
  * Responsibilities:
  * - Decompose component goals into module goals
@@ -64,7 +65,8 @@ class ComponentLeadAgent : public LeadAgentBase<ComponentLeadState> {
   /**
    * @brief Aggregate results from all completed modules
    *
-   * Public API for manual result aggregation (typically called after all results received)
+   * Public API for manual result aggregation (typically called after all
+   * results received)
    *
    * @return std::string Aggregated component-level result
    */
@@ -140,7 +142,8 @@ class ComponentLeadAgent : public LeadAgentBase<ComponentLeadState> {
    *
    * @param result_msg Message containing module result
    */
-  void processSubordinateResult(const core::KeystoneMessage& result_msg) override;
+  void processSubordinateResult(
+      const core::KeystoneMessage& result_msg) override;
 
   /**
    * @brief Convert state enum to string (HOOK METHOD)
@@ -155,14 +158,6 @@ class ComponentLeadAgent : public LeadAgentBase<ComponentLeadState> {
   std::vector<std::string> available_module_leads_;
 
 #ifdef ENABLE_GRPC
-  /**
-   * @brief Mark spec as FAILED and submit the error result via gRPC if possible
-   *
-   * @param spec  Task spec to update (modified in place)
-   * @param error Human-readable error message
-   */
-  void submitFailureResult(network::HierarchicalTaskSpec& spec, const std::string& error);
-
   // Result aggregator (component-specific, not in template)
   std::unique_ptr<network::ResultAggregator> result_aggregator_;
 #endif

--- a/include/agents/lead_agent_base.hpp
+++ b/include/agents/lead_agent_base.hpp
@@ -1,11 +1,16 @@
 #pragma once
 
+#include <string>
+#include <vector>
+
 #include "agents/async_agent.hpp"
 #include "agents/coordination_state.hpp"
 #include "core/message.hpp"
 
-#include <string>
-#include <vector>
+#ifdef ENABLE_GRPC
+#include "hmas_coordinator.pb.h"
+#include "network/yaml_parser.hpp"
+#endif
 
 namespace keystone {
 namespace agents {
@@ -35,12 +40,9 @@ class LeadAgentBase : public AsyncAgent {
    * @param aggregating_state Aggregating/Synthesizing results state value
    * @param error_state Error state value
    */
-  explicit LeadAgentBase(const std::string& agent_id,
-                         StateEnum idle_state,
-                         StateEnum planning_state,
-                         StateEnum waiting_state,
-                         StateEnum aggregating_state,
-                         StateEnum error_state);
+  explicit LeadAgentBase(const std::string& agent_id, StateEnum idle_state,
+                         StateEnum planning_state, StateEnum waiting_state,
+                         StateEnum aggregating_state, StateEnum error_state);
 
   /**
    * @brief Process incoming message asynchronously (TEMPLATE METHOD - FINAL)
@@ -57,14 +59,17 @@ class LeadAgentBase : public AsyncAgent {
    * @param msg Message to process
    * @return concurrency::Task<core::Response> Async task with response
    */
-  concurrency::Task<core::Response> processMessage(const core::KeystoneMessage& msg) final;
+  concurrency::Task<core::Response> processMessage(
+      const core::KeystoneMessage& msg) final;
 
   /**
    * @brief Get execution trace for testing/debugging
    *
    * @return std::vector<std::string> State transition history
    */
-  std::vector<std::string> getExecutionTrace() const { return coordination_.getExecutionTrace(); }
+  std::vector<std::string> getExecutionTrace() const {
+    return coordination_.getExecutionTrace();
+  }
 
   /**
    * @brief Get current state
@@ -125,7 +130,8 @@ class LeadAgentBase : public AsyncAgent {
    *
    * @param result_msg Message containing subordinate result
    */
-  virtual void processSubordinateResult(const core::KeystoneMessage& result_msg) = 0;
+  virtual void processSubordinateResult(
+      const core::KeystoneMessage& result_msg) = 0;
 
   /**
    * @brief HOOK: Handle a failure reported by a subordinate agent (Issue #87)
@@ -139,7 +145,8 @@ class LeadAgentBase : public AsyncAgent {
    *
    * @param failure_msg Message with action_type == TASK_FAILED
    */
-  virtual void processSubordinateFailure(const core::KeystoneMessage& failure_msg) {
+  virtual void processSubordinateFailure(
+      const core::KeystoneMessage& failure_msg) {
     std::string error = failure_msg.payload.value_or("subordinate task failed");
     bool all_done = coordination_.recordFailure(error);
     if (all_done) {
@@ -156,6 +163,37 @@ class LeadAgentBase : public AsyncAgent {
    * @return std::string String representation
    */
   virtual std::string stateToString(StateEnum state) const = 0;
+
+#ifdef ENABLE_GRPC
+  /**
+   * @brief Mark spec as FAILED and submit the error result via gRPC if
+   * possible.
+   *
+   * Shared implementation extracted from ComponentLeadAgent and ModuleLeadAgent
+   * (Issue #348). Both subclasses had byte-for-byte identical bodies.
+   *
+   * @param spec  Task spec to update (modified in place)
+   * @param error Human-readable error message
+   */
+  void submitFailureResult(network::HierarchicalTaskSpec& spec,
+                           const std::string& error) {
+    spec.status.phase = "FAILED";
+    spec.status.error = error;
+    this->coordination_.transitionTo(this->error_state_,
+                                     stateToString(this->error_state_));
+
+    std::string result_yaml = network::YamlParser::generateTaskSpec(spec);
+    auto coordinator_client = this->coordination_.getCoordinatorClient();
+    if (coordinator_client && spec.metadata.parent_task_id) {
+      hmas::TaskResult task_result;
+      task_result.set_task_id(spec.metadata.task_id);
+      task_result.set_result_yaml(result_yaml);
+      task_result.set_success(false);
+      task_result.set_error_message(*spec.status.error);
+      coordinator_client->submitResult(task_result);
+    }
+  }
+#endif
 
   // Coordination state (shared by all lead agents)
   CoordinationState<StateEnum, std::string> coordination_;

--- a/include/agents/module_lead_agent.hpp
+++ b/include/agents/module_lead_agent.hpp
@@ -1,17 +1,17 @@
 #pragma once
 
-#include "agents/async_agent.hpp"
-#include "agents/coordination_state.hpp"
-#include "agents/lead_agent_base.hpp"
-
 #include <map>
 #include <memory>
 #include <string>
 #include <vector>
 
+#include "agents/async_agent.hpp"
+#include "agents/coordination_state.hpp"
+#include "agents/lead_agent_base.hpp"
+
 #ifdef ENABLE_GRPC
-#  include "network/result_aggregator.hpp"
-#  include "network/yaml_parser.hpp"
+#include "network/result_aggregator.hpp"
+#include "network/yaml_parser.hpp"
 #endif
 
 namespace keystone {
@@ -32,7 +32,8 @@ enum class ModuleLeadState {
  * @brief Level 2 Module Lead Agent
  *
  * Coordinates multiple TaskAgents to accomplish module-level goals.
- * Uses Template Method Pattern from LeadAgentBase to eliminate code duplication.
+ * Uses Template Method Pattern from LeadAgentBase to eliminate code
+ * duplication.
  *
  * Responsibilities:
  * - Decompose module goals into individual tasks
@@ -64,7 +65,8 @@ class ModuleLeadAgent : public LeadAgentBase<ModuleLeadState> {
   /**
    * @brief Synthesize results from all completed tasks
    *
-   * Public API for manual result synthesis (typically called after all results received)
+   * Public API for manual result synthesis (typically called after all results
+   * received)
    *
    * @return std::string Synthesized module-level result
    */
@@ -140,7 +142,8 @@ class ModuleLeadAgent : public LeadAgentBase<ModuleLeadState> {
    *
    * @param result_msg Message containing task result
    */
-  void processSubordinateResult(const core::KeystoneMessage& result_msg) override;
+  void processSubordinateResult(
+      const core::KeystoneMessage& result_msg) override;
 
   /**
    * @brief Convert state enum to string (HOOK METHOD)
@@ -155,14 +158,6 @@ class ModuleLeadAgent : public LeadAgentBase<ModuleLeadState> {
   std::vector<std::string> available_task_agents_;
 
 #ifdef ENABLE_GRPC
-  /**
-   * @brief Mark spec as FAILED and submit the error result via gRPC if possible
-   *
-   * @param spec  Task spec to update (modified in place)
-   * @param error Human-readable error message
-   */
-  void submitFailureResult(network::HierarchicalTaskSpec& spec, const std::string& error);
-
   // Result aggregator (module-specific, not in template)
   std::unique_ptr<network::ResultAggregator> result_aggregator_;
 #endif

--- a/src/agents/component_lead_agent.cpp
+++ b/src/agents/component_lead_agent.cpp
@@ -1,34 +1,33 @@
 #include "agents/component_lead_agent.hpp"
 
-#include "concurrency/logger.hpp"
-#include "core/config.hpp"
-
 #include <algorithm>
 #include <chrono>
 #include <regex>
 #include <sstream>
 #include <thread>
 
+#include "concurrency/logger.hpp"
+#include "core/config.hpp"
+
 #ifdef ENABLE_GRPC
-#  include "hmas_coordinator.pb.h"
+#include "hmas_coordinator.pb.h"
 #endif
 
 namespace keystone {
 namespace agents {
 
 ComponentLeadAgent::ComponentLeadAgent(const std::string& agent_id)
-    : LeadAgentBase<State>(agent_id,
-                           State::IDLE,
-                           State::PLANNING,
-                           State::WAITING_FOR_MODULES,
-                           State::AGGREGATING,
+    : LeadAgentBase<State>(agent_id, State::IDLE, State::PLANNING,
+                           State::WAITING_FOR_MODULES, State::AGGREGATING,
                            State::ERROR) {
   // Base class constructor initializes coordination_ with IDLE state
 }
 
-// processMessage() is now implemented in LeadAgentBase (template method pattern)
+// processMessage() is now implemented in LeadAgentBase (template method
+// pattern)
 
-void ComponentLeadAgent::setAvailableModuleLeads(const std::vector<std::string>& module_lead_ids) {
+void ComponentLeadAgent::setAvailableModuleLeads(
+    const std::vector<std::string>& module_lead_ids) {
   available_module_leads_ = module_lead_ids;
 }
 
@@ -39,15 +38,17 @@ bool ComponentLeadAgent::isSubordinateResult(const core::KeystoneMessage& msg) {
   return msg.command == "module_result";
 }
 
-std::vector<std::string> ComponentLeadAgent::decomposeGoal(const std::string& goal) {
+std::vector<std::string> ComponentLeadAgent::decomposeGoal(
+    const std::string& goal) {
   std::vector<std::string> module_goals;
 
-  // Parse component goal like "Implement Core component: Messaging(10+20+30) and
-  // Concurrency(40+50+60)" Extract module sections using regex
+  // Parse component goal like "Implement Core component: Messaging(10+20+30)
+  // and Concurrency(40+50+60)" Extract module sections using regex
 
   // Pattern to match "ModuleName(numbers)"
   std::regex module_regex(R"((\w+)\(([0-9+]+)\))");
-  auto modules_begin = std::sregex_iterator(goal.begin(), goal.end(), module_regex);
+  auto modules_begin =
+      std::sregex_iterator(goal.begin(), goal.end(), module_regex);
   auto modules_end = std::sregex_iterator();
 
   for (std::sregex_iterator i = modules_begin; i != modules_end; ++i) {
@@ -63,7 +64,8 @@ std::vector<std::string> ComponentLeadAgent::decomposeGoal(const std::string& go
   return module_goals;
 }
 
-void ComponentLeadAgent::delegateSubtasks(const std::vector<std::string>& subtasks) {
+void ComponentLeadAgent::delegateSubtasks(
+    const std::vector<std::string>& subtasks) {
   // Assign module goals to available ModuleLeadAgents
   for (size_t i = 0; i < subtasks.size(); ++i) {
     if (available_module_leads_.empty()) {
@@ -78,7 +80,8 @@ void ComponentLeadAgent::delegateSubtasks(const std::vector<std::string>& subtas
     const std::string& module_lead_id = available_module_leads_[i];
 
     // Create and send module goal message
-    auto module_msg = core::KeystoneMessage::create(agent_id_, module_lead_id, subtasks[i]);
+    auto module_msg =
+        core::KeystoneMessage::create(agent_id_, module_lead_id, subtasks[i]);
 
     // Track pending module
     coordination_.trackPendingSubordinate(module_msg.msg_id, module_lead_id);
@@ -88,7 +91,8 @@ void ComponentLeadAgent::delegateSubtasks(const std::vector<std::string>& subtas
   }
 }
 
-void ComponentLeadAgent::processSubordinateResult(const core::KeystoneMessage& result_msg) {
+void ComponentLeadAgent::processSubordinateResult(
+    const core::KeystoneMessage& result_msg) {
   if (!result_msg.payload) {
     // No payload, skip
     return;
@@ -99,7 +103,8 @@ void ComponentLeadAgent::processSubordinateResult(const core::KeystoneMessage& r
 
   // Check if we've received all module results
   if (all_complete) {
-    coordination_.transitionTo(State::AGGREGATING, stateToString(State::AGGREGATING));
+    coordination_.transitionTo(State::AGGREGATING,
+                               stateToString(State::AGGREGATING));
   }
 }
 
@@ -107,14 +112,16 @@ std::string ComponentLeadAgent::synthesizeComponentResult() {
   State current_state = coordination_.getCurrentState();
   if (current_state == State::ERROR) {
     auto failures = coordination_.getFailureMessages();
-    std::string msg = "ERROR: " + std::to_string(coordination_.getFailureCount()) +
-                      " subordinate module(s) failed";
+    std::string msg =
+        "ERROR: " + std::to_string(coordination_.getFailureCount()) +
+        " subordinate module(s) failed";
     if (!failures.empty()) {
       msg += ": " + failures.front();
     }
     return msg;
   }
-  if (current_state != State::AGGREGATING && current_state != State::WAITING_FOR_MODULES) {
+  if (current_state != State::AGGREGATING &&
+      current_state != State::WAITING_FOR_MODULES) {
     return "ERROR: Cannot synthesize in current state";
   }
 
@@ -152,33 +159,15 @@ std::string ComponentLeadAgent::stateToString(State state) const {
   }
 }
 
-#ifdef ENABLE_GRPC
-void ComponentLeadAgent::submitFailureResult(network::HierarchicalTaskSpec& spec,
-                                             const std::string& error) {
-  spec.status.phase = "FAILED";
-  spec.status.error = error;
-  coordination_.transitionTo(State::ERROR, stateToString(State::ERROR));
-
-  std::string result_yaml = network::YamlParser::generateTaskSpec(spec);
-  auto coordinator_client = coordination_.getCoordinatorClient();
-  if (coordinator_client && spec.metadata.parent_task_id) {
-    hmas::TaskResult task_result;
-    task_result.set_task_id(spec.metadata.task_id);
-    task_result.set_result_yaml(result_yaml);
-    task_result.set_success(false);
-    task_result.set_error_message(*spec.status.error);
-    coordinator_client->submitResult(task_result);
-  }
-}
-
 void ComponentLeadAgent::initializeGrpc(const std::string& coordinator_address,
                                         const std::string& registry_address,
                                         const std::string& agent_type,
                                         uint8_t level) {
   // Delegate gRPC initialization to coordination template
-  std::vector<std::string> capabilities = {"module_coordination", "component_synthesis"};
-  coordination_.initializeGrpc(
-      agent_id_, coordinator_address, registry_address, agent_type, level, capabilities, 10);
+  std::vector<std::string> capabilities = {"module_coordination",
+                                           "component_synthesis"};
+  coordination_.initializeGrpc(agent_id_, coordinator_address, registry_address,
+                               agent_type, level, capabilities, 10);
 }
 
 void ComponentLeadAgent::processYamlComponent(const std::string& yaml_spec) {
@@ -193,7 +182,8 @@ void ComponentLeadAgent::processYamlComponent(const std::string& yaml_spec) {
   coordination_.transitionTo(State::PLANNING, stateToString(State::PLANNING));
 
   // Decompose component into modules using the hook method
-  auto module_goals = decomposeGoal(spec.hierarchy.level1_directive.value_or(""));
+  auto module_goals =
+      decomposeGoal(spec.hierarchy.level1_directive.value_or(""));
 
   if (module_goals.empty()) {
     submitFailureResult(spec, "Failed to decompose component goal");
@@ -201,7 +191,8 @@ void ComponentLeadAgent::processYamlComponent(const std::string& yaml_spec) {
   }
 
   // Query for available ModuleLeadAgents
-  available_module_leads_ = coordination_.queryAvailableChildren("ModuleLeadAgent");
+  available_module_leads_ =
+      coordination_.queryAvailableChildren("ModuleLeadAgent");
 
   if (available_module_leads_.empty()) {
     submitFailureResult(spec, "No ModuleLeadAgents available");
@@ -212,11 +203,13 @@ void ComponentLeadAgent::processYamlComponent(const std::string& yaml_spec) {
   auto timeout = network::YamlParser::parseDuration(spec.aggregation.timeout);
   result_aggregator_ = std::make_unique<network::ResultAggregator>(
       network::stringToStrategy(spec.aggregation.strategy),
-      std::chrono::milliseconds(timeout.value_or(core::Config::DEFAULT_TASK_TIMEOUT_MS)),
+      std::chrono::milliseconds(
+          timeout.value_or(core::Config::DEFAULT_TASK_TIMEOUT_MS)),
       module_goals.size());
 
   // Generate child module YAMLs and submit to ModuleLeadAgents
-  coordination_.transitionTo(State::WAITING_FOR_MODULES, stateToString(State::WAITING_FOR_MODULES));
+  coordination_.transitionTo(State::WAITING_FOR_MODULES,
+                             stateToString(State::WAITING_FOR_MODULES));
   coordination_.initializeCoordination(static_cast<int>(module_goals.size()));
 
   for (size_t i = 0; i < module_goals.size(); ++i) {
@@ -225,7 +218,8 @@ void ComponentLeadAgent::processYamlComponent(const std::string& yaml_spec) {
     child_spec.api_version = "v1";
     child_spec.kind = "HierarchicalTask";
     child_spec.metadata.name = "module-" + std::to_string(i);
-    child_spec.metadata.task_id = spec.metadata.task_id + "-module-" + std::to_string(i);
+    child_spec.metadata.task_id =
+        spec.metadata.task_id + "-module-" + std::to_string(i);
     child_spec.metadata.parent_task_id = spec.metadata.task_id;
     child_spec.metadata.session_id = spec.metadata.session_id;
 
@@ -251,17 +245,16 @@ void ComponentLeadAgent::processYamlComponent(const std::string& yaml_spec) {
 
     // Submit module via gRPC
     try {
-      auto deadline_ms = network::YamlParser::parseDuration(spec.metadata.deadline.value_or("25m"))
+      auto deadline_ms = network::YamlParser::parseDuration(
+                             spec.metadata.deadline.value_or("25m"))
                              .value_or(core::Config::DEFAULT_TASK_TIMEOUT_MS);
       auto coordinator_client = coordination_.getCoordinatorClient();
-      auto response = coordinator_client->submitTask(child_yaml,
-                                                     spec.metadata.session_id.value_or(""),
-                                                     deadline_ms,
-                                                     hmas::TASK_PRIORITY_NORMAL,
-                                                     coordination_.getCurrentTaskId());
+      auto response = coordinator_client->submitTask(
+          child_yaml, spec.metadata.session_id.value_or(""), deadline_ms,
+          hmas::TASK_PRIORITY_NORMAL, coordination_.getCurrentTaskId());
 
-      coordination_.trackPendingSubordinate(child_spec.metadata.task_id,
-                                            available_module_leads_[agent_index]);
+      coordination_.trackPendingSubordinate(
+          child_spec.metadata.task_id, available_module_leads_[agent_index]);
     } catch (const std::exception& e) {
       concurrency::Logger::error("Failed to submit module: {}", e.what());
     }

--- a/src/agents/module_lead_agent.cpp
+++ b/src/agents/module_lead_agent.cpp
@@ -1,8 +1,5 @@
 #include "agents/module_lead_agent.hpp"
 
-#include "concurrency/logger.hpp"
-#include "core/config.hpp"
-
 #include <algorithm>
 #include <chrono>
 #include <cstdint>
@@ -11,26 +8,28 @@
 #include <sstream>
 #include <thread>
 
+#include "concurrency/logger.hpp"
+#include "core/config.hpp"
+
 #ifdef ENABLE_GRPC
-#  include "hmas_coordinator.pb.h"
+#include "hmas_coordinator.pb.h"
 #endif
 
 namespace keystone {
 namespace agents {
 
 ModuleLeadAgent::ModuleLeadAgent(const std::string& agent_id)
-    : LeadAgentBase<State>(agent_id,
-                           State::IDLE,
-                           State::PLANNING,
-                           State::WAITING_FOR_TASKS,
-                           State::SYNTHESIZING,
+    : LeadAgentBase<State>(agent_id, State::IDLE, State::PLANNING,
+                           State::WAITING_FOR_TASKS, State::SYNTHESIZING,
                            State::ERROR) {
   // Base class constructor initializes coordination_ with IDLE state
 }
 
-// processMessage() is now implemented in LeadAgentBase (template method pattern)
+// processMessage() is now implemented in LeadAgentBase (template method
+// pattern)
 
-void ModuleLeadAgent::setAvailableTaskAgents(const std::vector<std::string>& task_agent_ids) {
+void ModuleLeadAgent::setAvailableTaskAgents(
+    const std::vector<std::string>& task_agent_ids) {
   available_task_agents_ = task_agent_ids;
 }
 
@@ -41,7 +40,8 @@ bool ModuleLeadAgent::isSubordinateResult(const core::KeystoneMessage& msg) {
   return msg.command == "response";
 }
 
-std::vector<std::string> ModuleLeadAgent::decomposeGoal(const std::string& goal) {
+std::vector<std::string> ModuleLeadAgent::decomposeGoal(
+    const std::string& goal) {
   std::vector<std::string> tasks;
 
   // Parse module goal like "Calculate sum of: 10 + 20 + 30"
@@ -49,7 +49,8 @@ std::vector<std::string> ModuleLeadAgent::decomposeGoal(const std::string& goal)
 
   // Extract numbers using regex
   std::regex number_regex(R"(\d+)");
-  auto numbers_begin = std::sregex_iterator(goal.begin(), goal.end(), number_regex);
+  auto numbers_begin =
+      std::sregex_iterator(goal.begin(), goal.end(), number_regex);
   auto numbers_end = std::sregex_iterator();
 
   // Create a task for each number (echo the number)
@@ -62,7 +63,8 @@ std::vector<std::string> ModuleLeadAgent::decomposeGoal(const std::string& goal)
   return tasks;
 }
 
-void ModuleLeadAgent::delegateSubtasks(const std::vector<std::string>& subtasks) {
+void ModuleLeadAgent::delegateSubtasks(
+    const std::vector<std::string>& subtasks) {
   // Assign tasks to available TaskAgents in round-robin fashion
   for (size_t i = 0; i < subtasks.size(); ++i) {
     if (available_task_agents_.empty()) {
@@ -74,7 +76,8 @@ void ModuleLeadAgent::delegateSubtasks(const std::vector<std::string>& subtasks)
     const std::string& task_agent_id = available_task_agents_[agent_index];
 
     // Create and send task message
-    auto task_msg = core::KeystoneMessage::create(agent_id_, task_agent_id, subtasks[i]);
+    auto task_msg =
+        core::KeystoneMessage::create(agent_id_, task_agent_id, subtasks[i]);
 
     // Track pending task
     coordination_.trackPendingSubordinate(task_msg.msg_id, task_agent_id);
@@ -84,7 +87,8 @@ void ModuleLeadAgent::delegateSubtasks(const std::vector<std::string>& subtasks)
   }
 }
 
-void ModuleLeadAgent::processSubordinateResult(const core::KeystoneMessage& result_msg) {
+void ModuleLeadAgent::processSubordinateResult(
+    const core::KeystoneMessage& result_msg) {
   if (!result_msg.payload) {
     // No payload, skip
     return;
@@ -95,7 +99,8 @@ void ModuleLeadAgent::processSubordinateResult(const core::KeystoneMessage& resu
 
   // Check if we've received all results
   if (all_complete) {
-    coordination_.transitionTo(State::SYNTHESIZING, stateToString(State::SYNTHESIZING));
+    coordination_.transitionTo(State::SYNTHESIZING,
+                               stateToString(State::SYNTHESIZING));
   }
 }
 
@@ -103,14 +108,16 @@ std::string ModuleLeadAgent::synthesizeResults() {
   State current_state = coordination_.getCurrentState();
   if (current_state == State::ERROR) {
     auto failures = coordination_.getFailureMessages();
-    std::string msg = "ERROR: " + std::to_string(coordination_.getFailureCount()) +
-                      " subordinate task(s) failed";
+    std::string msg =
+        "ERROR: " + std::to_string(coordination_.getFailureCount()) +
+        " subordinate task(s) failed";
     if (!failures.empty()) {
       msg += ": " + failures.front();
     }
     return msg;
   }
-  if (current_state != State::SYNTHESIZING && current_state != State::WAITING_FOR_TASKS) {
+  if (current_state != State::SYNTHESIZING &&
+      current_state != State::WAITING_FOR_TASKS) {
     return "ERROR: Cannot synthesize in current state";
   }
 
@@ -151,33 +158,15 @@ std::string ModuleLeadAgent::stateToString(State state) const {
   }
 }
 
-#ifdef ENABLE_GRPC
-void ModuleLeadAgent::submitFailureResult(network::HierarchicalTaskSpec& spec,
-                                          const std::string& error) {
-  spec.status.phase = "FAILED";
-  spec.status.error = error;
-  coordination_.transitionTo(State::ERROR, stateToString(State::ERROR));
-
-  std::string result_yaml = network::YamlParser::generateTaskSpec(spec);
-  auto coordinator_client = coordination_.getCoordinatorClient();
-  if (coordinator_client && spec.metadata.parent_task_id) {
-    hmas::TaskResult task_result;
-    task_result.set_task_id(spec.metadata.task_id);
-    task_result.set_result_yaml(result_yaml);
-    task_result.set_success(false);
-    task_result.set_error_message(*spec.status.error);
-    coordinator_client->submitResult(task_result);
-  }
-}
-
 void ModuleLeadAgent::initializeGrpc(const std::string& coordinator_address,
                                      const std::string& registry_address,
                                      const std::string& agent_type,
                                      uint8_t level) {
   // Delegate gRPC initialization to coordination template
-  std::vector<std::string> capabilities = {"task_coordination", "result_synthesis"};
-  coordination_.initializeGrpc(
-      agent_id_, coordinator_address, registry_address, agent_type, level, capabilities, 5);
+  std::vector<std::string> capabilities = {"task_coordination",
+                                           "result_synthesis"};
+  coordination_.initializeGrpc(agent_id_, coordinator_address, registry_address,
+                               agent_type, level, capabilities, 5);
 }
 
 void ModuleLeadAgent::processYamlModule(const std::string& yaml_spec) {
@@ -212,11 +201,13 @@ void ModuleLeadAgent::processYamlModule(const std::string& yaml_spec) {
   auto timeout = network::YamlParser::parseDuration(spec.aggregation.timeout);
   result_aggregator_ = std::make_unique<network::ResultAggregator>(
       network::stringToStrategy(spec.aggregation.strategy),
-      std::chrono::milliseconds(timeout.value_or(core::Config::DEFAULT_TASK_TIMEOUT_MS)),
+      std::chrono::milliseconds(
+          timeout.value_or(core::Config::DEFAULT_TASK_TIMEOUT_MS)),
       tasks.size());
 
   // Generate child task YAMLs and submit to TaskAgents
-  coordination_.transitionTo(State::WAITING_FOR_TASKS, stateToString(State::WAITING_FOR_TASKS));
+  coordination_.transitionTo(State::WAITING_FOR_TASKS,
+                             stateToString(State::WAITING_FOR_TASKS));
   coordination_.initializeCoordination(static_cast<int32_t>(tasks.size()));
 
   for (size_t i = 0; i < tasks.size(); ++i) {
@@ -225,7 +216,8 @@ void ModuleLeadAgent::processYamlModule(const std::string& yaml_spec) {
     child_spec.api_version = "v1";
     child_spec.kind = "HierarchicalTask";
     child_spec.metadata.name = "task-" + std::to_string(i);
-    child_spec.metadata.task_id = spec.metadata.task_id + "-subtask-" + std::to_string(i);
+    child_spec.metadata.task_id =
+        spec.metadata.task_id + "-subtask-" + std::to_string(i);
     child_spec.metadata.parent_task_id = spec.metadata.task_id;
     child_spec.metadata.session_id = spec.metadata.session_id;
 
@@ -251,17 +243,16 @@ void ModuleLeadAgent::processYamlModule(const std::string& yaml_spec) {
 
     // Submit task via gRPC
     try {
-      auto deadline_ms = network::YamlParser::parseDuration(spec.metadata.deadline.value_or("25m"))
+      auto deadline_ms = network::YamlParser::parseDuration(
+                             spec.metadata.deadline.value_or("25m"))
                              .value_or(core::Config::DEFAULT_TASK_TIMEOUT_MS);
       auto coordinator_client = coordination_.getCoordinatorClient();
-      auto response = coordinator_client->submitTask(child_yaml,
-                                                     spec.metadata.session_id.value_or(""),
-                                                     deadline_ms,
-                                                     hmas::TASK_PRIORITY_NORMAL,
-                                                     coordination_.getCurrentTaskId());
+      auto response = coordinator_client->submitTask(
+          child_yaml, spec.metadata.session_id.value_or(""), deadline_ms,
+          hmas::TASK_PRIORITY_NORMAL, coordination_.getCurrentTaskId());
 
-      coordination_.trackPendingSubordinate(child_spec.metadata.task_id,
-                                            available_task_agents_[agent_index]);
+      coordination_.trackPendingSubordinate(
+          child_spec.metadata.task_id, available_task_agents_[agent_index]);
     } catch (const std::exception& e) {
       concurrency::Logger::error("Failed to submit task: {}", e.what());
     }


### PR DESCRIPTION
## Summary

- `ComponentLeadAgent::submitFailureResult()` and `ModuleLeadAgent::submitFailureResult()` were byte-for-byte identical
- Extracted the shared implementation to `LeadAgentBase<T>` as a `protected` non-virtual method under `#ifdef ENABLE_GRPC`
- Uses `this->coordination_` and `this->error_state_` for correct dependent name lookup in the template context
- Removed declarations from `component_lead_agent.hpp` and `module_lead_agent.hpp`
- Removed implementations from `component_lead_agent.cpp` and `module_lead_agent.cpp`

## Test plan

- [ ] Verify `grep -n "submitFailureResult" include/agents/lead_agent_base.hpp` shows the extracted method
- [ ] Verify no `submitFailureResult` definitions remain in the subclass headers or .cpp files
- [ ] Build with ENABLE_GRPC to confirm the inherited method resolves correctly
- [ ] Run existing unit tests for `ComponentLeadAgent` and `ModuleLeadAgent`

Closes #348

🤖 Generated with [Claude Code](https://claude.com/claude-code)