### PR TITLE
fix(ci): match cmake build type to conan install type in CodeQL workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           cmake -S . -B build/codeql \
             -G Ninja \
-            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_TOOLCHAIN_FILE=build/conan-deps/conan_toolchain.cmake
           cmake --build build/codeql
 


### PR DESCRIPTION
## Summary
- `conan install` used `-s build_type=Release` but cmake was configured with `-DCMAKE_BUILD_TYPE=Debug`
- Conan 2 toolchains are build-type specific — the Release toolchain does not expose include paths to a Debug build
- Result: `spdlog/fmt/fmt.h` and `concurrentqueue.h` not found despite `conan_toolchain.cmake` being loaded
- Fix: align cmake to `-DCMAKE_BUILD_TYPE=Release` to match the conan install

## Root cause
CodeQL analysis does not need debug symbols (it instruments the tracer at link time). Release is correct for both conan install and cmake here.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)