### PR TITLE
feat(task_claimer): add lock cleanup, coalesced metrics, startup_scan

### DIFF
--- a/src/keystone/task_claimer.py
+++ b/src/keystone/task_claimer.py
@@ -35,17 +35,58 @@ class TaskClaimer:
         self._team_locks: dict[str, asyncio.Lock] = {}
         self._advancing: set[str] = set()
         self._in_flight: set[asyncio.Task[Any]] = set()
+        # Issue #295: track coalesced (skipped) advance_dag calls per team
+        self._coalesced_count: dict[str, int] = {}
 
     @property
     def in_flight_count(self) -> int:
         """Number of advance_dag_tracked tasks currently executing."""
         return len(self._in_flight)
 
+    def get_coalesced_count(self, team_id: str) -> int:
+        """Return the number of coalesced (skipped) advance_dag calls for a team.
+
+        A call is coalesced when advance_dag is invoked while another call for
+        the same team is already in-flight.
+
+        Args:
+            team_id: The team whose coalesced count to retrieve.
+
+        Returns:
+            Number of coalesced calls recorded for this team (0 if none).
+        """
+        return self._coalesced_count.get(team_id, 0)
+
+    def get_metrics(self) -> dict[str, Any]:
+        """Return a snapshot of coalesced-call metrics for all teams.
+
+        Returns:
+            A dict mapping team_id to its coalesced call count.
+        """
+        return dict(self._coalesced_count)
+
     def _get_team_lock(self, team_id: str) -> asyncio.Lock:
         """Return the per-team lock, creating it lazily if needed."""
         if team_id not in self._team_locks:
             self._team_locks[team_id] = asyncio.Lock()
         return self._team_locks[team_id]
+
+    def cleanup_idle_teams(self) -> list[str]:
+        """Remove per-team locks for teams that are not currently advancing.
+
+        Teams with an active advance_dag call in progress are kept. All other
+        teams have their lock entry removed from ``_team_locks``, preventing
+        unbounded growth as new team IDs are seen over time.
+
+        Returns:
+            List of team IDs whose locks were removed.
+        """
+        idle_teams = [t for t in self._team_locks if t not in self._advancing]
+        for team_id in idle_teams:
+            del self._team_locks[team_id]
+        if idle_teams:
+            logger.debug("cleanup_idle_teams: removed %d team locks", len(idle_teams))
+        return idle_teams
 
     async def advance_dag(self, team_id: str) -> list[str]:
         """Fetch ready tasks for team_id and claim them.
@@ -63,8 +104,9 @@ class TaskClaimer:
         """
         if team_id in self._advancing:
             logger.info(
-                "advance_dag already in-flight for team %s — skipping", team_id
+                "advance_dag already in-flight for team %s -- skipping", team_id
             )
+            self._coalesced_count[team_id] = self._coalesced_count.get(team_id, 0) + 1
             return []
 
         self._advancing.add(team_id)
@@ -119,3 +161,22 @@ class TaskClaimer:
         except asyncio.TimeoutError:
             logger.warning("drain_timeout", extra={"timeout": timeout})
             return False
+
+    async def startup_scan(self, team_ids: list[str]) -> list[asyncio.Task[Any]]:
+        """Dispatch advance_dag_tracked for each team in team_ids.
+
+        This method is intended to be called at daemon startup to prime the
+        claim pipeline for all known teams. It schedules one tracked task per
+        team and returns the list of tasks so the caller can optionally await
+        them or pass them to drain().
+
+        Args:
+            team_ids: List of team IDs to scan on startup.
+
+        Returns:
+            List of asyncio.Task objects, one per team_id.
+        """
+        tasks: list[asyncio.Task[Any]] = []
+        for team_id in team_ids:
+            tasks.append(self.advance_dag_tracked(team_id))
+        return tasks

--- a/tests/test_task_claimer.py
+++ b/tests/test_task_claimer.py
@@ -95,7 +95,7 @@ async def test_concurrent_advance_dag_coalesced() -> None:
     # First call completes normally; second was coalesced
     assert result1 == ["t1"]
     assert result2 == []
-    # get_tasks called only once — second call was skipped before calling it
+    # get_tasks called only once - second call was skipped before calling it
     assert get_tasks_mock.await_count == 1
 
 
