### PR TITLE
fix(tsan): guard command_log_ with mutex to eliminate data race in TaskAgent

### DIFF
--- a/include/agents/task_agent.hpp
+++ b/include/agents/task_agent.hpp
@@ -46,12 +46,12 @@ class TaskAgent : public AsyncAgent {
   concurrency::Task<core::Response> processMessage(const core::KeystoneMessage& msg) override;
 
   /**
-   * @brief Get command execution history
+   * @brief Get a snapshot of command execution history
    *
-   * @return const std::vector<std::pair<std::string, std::string>>& History of
-   * (command, result) pairs
+   * @return std::vector<std::pair<std::string, std::string>> Copy of history
    */
-  const std::vector<std::pair<std::string, std::string>>& getCommandHistory() const {
+  std::vector<std::pair<std::string, std::string>> getCommandHistory() const {
+    std::lock_guard<std::mutex> lock(log_mutex_);
     return command_log_;
   }
 
@@ -166,6 +166,7 @@ class TaskAgent : public AsyncAgent {
   std::string executeBash(const std::string& command);
 
   std::vector<std::pair<std::string, std::string>> command_log_;
+  mutable std::mutex log_mutex_;
 
   // Phase 5: Chaos Engineering failure state
   std::atomic<bool> failed_{false};

--- a/src/agents/task_agent.cpp
+++ b/src/agents/task_agent.cpp
@@ -77,8 +77,11 @@ concurrency::Task<core::Response> TaskAgent::processMessage(const core::Keystone
     // Execute the bash command
     std::string result = executeBash(msg.command);
 
-    // Log the execution
-    command_log_.emplace_back(msg.command, result);
+    // Log the execution (lock guards concurrent processMessage coroutines)
+    {
+      std::lock_guard<std::mutex> lock(log_mutex_);
+      command_log_.emplace_back(msg.command, result);
+    }
 
     auto response = core::Response::createSuccess(msg, agent_id_, result);
     sendResponseMessage(msg, result);


### PR DESCRIPTION
## Summary

Fixes a ThreadSanitizer data race on `command_log_` in `TaskAgent::processMessage`.

**Root cause** — `command_log_.emplace_back()` at `task_agent.cpp:81` is called from coroutine resumptions that execute on `WorkStealingScheduler` worker threads. Multiple messages routed to the same agent can have their coroutines resumed concurrently on different threads, causing an unsynchronized read+write on the `std::vector`.

**Fix:**
- Add `mutable std::mutex log_mutex_` to `TaskAgent`
- Wrap `command_log_.emplace_back()` in a scoped lock in `processMessage()`
- Change `getCommandHistory()` from returning `const&` (dangling under concurrent writes) to returning a locked copy — callers binding `const auto& history = ...` continue to compile fine (lifetime extension of the temporary)

## Test plan

- [x] `just format-check` passes
- [ ] CI `Test (tsan)` passes green (data race at `task_agent.cpp:81` gone)
- [ ] All other sanitizer presets (asan, ubsan, lsan) remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)