### PR TITLE
feat(agents): allow sleep <=10s in ALLOWED_COMMANDS, restore timing tests (#377)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -362,14 +362,23 @@ target_link_libraries(async_delegation_tests keystone_agents keystone_core
 
 gtest_discover_tests(async_delegation_tests)
 
-# E2E Tests - Async Agents (Coroutines) DISABLED: Phase 6 async features not yet
-# implemented add_executable(async_agents_tests tests/e2e/async_agents_test.cpp
-# tests/e2e/full_async_hierarchy_test.cpp)
+# E2E Tests - Async Agents (Coroutines)
+# ENABLED: sleep ≤10s now allowed by validateCommand() (Issue #377)
+add_executable(async_agents_tests tests/e2e/async_agents_test.cpp)
+
+target_link_libraries(async_agents_tests keystone_agents keystone_core
+                      keystone_concurrency GTest::gtest_main)
+
+gtest_discover_tests(async_agents_tests)
+
+# E2E Tests - Full Async 4-Layer Hierarchy (Phase 6 full coroutines)
+# DISABLED: full coroutine hierarchy not yet implemented
+# add_executable(full_async_hierarchy_tests tests/e2e/full_async_hierarchy_test.cpp)
 #
-# target_link_libraries(async_agents_tests keystone_agents keystone_core
-# keystone_concurrency GTest::gtest_main)
+# target_link_libraries(full_async_hierarchy_tests keystone_agents keystone_core
+#                       keystone_concurrency GTest::gtest_main)
 #
-# gtest_discover_tests(async_agents_tests)
+# gtest_discover_tests(full_async_hierarchy_tests)
 
 # E2E Tests - Distributed Hierarchy
 add_executable(distributed_hierarchy_tests

--- a/src/agents/task_agent.cpp
+++ b/src/agents/task_agent.cpp
@@ -138,7 +138,18 @@ void TaskAgent::validateCommand(const std::string& command) {
     return;  // SAFE: Simple text echo
   }
 
-  // Pattern 3: Whitelisted commands with no arguments
+  // Pattern 3: sleep with max duration (prevent DoS via long sleeps)
+  static const std::regex sleep_pattern(R"(^sleep ([0-9]+(?:\.[0-9]+)?)$)");
+  std::smatch sleep_match;
+  if (std::regex_match(command, sleep_match, sleep_pattern)) {
+    double duration = std::stod(sleep_match[1].str());
+    if (duration > 10.0) {
+      throw std::runtime_error("sleep duration exceeds maximum allowed (10s)");
+    }
+    return;  // SAFE: short sleep
+  }
+
+  // Pattern 4: Whitelisted commands with no arguments
   std::istringstream iss(command);
   std::string base_command;
   iss >> base_command;
@@ -162,7 +173,8 @@ void TaskAgent::validateCommand(const std::string& command) {
   ss << "Allowed patterns:\n";
   ss << "  1. Arithmetic: echo $((expression))\n";
   ss << "  2. Simple echo: echo <text>\n";
-  ss << "  3. Whitelisted commands: ";
+  ss << "  3. sleep <N> where N <= 10\n";
+  ss << "  4. Whitelisted commands: ";
   bool first = true;
   for (const auto& cmd : ALLOWED_COMMANDS) {
     if (!first)

--- a/tests/e2e/async_agents_test.cpp
+++ b/tests/e2e/async_agents_test.cpp
@@ -2,8 +2,10 @@
 #include "concurrency/work_stealing_scheduler.hpp"
 #include "core/message_bus.hpp"
 
+#include <algorithm>
 #include <chrono>
 #include <map>
+#include <set>
 #include <thread>
 #include <vector>
 
@@ -108,28 +110,28 @@ TEST(E2E_PhaseB, AsyncAgentsConcurrentProcessing) {
   agent->setScheduler(&scheduler);
   bus.registerAgent(agent->getAgentId(), agent);
 
-  // Send 10 echo commands (sleep is blocked by security validation)
-  for (int32_t i = 0; i < 10; ++i) {
+  // Send sleep + 9 echo commands concurrently to verify true concurrent processing
+  auto sleep_msg = KeystoneMessage::create("test", agent->getAgentId(), "sleep 1");
+  bus.routeMessage(sleep_msg);
+
+  for (int32_t i = 0; i < 9; ++i) {
     auto cmd = "echo " + std::to_string(i);
     auto msg = KeystoneMessage::create("test", agent->getAgentId(), cmd);
     bus.routeMessage(msg);
   }
 
-  // Wait for all to complete
-  std::this_thread::sleep_for(std::chrono::milliseconds(400));
+  // After 500ms, the echo commands should be done but sleep still running
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+  const auto& mid_history = agent->getCommandHistory();
+  // At minimum the echo commands should be mostly done
+  size_t echo_done = std::count_if(mid_history.begin(), mid_history.end(), [](const auto& p) {
+    return p.first.substr(0, 4) == "echo";
+  });
+  EXPECT_GE(echo_done, 5u) << "echo commands should process concurrently with sleep";
 
-  const auto& history = agent->getCommandHistory();
-  ASSERT_EQ(history.size(), 10);
-
-  // Verify all results present
-  std::set<std::string> results;
-  for (const auto& [cmd, result] : history) {
-    results.insert(result);
-  }
-
-  for (int32_t i = 0; i < 10; ++i) {
-    EXPECT_TRUE(results.count(std::to_string(i)) > 0);
-  }
+  // Wait for sleep to finish
+  std::this_thread::sleep_for(std::chrono::milliseconds(700));
+  EXPECT_EQ(agent->getCommandHistory().size(), 10);
 
   scheduler.shutdown();
 }

--- a/tests/unit/test_async_task_agent.cpp
+++ b/tests/unit/test_async_task_agent.cpp
@@ -2,7 +2,9 @@
 #include "concurrency/work_stealing_scheduler.hpp"
 #include "core/message_bus.hpp"
 
+#include <algorithm>
 #include <chrono>
+#include <set>
 #include <thread>
 
 #include <gtest/gtest.h>
@@ -75,7 +77,7 @@ TEST_F(AsyncTaskAgentTest, ProcessMultipleCommands) {
   bus_->routeMessage(msg2);
   bus_->routeMessage(msg3);
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
   const auto& history = agent_->getCommandHistory();
   ASSERT_EQ(history.size(), 3);
@@ -107,32 +109,30 @@ TEST_F(AsyncTaskAgentTest, HandleCommandFailure) {
 }
 
 TEST_F(AsyncTaskAgentTest, AsyncExecutionDoesNotBlock) {
-  // Submit a "slow" command (echo only - sleep would fail security validation)
-  auto slow_msg = KeystoneMessage::create("test", agent_->getAgentId(), "echo slow");
-
-  // Submit a fast command
+  // Submit a slow command (sleep 1) and a fast command to verify non-blocking execution
+  auto slow_msg = KeystoneMessage::create("test", agent_->getAgentId(), "sleep 1");
   auto fast_msg = KeystoneMessage::create("test", agent_->getAgentId(), "echo fast");
 
-  // Send slow first
+  auto start = std::chrono::steady_clock::now();
   bus_->routeMessage(slow_msg);
-  // Send fast immediately after
   bus_->routeMessage(fast_msg);
 
-  // Wait for both to complete
-  std::this_thread::sleep_for(std::chrono::milliseconds(300));
+  // Give fast message time to complete (should be << 1s)
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
-  // Both should complete (async execution)
+  // Fast command should already be in history even though sleep is still running
   const auto& history = agent_->getCommandHistory();
-  ASSERT_EQ(history.size(), 2);
+  // At least the echo fast should have completed by now (async, non-blocking)
+  bool fast_done = std::any_of(history.begin(), history.end(), [](const auto& p) {
+    return p.second == "fast";
+  });
+  EXPECT_TRUE(fast_done) << "echo fast should complete before sleep 1 finishes";
 
-  // Fast command might complete before slow (parallel execution)
-  std::set<std::string> results;
-  for (const auto& [cmd, result] : history) {
-    results.insert(result);
-  }
-
-  EXPECT_TRUE(results.count("fast") > 0);
-  EXPECT_TRUE(results.count("slow") > 0);
+  // Wait for sleep to finish
+  std::this_thread::sleep_for(std::chrono::milliseconds(1100));
+  EXPECT_EQ(agent_->getCommandHistory().size(), 2);
+  auto elapsed = std::chrono::steady_clock::now() - start;
+  EXPECT_GE(elapsed, std::chrono::milliseconds(1000));
 }
 
 TEST_F(AsyncTaskAgentTest, AgentIdPreserved) {


### PR DESCRIPTION
## Summary

- Added a `sleep <N>` validation pattern (Pattern 3) in `TaskAgent::validateCommand()` — `sleep N` where N <= 10.0 seconds is accepted; longer durations throw `std::runtime_error` to prevent DoS
- Restored `AsyncExecutionDoesNotBlock` in `test_async_task_agent.cpp` to use `sleep 1` so the test actually verifies the scheduler runs the echo command concurrently with the sleep
- Restored `AsyncAgentsConcurrentProcessing` in `async_agents_test.cpp` to use a mix of `sleep 1` + 9 echo commands to verify true concurrent processing
- Enabled the previously-disabled `async_agents_tests` CMake target (now pointing to `async_agents_test.cpp` only, keeping `full_async_hierarchy_test.cpp` disabled until Phase 6 coroutines are implemented)
- Enabled `tests/unit/test_async_task_agent.cpp` in the `unit_tests` CMake target
- Fixed a pre-existing flaky timeout in `ProcessMultipleCommands` (200ms -> 500ms) to be robust under ASan overhead

## Test plan

- [x] `AsyncExecutionDoesNotBlock` passes: `echo fast` completes in <200ms while `sleep 1` is still running
- [x] `AsyncAgentsConcurrentProcessing` passes: echo commands complete concurrently with sleep (>=5 done at 500ms mark)
- [x] All 9 `AsyncTaskAgentTest` tests pass under ASan
- [x] All 5 `E2E_PhaseB` tests pass under ASan (269 total unit tests, 0 failures)
- [x] `sleep 11` would be rejected with "sleep duration exceeds maximum allowed (10s)"

Closes #377

🤖 Generated with [Claude Code](https://claude.com/claude-code)