@@ -149,3 +149,203 @@ async def test_sequential_calls_same_team_both_execute() -> None:
     assert result1 == ["t1"]
     assert result2 == ["t1"]
     assert get_tasks_mock.await_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Issue #295 - coalesced count metrics
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_coalesced_count_increments_when_skipped() -> None:
+    """get_coalesced_count increments each time an advance_dag call is skipped."""
+    first_call_started = asyncio.Event()
+    first_call_proceed = asyncio.Event()
+
+    async def slow_get_tasks(team_id: str) -> list[dict]:
+        first_call_started.set()
+        await first_call_proceed.wait()
+        return []
+
+    get_tasks_mock = AsyncMock(side_effect=slow_get_tasks)
+    claim_mock = AsyncMock(return_value=True)
+    claimer = TaskClaimer(get_tasks=get_tasks_mock, claim_task=claim_mock)
+
+    async def first_call() -> list[str]:
+        return await claimer.advance_dag("team-X")
+
+    async def second_call() -> list[str]:
+        await first_call_started.wait()
+        result = await claimer.advance_dag("team-X")
+        first_call_proceed.set()
+        return result
+
+    await asyncio.gather(first_call(), second_call())
+
+    assert claimer.get_coalesced_count("team-X") == 1
+
+
+@pytest.mark.asyncio
+async def test_coalesced_count_zero_when_not_skipped() -> None:
+    """get_coalesced_count is 0 for a team that was never coalesced."""
+    claimer, _, _ = _make_claimer()
+    assert claimer.get_coalesced_count("team-never-seen") == 0
+
+
+@pytest.mark.asyncio
+async def test_get_metrics_returns_all_coalesced_teams() -> None:
+    """get_metrics returns a dict with entries for every coalesced team."""
+    first_started: dict[str, asyncio.Event] = {
+        "team-A": asyncio.Event(),
+        "team-B": asyncio.Event(),
+    }
+    proceed: dict[str, asyncio.Event] = {
+        "team-A": asyncio.Event(),
+        "team-B": asyncio.Event(),
+    }
+
+    async def slow_get_tasks(team_id: str) -> list[dict]:
+        first_started[team_id].set()
+        await proceed[team_id].wait()
+        return []
+
+    get_tasks_mock = AsyncMock(side_effect=slow_get_tasks)
+    claim_mock = AsyncMock(return_value=True)
+    claimer = TaskClaimer(get_tasks=get_tasks_mock, claim_task=claim_mock)
+
+    async def do_coalesce(team_id: str) -> None:
+        async def first() -> None:
+            await claimer.advance_dag(team_id)
+
+        async def second() -> None:
+            await first_started[team_id].wait()
+            await claimer.advance_dag(team_id)
+            proceed[team_id].set()
+
+        await asyncio.gather(first(), second())
+
+    await asyncio.gather(do_coalesce("team-A"), do_coalesce("team-B"))
+
+    metrics = claimer.get_metrics()
+    assert metrics.get("team-A", 0) == 1
+    assert metrics.get("team-B", 0) == 1
+
+
+# ---------------------------------------------------------------------------
+# Issue #296 - cleanup_idle_teams
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cleanup_idle_teams_removes_idle_locks() -> None:
+    """cleanup_idle_teams removes team locks that are not currently advancing."""
+    claimer, _, _ = _make_claimer()
+
+    # Trigger lazy lock creation for two teams by calling advance_dag
+    await claimer.advance_dag("team-A")
+    await claimer.advance_dag("team-B")
+
+    assert "team-A" in claimer._team_locks
+    assert "team-B" in claimer._team_locks
+
+    removed = claimer.cleanup_idle_teams()
+
+    assert "team-A" not in claimer._team_locks
+    assert "team-B" not in claimer._team_locks
+    assert set(removed) == {"team-A", "team-B"}
+
+
+@pytest.mark.asyncio
+async def test_cleanup_idle_teams_keeps_active_team() -> None:
+    """cleanup_idle_teams does not remove a lock for a team currently advancing."""
+    first_started = asyncio.Event()
+    proceed = asyncio.Event()
+
+    async def slow_get_tasks(team_id: str) -> list[dict]:
+        first_started.set()
+        await proceed.wait()
+        return []
+
+    claimer = TaskClaimer(
+        get_tasks=AsyncMock(side_effect=slow_get_tasks),
+        claim_task=AsyncMock(return_value=True),
+    )
+
+    advance_task = asyncio.get_event_loop().create_task(claimer.advance_dag("team-X"))
+    await first_started.wait()
+
+    # While team-X is actively advancing, cleanup should not remove it
+    removed = claimer.cleanup_idle_teams()
+    assert "team-X" not in removed
+    assert "team-X" in claimer._team_locks
+
+    proceed.set()
+    await advance_task
+
+
+@pytest.mark.asyncio
+async def test_cleanup_idle_teams_empty_is_noop() -> None:
+    """cleanup_idle_teams on a fresh claimer returns an empty list."""
+    claimer, _, _ = _make_claimer()
+    removed = claimer.cleanup_idle_teams()
+    assert removed == []
+
+
+# ---------------------------------------------------------------------------
+# Issue #300 - startup_scan
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_startup_scan_dispatches_advance_for_each_team() -> None:
+    """startup_scan schedules advance_dag_tracked for every supplied team_id."""
+    teams = {"team-A": [{"id": "a1"}], "team-B": [{"id": "b1"}]}
+    claimer, get_tasks_mock, claim_mock = _make_claimer(teams)
+
+    dispatched_tasks = await claimer.startup_scan(["team-A", "team-B"])
+
+    # All tasks should be asyncio.Task instances
+    assert len(dispatched_tasks) == 2
+    for t in dispatched_tasks:
+        assert isinstance(t, asyncio.Task)
+
+    # Let them all complete
+    await asyncio.gather(*dispatched_tasks)
+
+    # Both teams should have been fetched
+    assert get_tasks_mock.await_count == 2
+    called_teams = {c.args[0] for c in get_tasks_mock.call_args_list}
+    assert called_teams == {"team-A", "team-B"}
+
+
+@pytest.mark.asyncio
+async def test_startup_scan_empty_list_returns_no_tasks() -> None:
+    """startup_scan with an empty list produces no tasks."""
+    claimer, get_tasks_mock, _ = _make_claimer()
+
+    dispatched_tasks = await claimer.startup_scan([])
+
+    assert dispatched_tasks == []
+    get_tasks_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_startup_scan_tasks_are_tracked_in_flight() -> None:
+    """Tasks returned by startup_scan appear in the in_flight_count until done."""
+    proceed = asyncio.Event()
+
+    async def slow_get_tasks(team_id: str) -> list[dict]:
+        await proceed.wait()
+        return []
+
+    claimer = TaskClaimer(
+        get_tasks=AsyncMock(side_effect=slow_get_tasks),
+        claim_task=AsyncMock(return_value=True),
+    )
+
+    dispatched_tasks = await claimer.startup_scan(["team-A", "team-B"])
+    assert claimer.in_flight_count == 2
+
+    proceed.set()
+    await asyncio.gather(*dispatched_tasks)
+    assert claimer.in_flight_count == 0


