### PR TITLE
fix(agents): check isFailed() at entry of TaskAgent::processMessage (#376)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -416,7 +416,7 @@ add_executable(
   tests/unit/test_message_serializer.cpp
   # DISABLED: Async API not yet implemented
   # tests/unit/test_message_bus_async.cpp
-  # tests/unit/test_async_task_agent.cpp
+  tests/unit/test_async_task_agent.cpp  # Issue #376: isFailed() guard
   tests/unit/test_message_priority.cpp
   tests/unit/test_agent_core.cpp  # Additional coverage for AgentCore
   tests/unit/test_agent_id_interning.cpp  # Phase A2: Agent ID interning tests

--- a/src/agents/task_agent.cpp
+++ b/src/agents/task_agent.cpp
@@ -47,6 +47,15 @@ concurrency::Task<core::Response> TaskAgent::processMessage(const core::Keystone
   // Record message processed for metrics tracking
   core::Metrics::getInstance().recordMessageProcessed(msg.msg_id);
 
+  // Issue #376: Reject immediately if agent is in failed state
+  if (isFailed()) {
+    auto response = core::Response::createError(msg,
+                                                agent_id_,
+                                                "Agent is in failed state: " + getFailureReason());
+    sendResponseMessage(msg, response.result);
+    co_return response;
+  }
+
   // Phase 1.2 (Issue #52): Handle CANCEL_TASK action type
   if (msg.action_type == core::ActionType::CANCEL_TASK) {
     auto response = handleCancellation(msg);

--- a/tests/unit/test_async_task_agent.cpp
+++ b/tests/unit/test_async_task_agent.cpp
@@ -195,3 +195,16 @@ TEST_F(AsyncTaskAgentTest, SchedulerRequired) {
   ASSERT_TRUE(inbox_msg.has_value());
   EXPECT_EQ(inbox_msg->command, "echo test");
 }
+
+// Issue #376: A failed agent must reject messages without executing them.
+TEST_F(AsyncTaskAgentTest, FailedAgentRejectsMessages) {
+  agent_->markAsFailed("injected failure");
+
+  auto msg = KeystoneMessage::create("test", agent_->getAgentId(), "echo hello");
+  bus_->routeMessage(msg);
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+  // Command should NOT have been logged (agent rejected it before execution)
+  const auto& history = agent_->getCommandHistory();
+  EXPECT_TRUE(history.empty());
+}


### PR DESCRIPTION
## Summary

- Added `isFailed()` guard at the start of `TaskAgent::processMessage()` — if the agent is in a failed state, the message is rejected immediately with an error response containing the failure reason
- Added `FailedAgentRejectsMessages` unit test that marks an agent as failed then sends a command and verifies the command log remains empty
- Enabled `test_async_task_agent.cpp` in `CMakeLists.txt` (was previously commented out as "Async API not yet implemented")

## Test plan

- [x] New `FailedAgentRejectsMessages` test passes
- [x] All existing `AsyncTaskAgentTest` tests pass (10/10) under ASan build

Closes #376

🤖 Generated with [Claude Code](https://claude.com/claude-code)