### PR TITLE
fix(agents): capture weak_ptr in AsyncAgent scheduler lambda (#375)

### DIFF
--- a/include/agents/async_agent.hpp
+++ b/include/agents/async_agent.hpp
@@ -21,7 +21,7 @@ namespace agents {
  * with a single async-by-default base class, enabling polymorphic collections
  * and runtime execution model flexibility.
  */
-class AsyncAgent : public AgentCore {
+class AsyncAgent : public AgentCore, public std::enable_shared_from_this<AsyncAgent> {
  public:
   /**
    * @brief Construct a new Async Agent

--- a/src/agents/async_agent.cpp
+++ b/src/agents/async_agent.cpp
@@ -14,13 +14,19 @@ void AsyncAgent::receiveMessage(const core::KeystoneMessage& msg) {
   }
 
   // Scheduler stored: auto-process via worker thread (push model).
-  // The MessageBus holds a shared_ptr to this agent while the lambda is pending,
-  // so 'this' is safe to capture (scheduler drains before agents are destroyed).
-  sched->submit([this, msg]() {
+  // Capture a weak_ptr so that if the agent is destroyed while the lambda is
+  // still queued, the lock() returns null and the lambda silently no-ops
+  // instead of causing use-after-free.
+  std::weak_ptr<AsyncAgent> weak_self = weak_from_this();
+  sched->submit([weak_self, msg]() {
+    auto self = weak_self.lock();
+    if (!self) {
+      return;  // Agent was destroyed while lambda was queued
+    }
     // processMessage returns a Task<Response>; drive it to completion synchronously
     // on the worker thread. The thread-local scheduler is set, so any co_await
     // inside processMessage routes continuations through the worker pool.
-    auto task = processMessage(msg);
+    auto task = self->processMessage(msg);
     task.get();
   });
 }


### PR DESCRIPTION
## Summary

- `AsyncAgent::receiveMessage()` now captures `weak_ptr<AsyncAgent>` in the scheduler lambda instead of bare `this`
- Inside the lambda, `weak_self.lock()` is called; if the agent has been destroyed while the lambda was queued, the lambda silently returns instead of causing use-after-free
- `AsyncAgent` inherits from `std::enable_shared_from_this<AsyncAgent>` to enable `weak_from_this()`
- `AgentCore` was confirmed not to inherit from `enable_shared_from_this`, so no diamond inheritance issue arises

## Test plan

- [x] Existing async/cancellation agent tests pass (10/10)
- [x] All stack-allocated test agents were already using `make_shared` — no fixtures broken
- [x] Build completes cleanly with no errors or warnings on the modified files

Closes #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)