### PR TITLE
fix(python): add missing pytest import and remove unused imports (ruff F401/F821)

### DIFF
--- a/src/keystone/maestro_client.py
+++ b/src/keystone/maestro_client.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
-from .models import Agent, Task, TERMINAL_STATUSES
+from .models import Agent, Task
 from .validation import validate_id
 
 

--- a/tests/test_graceful_shutdown.py
+++ b/tests/test_graceful_shutdown.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -6,17 +6,13 @@ import json
 import logging
 import sys
 import threading
-from datetime import datetime, timezone
+from datetime import datetime
 from io import StringIO
 from unittest.mock import patch
-
-import pytest
 
 from keystone.logging import (
     JsonFormatter,
     KeystoneLogger,
-    _BASELINE_ATTRS,
-    _RESERVED_FIELDS,
     configure_logging,
     get_logger,
 )

--- a/tests/test_maestro_client.py
+++ b/tests/test_maestro_client.py
@@ -1,6 +1,7 @@
 """Tests for MaestroClient._agent_from_api() and get_agents()."""
 from __future__ import annotations
 
+import pytest
 from unittest.mock import AsyncMock, MagicMock
 
 from src.keystone.maestro_client import _agent_from_api, MaestroClient

--- a/tests/test_task_claimer.py
+++ b/tests/test_task_claimer.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import AsyncMock, call
+from unittest.mock import AsyncMock
 
 import pytest
 


### PR DESCRIPTION
## Summary

Fixes all ruff violations detected in CI `Python Quality (mypy)` and `Python Tests` jobs on main.

**Root cause** — commit `465802d` added `TestAssignTask` and `TestGetTasks` classes to `tests/test_maestro_client.py` using `@pytest.mark.asyncio` and `pytest.raises`, but omitted `import pytest`. This caused a `NameError: name 'pytest' is not defined` at collection time (before any test ran), failing the `Python Tests` job. Ruff then reported F821 for the same reason.

**Changes:**
- `tests/test_maestro_client.py` — add `import pytest` (fixes NameError + F821)
- `src/keystone/maestro_client.py` — remove unused `Optional`, `TERMINAL_STATUSES` (F401)
- `tests/test_graceful_shutdown.py` — remove unused `AsyncMock`, `MagicMock` (F401)
- `tests/test_logging.py` — remove unused `timezone`, `pytest`, `_BASELINE_ATTRS`, `_RESERVED_FIELDS` (F401)
- `tests/test_task_claimer.py` — remove unused `call` (F401)

## Test plan

- [x] `ruff check src/ tests/` passes clean
- [x] `just format-check` passes clean
- [ ] CI `Python Tests` and `Python Quality (mypy)` jobs green

🤖 Generated with [Claude Code](https://claude.com/claude-code)