### PR TITLE
style: apply clang-format-18 to all C++ source files

### DIFF
--- a/include/agents/component_lead_agent.hpp
+++ b/include/agents/component_lead_agent.hpp
@@ -1,17 +1,17 @@
 #pragma once
 
+#include "agents/async_agent.hpp"
+#include "agents/coordination_state.hpp"
+#include "agents/lead_agent_base.hpp"
+
 #include <map>
 #include <memory>
 #include <string>
 #include <vector>
 
-#include "agents/async_agent.hpp"
-#include "agents/coordination_state.hpp"
-#include "agents/lead_agent_base.hpp"
-
 #ifdef ENABLE_GRPC
-#include "network/result_aggregator.hpp"
-#include "network/yaml_parser.hpp"
+#  include "network/result_aggregator.hpp"
+#  include "network/yaml_parser.hpp"
 #endif
 
 namespace keystone {
@@ -142,8 +142,7 @@ class ComponentLeadAgent : public LeadAgentBase<ComponentLeadState> {
    *
    * @param result_msg Message containing module result
    */
-  void processSubordinateResult(
-      const core::KeystoneMessage& result_msg) override;
+  void processSubordinateResult(const core::KeystoneMessage& result_msg) override;
 
   /**
    * @brief Convert state enum to string (HOOK METHOD)

--- a/include/agents/lead_agent_base.hpp
+++ b/include/agents/lead_agent_base.hpp
@@ -1,15 +1,16 @@
 #pragma once
 
-#include <string>
-#include <vector>
-
 #include "agents/async_agent.hpp"
 #include "agents/coordination_state.hpp"
 #include "core/message.hpp"
 
+#include <string>
+#include <vector>
+
 #ifdef ENABLE_GRPC
-#include "hmas_coordinator.pb.h"
-#include "network/yaml_parser.hpp"
+#  include "network/yaml_parser.hpp"
+
+#  include "hmas_coordinator.pb.h"
 #endif
 
 namespace keystone {
@@ -40,9 +41,12 @@ class LeadAgentBase : public AsyncAgent {
    * @param aggregating_state Aggregating/Synthesizing results state value
    * @param error_state Error state value
    */
-  explicit LeadAgentBase(const std::string& agent_id, StateEnum idle_state,
-                         StateEnum planning_state, StateEnum waiting_state,
-                         StateEnum aggregating_state, StateEnum error_state);
+  explicit LeadAgentBase(const std::string& agent_id,
+                         StateEnum idle_state,
+                         StateEnum planning_state,
+                         StateEnum waiting_state,
+                         StateEnum aggregating_state,
+                         StateEnum error_state);
 
   /**
    * @brief Process incoming message asynchronously (TEMPLATE METHOD - FINAL)
@@ -59,17 +63,14 @@ class LeadAgentBase : public AsyncAgent {
    * @param msg Message to process
    * @return concurrency::Task<core::Response> Async task with response
    */
-  concurrency::Task<core::Response> processMessage(
-      const core::KeystoneMessage& msg) final;
+  concurrency::Task<core::Response> processMessage(const core::KeystoneMessage& msg) final;
 
   /**
    * @brief Get execution trace for testing/debugging
    *
    * @return std::vector<std::string> State transition history
    */
-  std::vector<std::string> getExecutionTrace() const {
-    return coordination_.getExecutionTrace();
-  }
+  std::vector<std::string> getExecutionTrace() const { return coordination_.getExecutionTrace(); }
 
   /**
    * @brief Get current state
@@ -130,8 +131,7 @@ class LeadAgentBase : public AsyncAgent {
    *
    * @param result_msg Message containing subordinate result
    */
-  virtual void processSubordinateResult(
-      const core::KeystoneMessage& result_msg) = 0;
+  virtual void processSubordinateResult(const core::KeystoneMessage& result_msg) = 0;
 
   /**
    * @brief HOOK: Handle a failure reported by a subordinate agent (Issue #87)
@@ -145,8 +145,7 @@ class LeadAgentBase : public AsyncAgent {
    *
    * @param failure_msg Message with action_type == TASK_FAILED
    */
-  virtual void processSubordinateFailure(
-      const core::KeystoneMessage& failure_msg) {
+  virtual void processSubordinateFailure(const core::KeystoneMessage& failure_msg) {
     std::string error = failure_msg.payload.value_or("subordinate task failed");
     bool all_done = coordination_.recordFailure(error);
     if (all_done) {
@@ -175,12 +174,10 @@ class LeadAgentBase : public AsyncAgent {
    * @param spec  Task spec to update (modified in place)
    * @param error Human-readable error message
    */
-  void submitFailureResult(network::HierarchicalTaskSpec& spec,
-                           const std::string& error) {
+  void submitFailureResult(network::HierarchicalTaskSpec& spec, const std::string& error) {
     spec.status.phase = "FAILED";
     spec.status.error = error;
-    this->coordination_.transitionTo(this->error_state_,
-                                     stateToString(this->error_state_));
+    this->coordination_.transitionTo(this->error_state_, stateToString(this->error_state_));
 
     std::string result_yaml = network::YamlParser::generateTaskSpec(spec);
     auto coordinator_client = this->coordination_.getCoordinatorClient();

--- a/include/agents/module_lead_agent.hpp
+++ b/include/agents/module_lead_agent.hpp
@@ -1,17 +1,17 @@
 #pragma once
 
+#include "agents/async_agent.hpp"
+#include "agents/coordination_state.hpp"
+#include "agents/lead_agent_base.hpp"
+
 #include <map>
 #include <memory>
 #include <string>
 #include <vector>
 
-#include "agents/async_agent.hpp"
-#include "agents/coordination_state.hpp"
-#include "agents/lead_agent_base.hpp"
-
 #ifdef ENABLE_GRPC
-#include "network/result_aggregator.hpp"
-#include "network/yaml_parser.hpp"
+#  include "network/result_aggregator.hpp"
+#  include "network/yaml_parser.hpp"
 #endif
 
 namespace keystone {
@@ -142,8 +142,7 @@ class ModuleLeadAgent : public LeadAgentBase<ModuleLeadState> {
    *
    * @param result_msg Message containing task result
    */
-  void processSubordinateResult(
-      const core::KeystoneMessage& result_msg) override;
+  void processSubordinateResult(const core::KeystoneMessage& result_msg) override;
 
   /**
    * @brief Convert state enum to string (HOOK METHOD)

--- a/include/concurrency/logger.hpp
+++ b/include/concurrency/logger.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <spdlog/fmt/fmt.h>
-#include <spdlog/sinks/stdout_color_sinks.h>
-#include <spdlog/spdlog.h>
-
 #include <memory>
 #include <string>
 #include <thread>
+
+#include <spdlog/fmt/fmt.h>
+#include <spdlog/sinks/stdout_color_sinks.h>
+#include <spdlog/spdlog.h>
 
 namespace keystone {
 namespace concurrency {
@@ -44,8 +44,7 @@ class LogContext {
    * @param worker_id Worker thread index
    * @param session_id Session identifier
    */
-  static void set(const std::string& agent_id, int32_t worker_id,
-                  const std::string& session_id);
+  static void set(const std::string& agent_id, int32_t worker_id, const std::string& session_id);
 
   /**
    * @brief Clear the thread-local logging context (including correlation ID)
@@ -237,8 +236,7 @@ class Logger {
   static std::shared_ptr<spdlog::logger> logger_;
 
   template <typename... Args>
-  static void log(spdlog::level::level_enum level, const std::string& fmt,
-                  Args&&... args) {
+  static void log(spdlog::level::level_enum level, const std::string& fmt, Args&&... args) {
     if (!logger_) {
       init();
     }
@@ -248,8 +246,7 @@ class Logger {
     std::string full_fmt = context + " " + fmt;
 
     // Use runtime format to avoid compile-time format string requirement
-    logger_->log(spdlog::source_loc{}, level, fmt::runtime(full_fmt),
-                 std::forward<Args>(args)...);
+    logger_->log(spdlog::source_loc{}, level, fmt::runtime(full_fmt), std::forward<Args>(args)...);
   }
 };
 

--- a/include/core/subject_validator.hpp
+++ b/include/core/subject_validator.hpp
@@ -42,11 +42,9 @@ inline const std::regex& natsTokenPattern() {
  * @throws std::invalid_argument if value is empty or contains unsafe
  * characters.
  */
-inline const std::string& validateSubjectToken(const std::string& value,
-                                               const std::string& label) {
+inline const std::string& validateSubjectToken(const std::string& value, const std::string& label) {
   if (value.empty() || !std::regex_match(value, safeIdPattern())) {
-    throw std::invalid_argument("Invalid " + label +
-                                ": unsafe characters in '" + value + "'");
+    throw std::invalid_argument("Invalid " + label + ": unsafe characters in '" + value + "'");
   }
   return value;
 }
@@ -79,9 +77,8 @@ inline const std::string& validateSubjectToken(const std::string& value,
 inline const std::string& validateNatsSubjectToken(const std::string& value,
                                                    const std::string& label) {
   if (value.empty() || !std::regex_match(value, natsTokenPattern())) {
-    throw std::invalid_argument(
-        "Invalid NATS token " + label +
-        ": must be [a-zA-Z0-9_-], '*', or '>' -- got '" + value + "'");
+    throw std::invalid_argument("Invalid NATS token " + label +
+                                ": must be [a-zA-Z0-9_-], '*', or '>' -- got '" + value + "'");
   }
   return value;
 }
@@ -115,8 +112,7 @@ inline const std::string& validateNatsSubjectToken(const std::string& value,
 inline const std::string& validateNatsSubject(const std::string& subject,
                                               const std::string& label) {
   if (subject.empty()) {
-    throw std::invalid_argument("Invalid NATS subject " + label +
-                                ": subject must not be empty");
+    throw std::invalid_argument("Invalid NATS subject " + label + ": subject must not be empty");
   }
 
   std::string_view remaining{subject};
@@ -126,8 +122,7 @@ inline const std::string& validateNatsSubject(const std::string& subject,
     if (saw_gt) {
       // A '>' token was already seen but there are more tokens after it.
       throw std::invalid_argument("Invalid NATS subject " + label +
-                                  ": '>' wildcard must be the last token in '" +
-                                  subject + "'");
+                                  ": '>' wildcard must be the last token in '" + subject + "'");
     }
 
     const auto dot_pos = remaining.find('.');
@@ -138,9 +133,8 @@ inline const std::string& validateNatsSubject(const std::string& subject,
     const std::string token{token_sv};
     // Validate the individual token (reuse natsTokenPattern).
     if (token.empty() || !std::regex_match(token, natsTokenPattern())) {
-      throw std::invalid_argument("Invalid NATS subject " + label +
-                                  ": token '" + token + "' in subject '" +
-                                  subject + "' contains invalid characters");
+      throw std::invalid_argument("Invalid NATS subject " + label + ": token '" + token +
+                                  "' in subject '" + subject + "' contains invalid characters");
     }
 
     if (token == ">") {

--- a/include/transport/nats_connection.hpp
+++ b/include/transport/nats_connection.hpp
@@ -14,14 +14,14 @@
 
 #pragma once
 
-#include <nats.h>
-
 #include <atomic>
 #include <chrono>
 #include <cstdint>
 #include <functional>
 #include <mutex>
 #include <string>
+
+#include <nats.h>
 
 namespace keystone {
 namespace transport {
@@ -204,7 +204,9 @@ class NatsConnection {
   // nats.c static callback shims — nats.c passes a void* user data pointer
   // which we cast back to NatsConnection*. Protected to allow test subclasses
   // to invoke them directly without a live nats.c connection.
-  static void onError(natsConnection* nc, natsSubscription* sub, natsStatus err,
+  static void onError(natsConnection* nc,
+                      natsSubscription* sub,
+                      natsStatus err,
                       void* closure) noexcept;
   static void onDisconnected(natsConnection* nc, void* closure) noexcept;
   static void onReconnected(natsConnection* nc, void* closure) noexcept;

--- a/src/agents/component_lead_agent.cpp
+++ b/src/agents/component_lead_agent.cpp
@@ -1,24 +1,27 @@
 #include "agents/component_lead_agent.hpp"
 
+#include "concurrency/logger.hpp"
+#include "core/config.hpp"
+
 #include <algorithm>
 #include <chrono>
 #include <regex>
 #include <sstream>
 #include <thread>
 
-#include "concurrency/logger.hpp"
-#include "core/config.hpp"
-
 #ifdef ENABLE_GRPC
-#include "hmas_coordinator.pb.h"
+#  include "hmas_coordinator.pb.h"
 #endif
 
 namespace keystone {
 namespace agents {
 
 ComponentLeadAgent::ComponentLeadAgent(const std::string& agent_id)
-    : LeadAgentBase<State>(agent_id, State::IDLE, State::PLANNING,
-                           State::WAITING_FOR_MODULES, State::AGGREGATING,
+    : LeadAgentBase<State>(agent_id,
+                           State::IDLE,
+                           State::PLANNING,
+                           State::WAITING_FOR_MODULES,
+                           State::AGGREGATING,
                            State::ERROR) {
   // Base class constructor initializes coordination_ with IDLE state
 }
@@ -26,8 +29,7 @@ ComponentLeadAgent::ComponentLeadAgent(const std::string& agent_id)
 // processMessage() is now implemented in LeadAgentBase (template method
 // pattern)
 
-void ComponentLeadAgent::setAvailableModuleLeads(
-    const std::vector<std::string>& module_lead_ids) {
+void ComponentLeadAgent::setAvailableModuleLeads(const std::vector<std::string>& module_lead_ids) {
   available_module_leads_ = module_lead_ids;
 }
 
@@ -38,8 +40,7 @@ bool ComponentLeadAgent::isSubordinateResult(const core::KeystoneMessage& msg) {
   return msg.command == "module_result";
 }
 
-std::vector<std::string> ComponentLeadAgent::decomposeGoal(
-    const std::string& goal) {
+std::vector<std::string> ComponentLeadAgent::decomposeGoal(const std::string& goal) {
   std::vector<std::string> module_goals;
 
   // Parse component goal like "Implement Core component: Messaging(10+20+30)
@@ -47,8 +48,7 @@ std::vector<std::string> ComponentLeadAgent::decomposeGoal(
 
   // Pattern to match "ModuleName(numbers)"
   std::regex module_regex(R"((\w+)\(([0-9+]+)\))");
-  auto modules_begin =
-      std::sregex_iterator(goal.begin(), goal.end(), module_regex);
+  auto modules_begin = std::sregex_iterator(goal.begin(), goal.end(), module_regex);
   auto modules_end = std::sregex_iterator();
 
   for (std::sregex_iterator i = modules_begin; i != modules_end; ++i) {
@@ -64,8 +64,7 @@ std::vector<std::string> ComponentLeadAgent::decomposeGoal(
   return module_goals;
 }
 
-void ComponentLeadAgent::delegateSubtasks(
-    const std::vector<std::string>& subtasks) {
+void ComponentLeadAgent::delegateSubtasks(const std::vector<std::string>& subtasks) {
   // Assign module goals to available ModuleLeadAgents
   for (size_t i = 0; i < subtasks.size(); ++i) {
     if (available_module_leads_.empty()) {
@@ -80,8 +79,7 @@ void ComponentLeadAgent::delegateSubtasks(
     const std::string& module_lead_id = available_module_leads_[i];
 
     // Create and send module goal message
-    auto module_msg =
-        core::KeystoneMessage::create(agent_id_, module_lead_id, subtasks[i]);
+    auto module_msg = core::KeystoneMessage::create(agent_id_, module_lead_id, subtasks[i]);
 
     // Track pending module
     coordination_.trackPendingSubordinate(module_msg.msg_id, module_lead_id);
@@ -91,8 +89,7 @@ void ComponentLeadAgent::delegateSubtasks(
   }
 }
 
-void ComponentLeadAgent::processSubordinateResult(
-    const core::KeystoneMessage& result_msg) {
+void ComponentLeadAgent::processSubordinateResult(const core::KeystoneMessage& result_msg) {
   if (!result_msg.payload) {
     // No payload, skip
     return;
@@ -103,8 +100,7 @@ void ComponentLeadAgent::processSubordinateResult(
 
   // Check if we've received all module results
   if (all_complete) {
-    coordination_.transitionTo(State::AGGREGATING,
-                               stateToString(State::AGGREGATING));
+    coordination_.transitionTo(State::AGGREGATING, stateToString(State::AGGREGATING));
   }
 }
 
@@ -112,16 +108,14 @@ std::string ComponentLeadAgent::synthesizeComponentResult() {
   State current_state = coordination_.getCurrentState();
   if (current_state == State::ERROR) {
     auto failures = coordination_.getFailureMessages();
-    std::string msg =
-        "ERROR: " + std::to_string(coordination_.getFailureCount()) +
-        " subordinate module(s) failed";
+    std::string msg = "ERROR: " + std::to_string(coordination_.getFailureCount()) +
+                      " subordinate module(s) failed";
     if (!failures.empty()) {
       msg += ": " + failures.front();
     }
     return msg;
   }
-  if (current_state != State::AGGREGATING &&
-      current_state != State::WAITING_FOR_MODULES) {
+  if (current_state != State::AGGREGATING && current_state != State::WAITING_FOR_MODULES) {
     return "ERROR: Cannot synthesize in current state";
   }
 
@@ -164,10 +158,9 @@ void ComponentLeadAgent::initializeGrpc(const std::string& coordinator_address,
                                         const std::string& agent_type,
                                         uint8_t level) {
   // Delegate gRPC initialization to coordination template
-  std::vector<std::string> capabilities = {"module_coordination",
-                                           "component_synthesis"};
-  coordination_.initializeGrpc(agent_id_, coordinator_address, registry_address,
-                               agent_type, level, capabilities, 10);
+  std::vector<std::string> capabilities = {"module_coordination", "component_synthesis"};
+  coordination_.initializeGrpc(
+      agent_id_, coordinator_address, registry_address, agent_type, level, capabilities, 10);
 }
 
 void ComponentLeadAgent::processYamlComponent(const std::string& yaml_spec) {
@@ -182,8 +175,7 @@ void ComponentLeadAgent::processYamlComponent(const std::string& yaml_spec) {
   coordination_.transitionTo(State::PLANNING, stateToString(State::PLANNING));
 
   // Decompose component into modules using the hook method
-  auto module_goals =
-      decomposeGoal(spec.hierarchy.level1_directive.value_or(""));
+  auto module_goals = decomposeGoal(spec.hierarchy.level1_directive.value_or(""));
 
   if (module_goals.empty()) {
     submitFailureResult(spec, "Failed to decompose component goal");
@@ -191,8 +183,7 @@ void ComponentLeadAgent::processYamlComponent(const std::string& yaml_spec) {
   }
 
   // Query for available ModuleLeadAgents
-  available_module_leads_ =
-      coordination_.queryAvailableChildren("ModuleLeadAgent");
+  available_module_leads_ = coordination_.queryAvailableChildren("ModuleLeadAgent");
 
   if (available_module_leads_.empty()) {
     submitFailureResult(spec, "No ModuleLeadAgents available");
@@ -203,13 +194,11 @@ void ComponentLeadAgent::processYamlComponent(const std::string& yaml_spec) {
   auto timeout = network::YamlParser::parseDuration(spec.aggregation.timeout);
   result_aggregator_ = std::make_unique<network::ResultAggregator>(
       network::stringToStrategy(spec.aggregation.strategy),
-      std::chrono::milliseconds(
-          timeout.value_or(core::Config::DEFAULT_TASK_TIMEOUT_MS)),
+      std::chrono::milliseconds(timeout.value_or(core::Config::DEFAULT_TASK_TIMEOUT_MS)),
       module_goals.size());
 
   // Generate child module YAMLs and submit to ModuleLeadAgents
-  coordination_.transitionTo(State::WAITING_FOR_MODULES,
-                             stateToString(State::WAITING_FOR_MODULES));
+  coordination_.transitionTo(State::WAITING_FOR_MODULES, stateToString(State::WAITING_FOR_MODULES));
   coordination_.initializeCoordination(static_cast<int>(module_goals.size()));
 
   for (size_t i = 0; i < module_goals.size(); ++i) {
@@ -218,8 +207,7 @@ void ComponentLeadAgent::processYamlComponent(const std::string& yaml_spec) {
     child_spec.api_version = "v1";
     child_spec.kind = "HierarchicalTask";
     child_spec.metadata.name = "module-" + std::to_string(i);
-    child_spec.metadata.task_id =
-        spec.metadata.task_id + "-module-" + std::to_string(i);
+    child_spec.metadata.task_id = spec.metadata.task_id + "-module-" + std::to_string(i);
     child_spec.metadata.parent_task_id = spec.metadata.task_id;
     child_spec.metadata.session_id = spec.metadata.session_id;
 
@@ -245,16 +233,17 @@ void ComponentLeadAgent::processYamlComponent(const std::string& yaml_spec) {
 
     // Submit module via gRPC
     try {
-      auto deadline_ms = network::YamlParser::parseDuration(
-                             spec.metadata.deadline.value_or("25m"))
+      auto deadline_ms = network::YamlParser::parseDuration(spec.metadata.deadline.value_or("25m"))
                              .value_or(core::Config::DEFAULT_TASK_TIMEOUT_MS);
       auto coordinator_client = coordination_.getCoordinatorClient();
-      auto response = coordinator_client->submitTask(
-          child_yaml, spec.metadata.session_id.value_or(""), deadline_ms,
-          hmas::TASK_PRIORITY_NORMAL, coordination_.getCurrentTaskId());
+      auto response = coordinator_client->submitTask(child_yaml,
+                                                     spec.metadata.session_id.value_or(""),
+                                                     deadline_ms,
+                                                     hmas::TASK_PRIORITY_NORMAL,
+                                                     coordination_.getCurrentTaskId());
 
-      coordination_.trackPendingSubordinate(
-          child_spec.metadata.task_id, available_module_leads_[agent_index]);
+      coordination_.trackPendingSubordinate(child_spec.metadata.task_id,
+                                            available_module_leads_[agent_index]);
     } catch (const std::exception& e) {
       concurrency::Logger::error("Failed to submit module: {}", e.what());
     }

--- a/src/agents/module_lead_agent.cpp
+++ b/src/agents/module_lead_agent.cpp
@@ -1,5 +1,8 @@
 #include "agents/module_lead_agent.hpp"
 
+#include "concurrency/logger.hpp"
+#include "core/config.hpp"
+
 #include <algorithm>
 #include <chrono>
 #include <cstdint>
@@ -8,19 +11,19 @@
 #include <sstream>
 #include <thread>
 
-#include "concurrency/logger.hpp"
-#include "core/config.hpp"
-
 #ifdef ENABLE_GRPC
-#include "hmas_coordinator.pb.h"
+#  include "hmas_coordinator.pb.h"
 #endif
 
 namespace keystone {
 namespace agents {
 
 ModuleLeadAgent::ModuleLeadAgent(const std::string& agent_id)
-    : LeadAgentBase<State>(agent_id, State::IDLE, State::PLANNING,
-                           State::WAITING_FOR_TASKS, State::SYNTHESIZING,
+    : LeadAgentBase<State>(agent_id,
+                           State::IDLE,
+                           State::PLANNING,
+                           State::WAITING_FOR_TASKS,
+                           State::SYNTHESIZING,
                            State::ERROR) {
   // Base class constructor initializes coordination_ with IDLE state
 }
@@ -28,8 +31,7 @@ ModuleLeadAgent::ModuleLeadAgent(const std::string& agent_id)
 // processMessage() is now implemented in LeadAgentBase (template method
 // pattern)
 
-void ModuleLeadAgent::setAvailableTaskAgents(
-    const std::vector<std::string>& task_agent_ids) {
+void ModuleLeadAgent::setAvailableTaskAgents(const std::vector<std::string>& task_agent_ids) {
   available_task_agents_ = task_agent_ids;
 }
 
@@ -40,8 +42,7 @@ bool ModuleLeadAgent::isSubordinateResult(const core::KeystoneMessage& msg) {
   return msg.command == "response";
 }
 
-std::vector<std::string> ModuleLeadAgent::decomposeGoal(
-    const std::string& goal) {
+std::vector<std::string> ModuleLeadAgent::decomposeGoal(const std::string& goal) {
   std::vector<std::string> tasks;
 
   // Parse module goal like "Calculate sum of: 10 + 20 + 30"
@@ -49,8 +50,7 @@ std::vector<std::string> ModuleLeadAgent::decomposeGoal(
 
   // Extract numbers using regex
   std::regex number_regex(R"(\d+)");
-  auto numbers_begin =
-      std::sregex_iterator(goal.begin(), goal.end(), number_regex);
+  auto numbers_begin = std::sregex_iterator(goal.begin(), goal.end(), number_regex);
   auto numbers_end = std::sregex_iterator();
 
   // Create a task for each number (echo the number)
@@ -63,8 +63,7 @@ std::vector<std::string> ModuleLeadAgent::decomposeGoal(
   return tasks;
 }
 
-void ModuleLeadAgent::delegateSubtasks(
-    const std::vector<std::string>& subtasks) {
+void ModuleLeadAgent::delegateSubtasks(const std::vector<std::string>& subtasks) {
   // Assign tasks to available TaskAgents in round-robin fashion
   for (size_t i = 0; i < subtasks.size(); ++i) {
     if (available_task_agents_.empty()) {
@@ -76,8 +75,7 @@ void ModuleLeadAgent::delegateSubtasks(
     const std::string& task_agent_id = available_task_agents_[agent_index];
 
     // Create and send task message
-    auto task_msg =
-        core::KeystoneMessage::create(agent_id_, task_agent_id, subtasks[i]);
+    auto task_msg = core::KeystoneMessage::create(agent_id_, task_agent_id, subtasks[i]);
 
     // Track pending task
     coordination_.trackPendingSubordinate(task_msg.msg_id, task_agent_id);
@@ -87,8 +85,7 @@ void ModuleLeadAgent::delegateSubtasks(
   }
 }
 
-void ModuleLeadAgent::processSubordinateResult(
-    const core::KeystoneMessage& result_msg) {
+void ModuleLeadAgent::processSubordinateResult(const core::KeystoneMessage& result_msg) {
   if (!result_msg.payload) {
     // No payload, skip
     return;
@@ -99,8 +96,7 @@ void ModuleLeadAgent::processSubordinateResult(
 
   // Check if we've received all results
   if (all_complete) {
-    coordination_.transitionTo(State::SYNTHESIZING,
-                               stateToString(State::SYNTHESIZING));
+    coordination_.transitionTo(State::SYNTHESIZING, stateToString(State::SYNTHESIZING));
   }
 }
 
@@ -108,16 +104,14 @@ std::string ModuleLeadAgent::synthesizeResults() {
   State current_state = coordination_.getCurrentState();
   if (current_state == State::ERROR) {
     auto failures = coordination_.getFailureMessages();
-    std::string msg =
-        "ERROR: " + std::to_string(coordination_.getFailureCount()) +
-        " subordinate task(s) failed";
+    std::string msg = "ERROR: " + std::to_string(coordination_.getFailureCount()) +
+                      " subordinate task(s) failed";
     if (!failures.empty()) {
       msg += ": " + failures.front();
     }
     return msg;
   }
-  if (current_state != State::SYNTHESIZING &&
-      current_state != State::WAITING_FOR_TASKS) {
+  if (current_state != State::SYNTHESIZING && current_state != State::WAITING_FOR_TASKS) {
     return "ERROR: Cannot synthesize in current state";
   }
 
@@ -163,10 +157,9 @@ void ModuleLeadAgent::initializeGrpc(const std::string& coordinator_address,
                                      const std::string& agent_type,
                                      uint8_t level) {
   // Delegate gRPC initialization to coordination template
-  std::vector<std::string> capabilities = {"task_coordination",
-                                           "result_synthesis"};
-  coordination_.initializeGrpc(agent_id_, coordinator_address, registry_address,
-                               agent_type, level, capabilities, 5);
+  std::vector<std::string> capabilities = {"task_coordination", "result_synthesis"};
+  coordination_.initializeGrpc(
+      agent_id_, coordinator_address, registry_address, agent_type, level, capabilities, 5);
 }
 
 void ModuleLeadAgent::processYamlModule(const std::string& yaml_spec) {
@@ -201,13 +194,11 @@ void ModuleLeadAgent::processYamlModule(const std::string& yaml_spec) {
   auto timeout = network::YamlParser::parseDuration(spec.aggregation.timeout);
   result_aggregator_ = std::make_unique<network::ResultAggregator>(
       network::stringToStrategy(spec.aggregation.strategy),
-      std::chrono::milliseconds(
-          timeout.value_or(core::Config::DEFAULT_TASK_TIMEOUT_MS)),
+      std::chrono::milliseconds(timeout.value_or(core::Config::DEFAULT_TASK_TIMEOUT_MS)),
       tasks.size());
 
   // Generate child task YAMLs and submit to TaskAgents
-  coordination_.transitionTo(State::WAITING_FOR_TASKS,
-                             stateToString(State::WAITING_FOR_TASKS));
+  coordination_.transitionTo(State::WAITING_FOR_TASKS, stateToString(State::WAITING_FOR_TASKS));
   coordination_.initializeCoordination(static_cast<int32_t>(tasks.size()));
 
   for (size_t i = 0; i < tasks.size(); ++i) {
@@ -216,8 +207,7 @@ void ModuleLeadAgent::processYamlModule(const std::string& yaml_spec) {
     child_spec.api_version = "v1";
     child_spec.kind = "HierarchicalTask";
     child_spec.metadata.name = "task-" + std::to_string(i);
-    child_spec.metadata.task_id =
-        spec.metadata.task_id + "-subtask-" + std::to_string(i);
+    child_spec.metadata.task_id = spec.metadata.task_id + "-subtask-" + std::to_string(i);
     child_spec.metadata.parent_task_id = spec.metadata.task_id;
     child_spec.metadata.session_id = spec.metadata.session_id;
 
@@ -243,16 +233,17 @@ void ModuleLeadAgent::processYamlModule(const std::string& yaml_spec) {
 
     // Submit task via gRPC
     try {
-      auto deadline_ms = network::YamlParser::parseDuration(
-                             spec.metadata.deadline.value_or("25m"))
+      auto deadline_ms = network::YamlParser::parseDuration(spec.metadata.deadline.value_or("25m"))
                              .value_or(core::Config::DEFAULT_TASK_TIMEOUT_MS);
       auto coordinator_client = coordination_.getCoordinatorClient();
-      auto response = coordinator_client->submitTask(
-          child_yaml, spec.metadata.session_id.value_or(""), deadline_ms,
-          hmas::TASK_PRIORITY_NORMAL, coordination_.getCurrentTaskId());
+      auto response = coordinator_client->submitTask(child_yaml,
+                                                     spec.metadata.session_id.value_or(""),
+                                                     deadline_ms,
+                                                     hmas::TASK_PRIORITY_NORMAL,
+                                                     coordination_.getCurrentTaskId());
 
-      coordination_.trackPendingSubordinate(
-          child_spec.metadata.task_id, available_task_agents_[agent_index]);
+      coordination_.trackPendingSubordinate(child_spec.metadata.task_id,
+                                            available_task_agents_[agent_index]);
     } catch (const std::exception& e) {
       concurrency::Logger::error("Failed to submit task: {}", e.what());
     }

--- a/src/transport/nats_connection.cpp
+++ b/src/transport/nats_connection.cpp
@@ -5,11 +5,11 @@
 
 #include "transport/nats_connection.hpp"
 
-#include <nats.h>
-#include <spdlog/spdlog.h>
-
 #include <cstdlib>
 #include <string>
+
+#include <nats.h>
+#include <spdlog/spdlog.h>
 
 namespace keystone {
 namespace transport {
@@ -27,10 +27,11 @@ std::string getEnvVar(const char* name) {
 // Construction / destruction
 // ---------------------------------------------------------------------------
 
-NatsConnection::NatsConnection(NatsConfig config)
-    : config_(std::move(config)) {}
+NatsConnection::NatsConnection(NatsConfig config) : config_(std::move(config)) {}
 
-NatsConnection::~NatsConnection() { disconnect(); }
+NatsConnection::~NatsConnection() {
+  disconnect();
+}
 
 // ---------------------------------------------------------------------------
 // Callback registration
@@ -85,10 +86,8 @@ bool NatsConnection::applyTlsOptions(natsOptions* opts) const {
     ca_path = tls.ca_cert_path;
   }
   if (!ca_path.empty()) {
-    if (natsOptions_LoadCATrustedCertificates(opts, ca_path.c_str()) !=
-        NATS_OK) {
-      spdlog::error("NatsConnection: failed to load CA certificate from {}",
-                    ca_path);
+    if (natsOptions_LoadCATrustedCertificates(opts, ca_path.c_str()) != NATS_OK) {
+      spdlog::error("NatsConnection: failed to load CA certificate from {}", ca_path);
       return false;
     }
   }
@@ -105,11 +104,10 @@ bool NatsConnection::applyTlsOptions(natsOptions* opts) const {
   }
 
   if (!cert_path.empty() && !key_path.empty()) {
-    if (natsOptions_LoadCertificatesChain(opts, cert_path.c_str(),
-                                          key_path.c_str()) != NATS_OK) {
-      spdlog::error(
-          "NatsConnection: failed to load client certificate from {} / {}",
-          cert_path, key_path);
+    if (natsOptions_LoadCertificatesChain(opts, cert_path.c_str(), key_path.c_str()) != NATS_OK) {
+      spdlog::error("NatsConnection: failed to load client certificate from {} / {}",
+                    cert_path,
+                    key_path);
       return false;
     }
   } else if (!cert_path.empty() || !key_path.empty()) {
@@ -118,7 +116,8 @@ bool NatsConnection::applyTlsOptions(natsOptions* opts) const {
         "NatsConnection: TLS client certificate requires both cert and key "
         "paths; "
         "cert_path='{}' key_path='{}'",
-        cert_path, key_path);
+        cert_path,
+        key_path);
     return false;
   }
 
@@ -150,8 +149,7 @@ bool NatsConnection::connect() {
   }
 
   // Reconnection policy
-  if (natsOptions_SetMaxReconnect(opts, config_.max_reconnect_attempts) !=
-      NATS_OK) {
+  if (natsOptions_SetMaxReconnect(opts, config_.max_reconnect_attempts) != NATS_OK) {
     return false;
   }
 
@@ -175,20 +173,16 @@ bool NatsConnection::connect() {
   }
 
   // Lifecycle callbacks — pass `this` as closure so static shims can dispatch
-  if (natsOptions_SetErrorHandler(opts, NatsConnection::onError, this) !=
-      NATS_OK) {
+  if (natsOptions_SetErrorHandler(opts, NatsConnection::onError, this) != NATS_OK) {
     return false;
   }
-  if (natsOptions_SetDisconnectedCB(opts, NatsConnection::onDisconnected,
-                                    this) != NATS_OK) {
+  if (natsOptions_SetDisconnectedCB(opts, NatsConnection::onDisconnected, this) != NATS_OK) {
     return false;
   }
-  if (natsOptions_SetReconnectedCB(opts, NatsConnection::onReconnected, this) !=
-      NATS_OK) {
+  if (natsOptions_SetReconnectedCB(opts, NatsConnection::onReconnected, this) != NATS_OK) {
     return false;
   }
-  if (natsOptions_SetClosedCB(opts, NatsConnection::onClosed, this) !=
-      NATS_OK) {
+  if (natsOptions_SetClosedCB(opts, NatsConnection::onClosed, this) != NATS_OK) {
     return false;
   }
 
@@ -225,8 +219,7 @@ jsCtx* NatsConnection::jsContext() noexcept {
   }
   const natsStatus status = js_Context(&js_ctx_, conn_, nullptr, nullptr);
   if (status != NATS_OK) {
-    spdlog::error("NatsConnection::jsContext: js_Context failed: {}",
-                  natsStatus_GetText(status));
+    spdlog::error("NatsConnection::jsContext: js_Context failed: {}", natsStatus_GetText(status));
     js_ctx_ = nullptr;
     return nullptr;
   }
@@ -245,15 +238,19 @@ bool NatsConnection::isConnected() const noexcept {
   return getState() == NatsConnectionState::CONNECTED;
 }
 
-natsConnection* NatsConnection::handle() const noexcept { return conn_; }
+natsConnection* NatsConnection::handle() const noexcept {
+  return conn_;
+}
 
 // ---------------------------------------------------------------------------
 // Static callback shims
 // ---------------------------------------------------------------------------
 
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
-void NatsConnection::onError(natsConnection* /*nc*/, natsSubscription* /*sub*/,
-                             natsStatus err, void* closure) noexcept {
+void NatsConnection::onError(natsConnection* /*nc*/,
+                             natsSubscription* /*sub*/,
+                             natsStatus err,
+                             void* closure) noexcept {
   auto* self = static_cast<NatsConnection*>(closure);
   ErrorCallback cb;
   {
@@ -266,11 +263,9 @@ void NatsConnection::onError(natsConnection* /*nc*/, natsSubscription* /*sub*/,
   }
 }
 
-void NatsConnection::onDisconnected(natsConnection* /*nc*/,
-                                    void* closure) noexcept {
+void NatsConnection::onDisconnected(natsConnection* /*nc*/, void* closure) noexcept {
   auto* self = static_cast<NatsConnection*>(closure);
-  self->state_.store(NatsConnectionState::RECONNECTING,
-                     std::memory_order_release);
+  self->state_.store(NatsConnectionState::RECONNECTING, std::memory_order_release);
   DisconnectedCallback cb;
   {
     std::lock_guard<std::mutex> lock(self->callbacks_mutex_);
@@ -281,8 +276,7 @@ void NatsConnection::onDisconnected(natsConnection* /*nc*/,
   }
 }
 
-void NatsConnection::onReconnected(natsConnection* /*nc*/,
-                                   void* closure) noexcept {
+void NatsConnection::onReconnected(natsConnection* /*nc*/, void* closure) noexcept {
   auto* self = static_cast<NatsConnection*>(closure);
   self->state_.store(NatsConnectionState::CONNECTED, std::memory_order_release);
   ReconnectedCallback cb;

--- a/tests/unit/test_nats_connection.cpp
+++ b/tests/unit/test_nats_connection.cpp
@@ -22,12 +22,12 @@
  * the NatsConnectionTestPeer helper below.
  */
 
-#include <gtest/gtest.h>
+#include "transport/nats_connection.hpp"
 
 #include <atomic>
 #include <string>
 
-#include "transport/nats_connection.hpp"
+#include <gtest/gtest.h>
 
 using namespace keystone::transport;
 
@@ -39,9 +39,7 @@ class NatsConnectionTestPeer : public NatsConnection {
  public:
   using NatsConnection::NatsConnection;
 
-  void fireError() {
-    NatsConnection::onError(nullptr, nullptr, static_cast<natsStatus>(0), this);
-  }
+  void fireError() { NatsConnection::onError(nullptr, nullptr, static_cast<natsStatus>(0), this); }
 
   void fireDisconnected() { NatsConnection::onDisconnected(nullptr, this); }
   void fireReconnected() { NatsConnection::onReconnected(nullptr, this); }

--- a/tests/unit/test_subject_validator.cpp
+++ b/tests/unit/test_subject_validator.cpp
@@ -11,11 +11,11 @@
  * (Issue #280).
  */
 
-#include <gtest/gtest.h>
-
 #include "agents/task_agent.hpp"
 #include "core/message_bus.hpp"
 #include "core/subject_validator.hpp"
+
+#include <gtest/gtest.h>
 
 // =============================================================================
 // Valid identifiers -- must pass without throwing
@@ -38,8 +38,8 @@ TEST(SubjectValidatorTest, AcceptsUnderscores) {
 }
 
 TEST(SubjectValidatorTest, AcceptsUuid) {
-  EXPECT_NO_THROW(keystone::core::validateSubjectToken(
-      "550e8400-e29b-41d4-a716-446655440000", "team_id"));
+  EXPECT_NO_THROW(
+      keystone::core::validateSubjectToken("550e8400-e29b-41d4-a716-446655440000", "team_id"));
 }
 
 TEST(SubjectValidatorTest, ReturnsValueUnchanged) {
@@ -57,8 +57,7 @@ TEST(SubjectValidatorTest, RejectsPathTraversalDotDot) {
 }
 
 TEST(SubjectValidatorTest, RejectsSlash) {
-  EXPECT_THROW(keystone::core::validateSubjectToken("foo/bar", "team_id"),
-               std::invalid_argument);
+  EXPECT_THROW(keystone::core::validateSubjectToken("foo/bar", "team_id"), std::invalid_argument);
 }
 
 TEST(SubjectValidatorTest, RejectsLeadingSlash) {
@@ -71,23 +70,19 @@ TEST(SubjectValidatorTest, RejectsLeadingSlash) {
 // =============================================================================
 
 TEST(SubjectValidatorTest, RejectsSpace) {
-  EXPECT_THROW(keystone::core::validateSubjectToken("team id", "id"),
-               std::invalid_argument);
+  EXPECT_THROW(keystone::core::validateSubjectToken("team id", "id"), std::invalid_argument);
 }
 
 TEST(SubjectValidatorTest, RejectsNewline) {
-  EXPECT_THROW(keystone::core::validateSubjectToken("team\nid", "id"),
-               std::invalid_argument);
+  EXPECT_THROW(keystone::core::validateSubjectToken("team\nid", "id"), std::invalid_argument);
 }
 
 TEST(SubjectValidatorTest, RejectsSemicolon) {
-  EXPECT_THROW(keystone::core::validateSubjectToken("team;id", "id"),
-               std::invalid_argument);
+  EXPECT_THROW(keystone::core::validateSubjectToken("team;id", "id"), std::invalid_argument);
 }
 
 TEST(SubjectValidatorTest, RejectsDot) {
-  EXPECT_THROW(keystone::core::validateSubjectToken("team.id", "id"),
-               std::invalid_argument);
+  EXPECT_THROW(keystone::core::validateSubjectToken("team.id", "id"), std::invalid_argument);
 }
 
 // =============================================================================
@@ -95,8 +90,7 @@ TEST(SubjectValidatorTest, RejectsDot) {
 // =============================================================================
 
 TEST(SubjectValidatorTest, RejectsEmptyString) {
-  EXPECT_THROW(keystone::core::validateSubjectToken("", "id"),
-               std::invalid_argument);
+  EXPECT_THROW(keystone::core::validateSubjectToken("", "id"), std::invalid_argument);
 }
 
 TEST(SubjectValidatorTest, ErrorMessageContainsLabel) {
@@ -138,8 +132,7 @@ TEST(SubjectValidatorTest, MessageBusAcceptsValidAgentId) {
 TEST(NatsSubjectTokenTest, AcceptsAlphanumericToken) {
   EXPECT_NO_THROW(keystone::core::validateNatsSubjectToken("foo", "tok"));
   EXPECT_NO_THROW(keystone::core::validateNatsSubjectToken("abc123", "tok"));
-  EXPECT_NO_THROW(
-      keystone::core::validateNatsSubjectToken("agent-core_7", "tok"));
+  EXPECT_NO_THROW(keystone::core::validateNatsSubjectToken("agent-core_7", "tok"));
 }
 
 TEST(NatsSubjectTokenTest, AcceptsSingleStarWildcard) {
@@ -152,29 +145,24 @@ TEST(NatsSubjectTokenTest, AcceptsGreaterThanWildcard) {
 
 TEST(NatsSubjectTokenTest, RejectsDotInSingleToken) {
   // Dots are subject separators and must not appear inside a single token.
-  EXPECT_THROW(keystone::core::validateNatsSubjectToken("foo.bar", "tok"),
-               std::invalid_argument);
+  EXPECT_THROW(keystone::core::validateNatsSubjectToken("foo.bar", "tok"), std::invalid_argument);
 }
 
 TEST(NatsSubjectTokenTest, RejectsEmptyToken) {
-  EXPECT_THROW(keystone::core::validateNatsSubjectToken("", "tok"),
-               std::invalid_argument);
+  EXPECT_THROW(keystone::core::validateNatsSubjectToken("", "tok"), std::invalid_argument);
 }
 
 TEST(NatsSubjectTokenTest, RejectsSlashInToken) {
-  EXPECT_THROW(keystone::core::validateNatsSubjectToken("foo/bar", "tok"),
-               std::invalid_argument);
+  EXPECT_THROW(keystone::core::validateNatsSubjectToken("foo/bar", "tok"), std::invalid_argument);
 }
 
 TEST(NatsSubjectTokenTest, RejectsSpaceInToken) {
-  EXPECT_THROW(keystone::core::validateNatsSubjectToken("foo bar", "tok"),
-               std::invalid_argument);
+  EXPECT_THROW(keystone::core::validateNatsSubjectToken("foo bar", "tok"), std::invalid_argument);
 }
 
 TEST(NatsSubjectTokenTest, RejectsDoubleWildcard) {
   // "**" is not a valid NATS token.
-  EXPECT_THROW(keystone::core::validateNatsSubjectToken("**", "tok"),
-               std::invalid_argument);
+  EXPECT_THROW(keystone::core::validateNatsSubjectToken("**", "tok"), std::invalid_argument);
 }
 
 TEST(NatsSubjectTokenTest, ReturnsValueUnchanged) {
@@ -196,8 +184,7 @@ TEST(NatsSubjectTokenTest, ErrorMessageContainsLabel) {
 // =============================================================================
 
 TEST(NatsSubjectTest, AcceptsSimpleSubject) {
-  EXPECT_NO_THROW(
-      keystone::core::validateNatsSubject("hi.agents.task-1", "subj"));
+  EXPECT_NO_THROW(keystone::core::validateNatsSubject("hi.agents.task-1", "subj"));
 }
 
 TEST(NatsSubjectTest, AcceptsSingleToken) {
@@ -205,8 +192,7 @@ TEST(NatsSubjectTest, AcceptsSingleToken) {
 }
 
 TEST(NatsSubjectTest, AcceptsStarWildcardInMiddle) {
-  EXPECT_NO_THROW(
-      keystone::core::validateNatsSubject("hi.myrmidon.*.status", "subj"));
+  EXPECT_NO_THROW(keystone::core::validateNatsSubject("hi.myrmidon.*.status", "subj"));
 }
 
 TEST(NatsSubjectTest, AcceptsGtWildcardAtEnd) {
@@ -218,18 +204,15 @@ TEST(NatsSubjectTest, AcceptsGtAloneAsSubject) {
 }
 
 TEST(NatsSubjectTest, RejectsGtNotAtEnd) {
-  EXPECT_THROW(keystone::core::validateNatsSubject("hi.>.extra", "subj"),
-               std::invalid_argument);
+  EXPECT_THROW(keystone::core::validateNatsSubject("hi.>.extra", "subj"), std::invalid_argument);
 }
 
 TEST(NatsSubjectTest, RejectsEmptySubject) {
-  EXPECT_THROW(keystone::core::validateNatsSubject("", "subj"),
-               std::invalid_argument);
+  EXPECT_THROW(keystone::core::validateNatsSubject("", "subj"), std::invalid_argument);
 }
 
 TEST(NatsSubjectTest, RejectsEmptyTokenBetweenDots) {
-  EXPECT_THROW(keystone::core::validateNatsSubject("hi..agents", "subj"),
-               std::invalid_argument);
+  EXPECT_THROW(keystone::core::validateNatsSubject("hi..agents", "subj"), std::invalid_argument);
 }
 
 TEST(NatsSubjectTest, RejectsSpaceInToken) {


### PR DESCRIPTION
## Summary
- CI uses clang-format-18 (ubuntu-24.04); local toolchain produces different lambda/line-break layout
- 11 files were reformatted: `src/agents/`, `include/agents/`, `include/concurrency/logger.hpp`, `include/core/subject_validator.hpp`, `include/transport/nats_connection.hpp`, `src/transport/nats_connection.cpp`, `tests/unit/test_nats_connection.cpp`, `tests/unit/test_subject_validator.cpp`
- No logic changes — pure formatting

## Root cause
Local clang-format (v22+) and CI clang-format-18 produce different decisions for lambda expressions inside `emplace_back` / long function calls. All files were reformatted using `podman run ubuntu:24.04 clang-format-18 -i` to match the exact CI version.

## Blocks / unblocks
- Unblocks `Code Quality` gate on `main` and all open PRs (#400, #416, #441)
- Must merge before any other open PR can pass CI

🤖 Generated with [Claude Code](https://claude.ai/claude-code)