### PR TITLE
fix(python): handle stream-not-found in NATSListener.start() with retry backoff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ version = "0.1.0"
 requires-python = ">=3.9"
 dependencies = [
     "pydantic>=2.0",
+    "nats-py>=2.0,<3",
 ]
 
 [project.optional-dependencies]

--- a/src/keystone/nats_listener.py
+++ b/src/keystone/nats_listener.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from typing import Any, Protocol
+
+import nats.errors
+import nats.js.errors
 
 from pydantic import ValidationError
 
@@ -56,6 +60,100 @@ class NATSListener:
         """
         self._shutting_down = True
         logger.info("nats_listener_shutdown_started")
+
+    async def start(
+        self,
+        nc: Any,
+        subject: str = "hi.tasks.>",
+        *,
+        stream: str = "homeric-tasks",
+        max_retries: int = 5,
+        retry_base_delay: float = 1.0,
+    ) -> None:
+        """Subscribe to a JetStream subject, retrying with backoff on stream-not-found.
+
+        Args:
+            nc: An active ``nats.aio.client.Client`` connection.
+            subject: The NATS subject pattern to subscribe to.
+            stream: The JetStream stream name (used in error messages).
+            max_retries: Number of retry attempts when the stream is not found.
+            retry_base_delay: Initial delay (seconds) before the first retry;
+                doubles on each subsequent attempt.
+
+        Raises:
+            ConnectionError: If the NATS server is unreachable or authentication fails.
+            RuntimeError: If the stream is not found after all retries are exhausted,
+                or if JetStream is not available on the server.
+        """
+        js = nc.jetstream()
+        last_exc: Exception | None = None
+        delay = retry_base_delay
+
+        for attempt in range(1, max_retries + 1):
+            try:
+                await js.subscribe(subject)
+                logger.info(
+                    "nats_listener_subscribed",
+                    extra={"subject": subject, "stream": stream},
+                )
+                return
+            except nats.js.errors.NotFoundError as exc:
+                last_exc = exc
+                logger.warning(
+                    "nats_stream_not_found",
+                    extra={
+                        "stream": stream,
+                        "subject": subject,
+                        "attempt": attempt,
+                        "max_retries": max_retries,
+                        "retry_delay_seconds": delay,
+                        "error": str(exc),
+                    },
+                )
+                if attempt < max_retries:
+                    await asyncio.sleep(delay)
+                    delay *= 2
+            except nats.errors.NoServersError as exc:
+                logger.error(
+                    "nats_no_servers",
+                    extra={"subject": subject, "stream": stream, "error": str(exc)},
+                )
+                raise ConnectionError(
+                    f"NATS server unreachable — cannot subscribe to '{subject}': {exc}"
+                ) from exc
+            except (
+                nats.errors.AuthorizationError,
+                nats.errors.InvalidUserCredentialsError,
+            ) as exc:
+                logger.error(
+                    "nats_auth_error",
+                    extra={"subject": subject, "stream": stream, "error": str(exc)},
+                )
+                raise ConnectionError(
+                    f"NATS authentication failed — cannot subscribe to '{subject}': {exc}"
+                ) from exc
+            except nats.js.errors.ServiceUnavailableError as exc:
+                logger.error(
+                    "nats_jetstream_unavailable",
+                    extra={"subject": subject, "stream": stream, "error": str(exc)},
+                )
+                raise RuntimeError(
+                    "JetStream is not enabled on the connected NATS server"
+                ) from exc
+
+        logger.error(
+            "nats_stream_not_found_fatal",
+            extra={
+                "stream": stream,
+                "subject": subject,
+                "attempts": max_retries,
+                "error": str(last_exc),
+            },
+        )
+        raise RuntimeError(
+            f"NATS stream for task events not found — ensure stream '{stream}' is "
+            f"configured (tried {max_retries} time(s)): {last_exc}"
+        ) from last_exc
 
     async def _on_task_event(
         self,

--- a/tests/test_nats_listener.py
+++ b/tests/test_nats_listener.py
@@ -1,10 +1,15 @@
-"""Tests for NATSListener ID validation in _on_task_event."""
+"""Tests for NATSListener: ID validation in _on_task_event and start() error handling."""
 from __future__ import annotations
 
 import json
 
 import pytest
 from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
+
+import nats.errors
+import nats.js.errors
+import pytest
 
 from src.keystone.nats_listener import NATSListener
 
@@ -137,3 +142,93 @@ class TestOnTaskEventRawPayload:
             "hi.tasks.team-1.task-42.completed", "team-1", "task-42", raw_payload=None
         )
         claimer.advance_dag_tracked.assert_called_once_with("team-1")
+# ---------------------------------------------------------------------------
+# Helpers for start() tests
+# ---------------------------------------------------------------------------
+
+def _make_mock_nc(subscribe_side_effect: object = None) -> MagicMock:
+    """Return a mock NATS client whose jetstream().subscribe() behaves as specified."""
+    nc = MagicMock()
+    js = MagicMock()
+    nc.jetstream.return_value = js
+    if subscribe_side_effect is None:
+        js.subscribe = AsyncMock(return_value=MagicMock())
+    else:
+        js.subscribe = AsyncMock(side_effect=subscribe_side_effect)
+    return nc
+
+
+class TestStartSubscribeSuccess:
+    async def test_subscribe_success_returns(self) -> None:
+        listener, _ = _make_listener()
+        nc = _make_mock_nc()
+        await listener.start(nc, "hi.tasks.>", stream="homeric-tasks")
+        nc.jetstream().subscribe.assert_awaited_once()
+
+    async def test_subscribe_success_uses_subject(self) -> None:
+        listener, _ = _make_listener()
+        nc = _make_mock_nc()
+        await listener.start(nc, "hi.tasks.team-1.>", stream="homeric-tasks")
+        nc.jetstream().subscribe.assert_awaited_once_with("hi.tasks.team-1.>")
+
+
+class TestStartStreamNotFound:
+    async def test_stream_not_found_raises_runtime_error(self) -> None:
+        listener, _ = _make_listener()
+        nc = _make_mock_nc(subscribe_side_effect=nats.js.errors.NotFoundError())
+        with pytest.raises(RuntimeError, match="homeric-tasks"):
+            await listener.start(
+                nc, "hi.tasks.>", stream="homeric-tasks", max_retries=1, retry_base_delay=0.0
+            )
+
+    async def test_stream_not_found_retries_up_to_max(self) -> None:
+        listener, _ = _make_listener()
+        nc = _make_mock_nc(subscribe_side_effect=nats.js.errors.NotFoundError())
+        with pytest.raises(RuntimeError):
+            await listener.start(nc, "hi.tasks.>", max_retries=3, retry_base_delay=0.0)
+        assert nc.jetstream().subscribe.await_count == 3
+
+    async def test_stream_not_found_succeeds_on_retry(self) -> None:
+        listener, _ = _make_listener()
+        nc = MagicMock()
+        js = MagicMock()
+        nc.jetstream.return_value = js
+        js.subscribe = AsyncMock(
+            side_effect=[
+                nats.js.errors.NotFoundError(),
+                nats.js.errors.NotFoundError(),
+                MagicMock(),
+            ]
+        )
+        await listener.start(nc, "hi.tasks.>", max_retries=3, retry_base_delay=0.0)
+        assert js.subscribe.await_count == 3
+
+    async def test_error_message_includes_stream_name(self) -> None:
+        listener, _ = _make_listener()
+        nc = _make_mock_nc(subscribe_side_effect=nats.js.errors.NotFoundError())
+        with pytest.raises(RuntimeError, match="my-custom-stream"):
+            await listener.start(
+                nc, "hi.tasks.>", stream="my-custom-stream", max_retries=1, retry_base_delay=0.0
+            )
+
+
+class TestStartConnectionErrors:
+    async def test_no_servers_raises_connection_error(self) -> None:
+        listener, _ = _make_listener()
+        nc = _make_mock_nc(subscribe_side_effect=nats.errors.NoServersError())
+        with pytest.raises(ConnectionError, match="unreachable"):
+            await listener.start(nc, "hi.tasks.>")
+
+    async def test_auth_error_raises_connection_error(self) -> None:
+        listener, _ = _make_listener()
+        nc = _make_mock_nc(subscribe_side_effect=nats.errors.AuthorizationError())
+        with pytest.raises(ConnectionError, match="authentication"):
+            await listener.start(nc, "hi.tasks.>")
+
+    async def test_jetstream_unavailable_raises_runtime_error(self) -> None:
+        listener, _ = _make_listener()
+        nc = _make_mock_nc(
+            subscribe_side_effect=nats.js.errors.ServiceUnavailableError()
+        )
+        with pytest.raises(RuntimeError, match="JetStream"):
+            await listener.start(nc, "hi.tasks.>")

--- a/tests/test_nats_listener.py
+++ b/tests/test_nats_listener.py
@@ -4,12 +4,10 @@ from __future__ import annotations
 import json
 
 import pytest
-from unittest.mock import MagicMock
 from unittest.mock import AsyncMock, MagicMock
 
 import nats.errors
 import nats.js.errors
-import pytest
 
 from src.keystone.nats_listener import NATSListener
 


### PR DESCRIPTION
## Summary

Closes #139

Adds `NATSListener.start()` which subscribes to a JetStream subject with structured error handling and exponential-backoff retry:

- `nats.js.errors.NotFoundError` → retries up to `max_retries` times with doubling delay; raises `RuntimeError` after exhausting retries
- `nats.errors.NoServersError` → raises `ConnectionError` immediately
- `nats.errors.AuthorizationError` / `InvalidUserCredentialsError` → raises `ConnectionError` immediately
- `nats.js.errors.ServiceUnavailableError` → raises `RuntimeError` immediately

All error paths emit structured log events for observability.

## Test plan
- [ ] 18 unit tests in `tests/test_nats_listener.py` cover success, retry-then-succeed, exhausted retries, and all error paths
- [ ] `pytest tests/test_nats_listener.py` — 18 passed
- [ ] CI green

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>