### PR DESCRIPTION
## Summary

- **#296**: Add `cleanup_idle_teams()` method to `TaskClaimer` that removes `_team_locks` entries for teams not currently advancing, preventing unbounded dictionary growth as new team IDs are seen over time.
- **#295**: Add `_coalesced_count` dict incremented on each skipped/coalesced `advance_dag` call; expose via `get_coalesced_count(team_id)` and `get_metrics()` methods.
- **#300**: Add `async startup_scan(team_ids)` method that calls `advance_dag_tracked` for each team and returns the list of tracked tasks for optional awaiting or draining.

## Test plan

- [ ] `test_coalesced_count_increments_when_skipped` — verifies counter increments on coalesced calls
- [ ] `test_coalesced_count_zero_when_not_skipped` — verifies counter starts at 0
- [ ] `test_get_metrics_returns_all_coalesced_teams` — verifies `get_metrics()` covers all teams
- [ ] `test_cleanup_idle_teams_removes_idle_locks` — verifies idle locks are removed
- [ ] `test_cleanup_idle_teams_keeps_active_team` — verifies active team locks are preserved
- [ ] `test_cleanup_idle_teams_empty_is_noop` — verifies no-op on fresh claimer
- [ ] `test_startup_scan_dispatches_advance_for_each_team` — verifies all teams get a task
- [ ] `test_startup_scan_empty_list_returns_no_tasks` — verifies empty list is handled
- [ ] `test_startup_scan_tasks_are_tracked_in_flight` — verifies in_flight_count is correct

All 16 tests pass (`pixi run pytest tests/test_task_claimer.py`).

Closes #295
Closes #296
Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)