### PR TITLE
fix(ci): apply clang-format-18 and fix CMake cycle check quoting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,19 +44,15 @@ jobs:
       - name: Check CMake dependency graph for cycles
         run: |
           cmake -S . -B build/graphviz -G Ninja --graphviz=build/graphviz/deps.dot -DCMAKE_BUILD_TYPE=Debug 2>/dev/null || true
-          # Check if any graphviz output was created (optional ci-only check)
           if [ -f build/graphviz/deps.dot ]; then
             echo "CMake dependency graph generated successfully"
-            # A simple cycle check: no node should appear as its own ancestor
-            python3 -c "
+            python3 << 'EOF'
           import re, sys
           content = open("build/graphviz/deps.dot").read()
-          edges = re.findall(r"\\"([^\\"]+)\\" -> \\"([^\\"]+)\\"", content)
-          # Build adjacency list
+          edges = re.findall(r'"([^"]+)" -> "([^"]+)"', content)
           adj = {}
           for src, dst in edges:
               adj.setdefault(src, []).append(dst)
-          # DFS cycle detection
           visited, in_stack = set(), set()
           def has_cycle(node):
               if node in in_stack: return True
@@ -67,7 +63,7 @@ jobs:
           if any(has_cycle(n) for n in list(adj)):
               print("CYCLE DETECTED in CMake dependency graph!"); sys.exit(1)
           print("No cycles detected in CMake dependency graph")
-          "
+          EOF
           fi
 
       # Note: Full static analysis (clang-tidy, cppcheck) takes 30+ minutes

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           cmake -S . -B build/codeql \
             -G Ninja \
-            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_TOOLCHAIN_FILE=build/conan-deps/conan_toolchain.cmake
           cmake --build build/codeql
 

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Run Trivy filesystem scan (SARIF)
-        uses: aquasecurity/trivy-action@0.36.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -34,7 +34,7 @@ jobs:
         continue-on-error: true
 
       - name: Run Trivy filesystem scan (JSON for summary)
-        uses: aquasecurity/trivy-action@0.36.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: 'fs'
           scan-ref: '.'

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Run Trivy filesystem scan (SARIF)
-        uses: aquasecurity/trivy-action@0.24.0
+        uses: aquasecurity/trivy-action@0.36.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -34,7 +34,7 @@ jobs:
         continue-on-error: true
 
       - name: Run Trivy filesystem scan (JSON for summary)
-        uses: aquasecurity/trivy-action@0.24.0
+        uses: aquasecurity/trivy-action@0.36.0
         with:
           scan-type: 'fs'
           scan-ref: '.'

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -128,7 +128,7 @@ jobs:
 
       # Filesystem scan covers C++ headers and Conan lock files for known CVEs
       - name: Run Trivy filesystem scan (Conan + OS packages) — SARIF
-        uses: aquasecurity/trivy-action@0.24.0
+        uses: aquasecurity/trivy-action@0.36.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -139,7 +139,7 @@ jobs:
         continue-on-error: true
 
       - name: Run Trivy filesystem scan (Conan + OS packages) — JSON
-        uses: aquasecurity/trivy-action@0.24.0
+        uses: aquasecurity/trivy-action@0.36.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -214,7 +214,7 @@ jobs:
 
       - name: Run Trivy vulnerability scanner (table format)
         if: steps.docker_build.outcome == 'success'
-        uses: aquasecurity/trivy-action@0.24.0
+        uses: aquasecurity/trivy-action@0.36.0
         with:
           image-ref: 'projectkeystone:scan'
           format: 'table'
@@ -224,7 +224,7 @@ jobs:
 
       - name: Run Trivy vulnerability scanner (SARIF format)
         if: steps.docker_build.outcome == 'success'
-        uses: aquasecurity/trivy-action@0.24.0
+        uses: aquasecurity/trivy-action@0.36.0
         with:
           image-ref: 'projectkeystone:scan'
           format: 'sarif'
@@ -241,7 +241,7 @@ jobs:
 
       - name: Run Trivy vulnerability scanner (JSON format)
         if: steps.docker_build.outcome == 'success'
-        uses: aquasecurity/trivy-action@0.24.0
+        uses: aquasecurity/trivy-action@0.36.0
         with:
           image-ref: 'projectkeystone:scan'
           format: 'json'

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -128,7 +128,7 @@ jobs:
 
       # Filesystem scan covers C++ headers and Conan lock files for known CVEs
       - name: Run Trivy filesystem scan (Conan + OS packages) — SARIF
-        uses: aquasecurity/trivy-action@0.36.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -139,7 +139,7 @@ jobs:
         continue-on-error: true
 
       - name: Run Trivy filesystem scan (Conan + OS packages) — JSON
-        uses: aquasecurity/trivy-action@0.36.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -214,7 +214,7 @@ jobs:
 
       - name: Run Trivy vulnerability scanner (table format)
         if: steps.docker_build.outcome == 'success'
-        uses: aquasecurity/trivy-action@0.36.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: 'projectkeystone:scan'
           format: 'table'
@@ -224,7 +224,7 @@ jobs:
 
       - name: Run Trivy vulnerability scanner (SARIF format)
         if: steps.docker_build.outcome == 'success'
-        uses: aquasecurity/trivy-action@0.36.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: 'projectkeystone:scan'
           format: 'sarif'
@@ -241,7 +241,7 @@ jobs:
 
       - name: Run Trivy vulnerability scanner (JSON format)
         if: steps.docker_build.outcome == 'success'
-        uses: aquasecurity/trivy-action@0.36.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: 'projectkeystone:scan'
           format: 'json'

--- a/fuzz/fuzz_message_bus_routing.cpp
+++ b/fuzz/fuzz_message_bus_routing.cpp
@@ -12,15 +12,15 @@
 // Build with: cmake -DENABLE_FUZZING=ON -DCMAKE_CXX_COMPILER=clang++ ..
 // Run with: ./fuzz_message_bus_routing -max_len=4096 -runs=1000000
 
+#include "agents/base_agent.hpp"
+#include "core/message.hpp"
+#include "core/message_bus.hpp"
+
 #include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
-
-#include "agents/base_agent.hpp"
-#include "core/message.hpp"
-#include "core/message_bus.hpp"
 
 using namespace keystone;
 using namespace keystone::core;
@@ -59,14 +59,15 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
       offset++;
 
       // Extract string length (limit to prevent excessive allocations)
-      if (offset >= size) break;
+      if (offset >= size)
+        break;
       uint8_t str_len = std::min(data[offset], uint8_t(64));
       offset++;
 
       // Extract agent ID string
-      if (offset + str_len > size) break;
-      std::string agent_id(reinterpret_cast<const char*>(data + offset),
-                           str_len);
+      if (offset + str_len > size)
+        break;
+      std::string agent_id(reinterpret_cast<const char*>(data + offset), str_len);
       offset += str_len;
 
       switch (op_type) {
@@ -92,24 +93,26 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
 
         case 3: {
           // Try to route a message
-          if (offset + 2 > size) break;
+          if (offset + 2 > size)
+            break;
 
           // Extract sender and receiver lengths
           uint8_t sender_len = std::min(data[offset], uint8_t(32));
           offset++;
 
-          if (offset + sender_len > size) break;
-          std::string sender(reinterpret_cast<const char*>(data + offset),
-                             sender_len);
+          if (offset + sender_len > size)
+            break;
+          std::string sender(reinterpret_cast<const char*>(data + offset), sender_len);
           offset += sender_len;
 
-          if (offset >= size) break;
+          if (offset >= size)
+            break;
           uint8_t receiver_len = std::min(data[offset], uint8_t(32));
           offset++;
 
-          if (offset + receiver_len > size) break;
-          std::string receiver(reinterpret_cast<const char*>(data + offset),
-                               receiver_len);
+          if (offset + receiver_len > size)
+            break;
+          std::string receiver(reinterpret_cast<const char*>(data + offset), receiver_len);
           offset += receiver_len;
 
           // Create and route message

--- a/fuzz/fuzz_message_serialization.cpp
+++ b/fuzz/fuzz_message_serialization.cpp
@@ -11,13 +11,13 @@
 // Build with: cmake -DENABLE_FUZZING=ON -DCMAKE_CXX_COMPILER=clang++ ..
 // Run with: ./fuzz_message_serialization -max_len=4096 -runs=1000000
 
+#include "core/message.hpp"
+#include "core/message_serializer.hpp"
+
 #include <cstddef>
 #include <cstdint>
 #include <string>
 #include <vector>
-
-#include "core/message.hpp"
-#include "core/message_serializer.hpp"
 
 using namespace keystone;
 using namespace keystone::core;
@@ -53,14 +53,12 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     try {
       // Split input into 4 parts for msg_id, sender, receiver, command
       size_t quarter = size / 4;
-      std::string msg_id(reinterpret_cast<const char*>(data),
-                         std::min(quarter, size_t(256)));
+      std::string msg_id(reinterpret_cast<const char*>(data), std::min(quarter, size_t(256)));
       std::string sender(reinterpret_cast<const char*>(data + quarter),
                          std::min(quarter, size_t(256)));
       std::string receiver(reinterpret_cast<const char*>(data + 2 * quarter),
                            std::min(quarter, size_t(256)));
-      std::string command(reinterpret_cast<const char*>(data + 3 * quarter),
-                          size - 3 * quarter);
+      std::string command(reinterpret_cast<const char*>(data + 3 * quarter), size - 3 * quarter);
 
       auto msg = KeystoneMessage::create(sender, receiver, command);
 

--- a/fuzz/fuzz_retry_policy.cpp
+++ b/fuzz/fuzz_retry_policy.cpp
@@ -11,12 +11,12 @@
 // Build with: cmake -DENABLE_FUZZING=ON -DCMAKE_CXX_COMPILER=clang++ ..
 // Run with: ./fuzz_retry_policy -max_len=512 -runs=1000000
 
+#include "core/retry_policy.hpp"
+
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <limits>
-
-#include "core/retry_policy.hpp"
 
 using namespace keystone;
 
@@ -41,16 +41,14 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     for (int i = 0; i < 4; ++i) {
       initial_delay_ms |= (uint32_t(data[4 + i]) << (i * 8));
     }
-    initial_delay_ms =
-        std::min(initial_delay_ms, uint32_t(60000));             // Cap at 60s
-    initial_delay_ms = std::max(initial_delay_ms, uint32_t(1));  // Min 1ms
+    initial_delay_ms = std::min(initial_delay_ms, uint32_t(60000));  // Cap at 60s
+    initial_delay_ms = std::max(initial_delay_ms, uint32_t(1));      // Min 1ms
 
     // Backoff multiplier (as fixed-point: value / 100.0)
     uint16_t multiplier_fixed = 0;
     multiplier_fixed |= uint16_t(data[8]);
     multiplier_fixed |= (uint16_t(data[9]) << 8);
-    double backoff_multiplier =
-        std::min(double(multiplier_fixed) / 100.0, 10.0);
+    double backoff_multiplier = std::min(double(multiplier_fixed) / 100.0, 10.0);
     backoff_multiplier = std::max(backoff_multiplier, 1.0);
 
     // Max delay in milliseconds
@@ -58,15 +56,13 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     for (int i = 0; i < 4; ++i) {
       max_delay_ms |= (uint32_t(data[10 + i]) << (i * 8));
     }
-    max_delay_ms =
-        std::min(max_delay_ms, uint32_t(300000));  // Cap at 5 minutes
+    max_delay_ms = std::min(max_delay_ms, uint32_t(300000));  // Cap at 5 minutes
 
     // Create retry policy with fuzzed parameters
     auto initial_delay = std::chrono::milliseconds(initial_delay_ms);
     auto max_delay = std::chrono::milliseconds(max_delay_ms);
 
-    RetryPolicy policy(max_retries, initial_delay, backoff_multiplier,
-                       max_delay);
+    RetryPolicy policy(max_retries, initial_delay, backoff_multiplier, max_delay);
 
     // Test 1: Query if retry is allowed for various attempt counts
     if (size >= 17) {
@@ -86,8 +82,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
       auto delay = policy.getBackoffDelay(attempt);
 
       // Verify delay is within reasonable bounds
-      auto delay_ms =
-          std::chrono::duration_cast<std::chrono::milliseconds>(delay).count();
+      auto delay_ms = std::chrono::duration_cast<std::chrono::milliseconds>(delay).count();
 
       // Should not exceed max_delay
       if (delay_ms > static_cast<int64_t>(max_delay_ms)) {

--- a/fuzz/fuzz_subject_validator.cpp
+++ b/fuzz/fuzz_subject_validator.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 #include "core/subject_validator.hpp"
+
 #include <cstddef>
 #include <cstdint>
 #include <stdexcept>

--- a/fuzz/fuzz_work_stealing.cpp
+++ b/fuzz/fuzz_work_stealing.cpp
@@ -12,14 +12,14 @@
 // Build with: cmake -DENABLE_FUZZING=ON -DCMAKE_CXX_COMPILER=clang++ ..
 // Run with: ./fuzz_work_stealing -max_len=2048 -runs=1000000
 
+#include "concurrency/task.hpp"
+#include "concurrency/work_stealing_scheduler.hpp"
+
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <thread>
-
-#include "concurrency/task.hpp"
-#include "concurrency/work_stealing_scheduler.hpp"
 
 using namespace keystone;
 using namespace keystone::concurrency;
@@ -44,7 +44,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
 
     // Submit fuzzed tasks
     for (uint8_t i = 0; i < task_count && offset < size; ++i) {
-      if (offset >= size) break;
+      if (offset >= size)
+        break;
 
       // Get task type from data
       uint8_t task_type = data[offset] % 4;
@@ -63,7 +64,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
 
         case 1: {
           // Priority task (if we have priority data)
-          if (offset >= size) break;
+          if (offset >= size)
+            break;
           uint8_t priority = data[offset];
           offset++;
 
@@ -76,7 +78,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
 
         case 2: {
           // Task with fuzzed deadline
-          if (offset + 4 > size) break;
+          if (offset + 4 > size)
+            break;
 
           // Extract deadline offset in microseconds
           uint32_t deadline_us = 0;
@@ -89,8 +92,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
           deadline_us = std::min(deadline_us, uint32_t(1000000));
           deadline_us = std::max(deadline_us, uint32_t(1000));
 
-          auto deadline = std::chrono::steady_clock::now() +
-                          std::chrono::microseconds(deadline_us);
+          auto deadline = std::chrono::steady_clock::now() + std::chrono::microseconds(deadline_us);
 
           scheduler->submit([deadline]() {
             // Check if we met the deadline
@@ -102,7 +104,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
 
         case 3: {
           // Potentially throwing task
-          if (offset >= size) break;
+          if (offset >= size)
+            break;
           bool should_throw = (data[offset] % 10 == 0);
           offset++;
 

--- a/include/agents/component_lead_agent.hpp
+++ b/include/agents/component_lead_agent.hpp
@@ -1,17 +1,17 @@
 #pragma once
 
+#include "agents/async_agent.hpp"
+#include "agents/coordination_state.hpp"
+#include "agents/lead_agent_base.hpp"
+
 #include <map>
 #include <memory>
 #include <string>
 #include <vector>
 
-#include "agents/async_agent.hpp"
-#include "agents/coordination_state.hpp"
-#include "agents/lead_agent_base.hpp"
-
 #ifdef ENABLE_GRPC
-#include "network/result_aggregator.hpp"
-#include "network/yaml_parser.hpp"
+#  include "network/result_aggregator.hpp"
+#  include "network/yaml_parser.hpp"
 #endif
 
 namespace keystone {
@@ -142,8 +142,7 @@ class ComponentLeadAgent : public LeadAgentBase<ComponentLeadState> {
    *
    * @param result_msg Message containing module result
    */
-  void processSubordinateResult(
-      const core::KeystoneMessage& result_msg) override;
+  void processSubordinateResult(const core::KeystoneMessage& result_msg) override;
 
   /**
    * @brief Convert state enum to string (HOOK METHOD)

--- a/include/agents/lead_agent_base.hpp
+++ b/include/agents/lead_agent_base.hpp
@@ -1,15 +1,16 @@
 #pragma once
 
-#include <string>
-#include <vector>
-
 #include "agents/async_agent.hpp"
 #include "agents/coordination_state.hpp"
 #include "core/message.hpp"
 
+#include <string>
+#include <vector>
+
 #ifdef ENABLE_GRPC
-#include "hmas_coordinator.pb.h"
-#include "network/yaml_parser.hpp"
+#  include "network/yaml_parser.hpp"
+
+#  include "hmas_coordinator.pb.h"
 #endif
 
 namespace keystone {
@@ -40,9 +41,12 @@ class LeadAgentBase : public AsyncAgent {
    * @param aggregating_state Aggregating/Synthesizing results state value
    * @param error_state Error state value
    */
-  explicit LeadAgentBase(const std::string& agent_id, StateEnum idle_state,
-                         StateEnum planning_state, StateEnum waiting_state,
-                         StateEnum aggregating_state, StateEnum error_state);
+  explicit LeadAgentBase(const std::string& agent_id,
+                         StateEnum idle_state,
+                         StateEnum planning_state,
+                         StateEnum waiting_state,
+                         StateEnum aggregating_state,
+                         StateEnum error_state);
 
   /**
    * @brief Process incoming message asynchronously (TEMPLATE METHOD - FINAL)
@@ -59,17 +63,14 @@ class LeadAgentBase : public AsyncAgent {
    * @param msg Message to process
    * @return concurrency::Task<core::Response> Async task with response
    */
-  concurrency::Task<core::Response> processMessage(
-      const core::KeystoneMessage& msg) final;
+  concurrency::Task<core::Response> processMessage(const core::KeystoneMessage& msg) final;
 
   /**
    * @brief Get execution trace for testing/debugging
    *
    * @return std::vector<std::string> State transition history
    */
-  std::vector<std::string> getExecutionTrace() const {
-    return coordination_.getExecutionTrace();
-  }
+  std::vector<std::string> getExecutionTrace() const { return coordination_.getExecutionTrace(); }
 
   /**
    * @brief Get current state
@@ -130,8 +131,7 @@ class LeadAgentBase : public AsyncAgent {
    *
    * @param result_msg Message containing subordinate result
    */
-  virtual void processSubordinateResult(
-      const core::KeystoneMessage& result_msg) = 0;
+  virtual void processSubordinateResult(const core::KeystoneMessage& result_msg) = 0;
 
   /**
    * @brief HOOK: Handle a failure reported by a subordinate agent (Issue #87)
@@ -145,8 +145,7 @@ class LeadAgentBase : public AsyncAgent {
    *
    * @param failure_msg Message with action_type == TASK_FAILED
    */
-  virtual void processSubordinateFailure(
-      const core::KeystoneMessage& failure_msg) {
+  virtual void processSubordinateFailure(const core::KeystoneMessage& failure_msg) {
     std::string error = failure_msg.payload.value_or("subordinate task failed");
     bool all_done = coordination_.recordFailure(error);
     if (all_done) {
@@ -175,12 +174,10 @@ class LeadAgentBase : public AsyncAgent {
    * @param spec  Task spec to update (modified in place)
    * @param error Human-readable error message
    */
-  void submitFailureResult(network::HierarchicalTaskSpec& spec,
-                           const std::string& error) {
+  void submitFailureResult(network::HierarchicalTaskSpec& spec, const std::string& error) {
     spec.status.phase = "FAILED";
     spec.status.error = error;
-    this->coordination_.transitionTo(this->error_state_,
-                                     stateToString(this->error_state_));
+    this->coordination_.transitionTo(this->error_state_, stateToString(this->error_state_));
 
     std::string result_yaml = network::YamlParser::generateTaskSpec(spec);
     auto coordinator_client = this->coordination_.getCoordinatorClient();

--- a/include/agents/module_lead_agent.hpp
+++ b/include/agents/module_lead_agent.hpp
@@ -1,17 +1,17 @@
 #pragma once
 
+#include "agents/async_agent.hpp"
+#include "agents/coordination_state.hpp"
+#include "agents/lead_agent_base.hpp"
+
 #include <map>
 #include <memory>
 #include <string>
 #include <vector>
 
-#include "agents/async_agent.hpp"
-#include "agents/coordination_state.hpp"
-#include "agents/lead_agent_base.hpp"
-
 #ifdef ENABLE_GRPC
-#include "network/result_aggregator.hpp"
-#include "network/yaml_parser.hpp"
+#  include "network/result_aggregator.hpp"
+#  include "network/yaml_parser.hpp"
 #endif
 
 namespace keystone {
@@ -142,8 +142,7 @@ class ModuleLeadAgent : public LeadAgentBase<ModuleLeadState> {
    *
    * @param result_msg Message containing task result
    */
-  void processSubordinateResult(
-      const core::KeystoneMessage& result_msg) override;
+  void processSubordinateResult(const core::KeystoneMessage& result_msg) override;
 
   /**
    * @brief Convert state enum to string (HOOK METHOD)

--- a/include/concurrency/logger.hpp
+++ b/include/concurrency/logger.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <spdlog/fmt/fmt.h>
-#include <spdlog/sinks/stdout_color_sinks.h>
-#include <spdlog/spdlog.h>
-
 #include <memory>
 #include <string>
 #include <thread>
+
+#include <spdlog/fmt/fmt.h>
+#include <spdlog/sinks/stdout_color_sinks.h>
+#include <spdlog/spdlog.h>
 
 namespace keystone {
 namespace concurrency {
@@ -44,8 +44,7 @@ class LogContext {
    * @param worker_id Worker thread index
    * @param session_id Session identifier
    */
-  static void set(const std::string& agent_id, int32_t worker_id,
-                  const std::string& session_id);
+  static void set(const std::string& agent_id, int32_t worker_id, const std::string& session_id);
 
   /**
    * @brief Clear the thread-local logging context (including correlation ID)
@@ -237,8 +236,7 @@ class Logger {
   static std::shared_ptr<spdlog::logger> logger_;
 
   template <typename... Args>
-  static void log(spdlog::level::level_enum level, const std::string& fmt,
-                  Args&&... args) {
+  static void log(spdlog::level::level_enum level, const std::string& fmt, Args&&... args) {
     if (!logger_) {
       init();
     }
@@ -248,8 +246,7 @@ class Logger {
     std::string full_fmt = context + " " + fmt;
 
     // Use runtime format to avoid compile-time format string requirement
-    logger_->log(spdlog::source_loc{}, level, fmt::runtime(full_fmt),
-                 std::forward<Args>(args)...);
+    logger_->log(spdlog::source_loc{}, level, fmt::runtime(full_fmt), std::forward<Args>(args)...);
   }
 };
 

--- a/include/core/config.hpp
+++ b/include/core/config.hpp
@@ -99,3 +99,50 @@ struct Config {
   static constexpr size_t METRICS_QUEUE_DEPTH_CRITICAL = 10000;
 
   // ========================================================================
+  // Task / Coordination Configuration
+  // ========================================================================
+
+  /**
+   * @brief Default task execution timeout (25 minutes in milliseconds)
+   *
+   * Used as fallback when no explicit deadline is specified in a task spec.
+   * 25 minutes allows for complex multi-level coordination chains while
+   * preventing indefinite hangs.
+   */
+  static constexpr int DEFAULT_TASK_TIMEOUT_MS = 25 * 60 * 1000;
+
+  // ========================================================================
+  // HTTP Server Configuration (PrometheusExporter)
+  // ========================================================================
+
+  /**
+   * @brief HTTP request buffer size
+   *
+   * Maximum size of HTTP request that can be read in one call.
+   * Requests larger than this are truncated.
+   *
+   * Default: 1024 bytes (sufficient for GET /metrics requests)
+   */
+  static constexpr size_t HTTP_REQUEST_BUFFER_SIZE = 1024;
+
+  /**
+   * @brief HTTP socket read timeout
+   *
+   * Prevents slowloris attacks by limiting time spent waiting for data.
+   *
+   * Default: 5 seconds
+   */
+  static constexpr std::chrono::seconds HTTP_READ_TIMEOUT{5};
+
+  /**
+   * @brief Maximum concurrent HTTP connections
+   *
+   * Listen backlog size for the HTTP server.
+   *
+   * Default: 10 connections
+   */
+  static constexpr int HTTP_MAX_PENDING_CONNECTIONS = 10;
+};
+
+}  // namespace core
+}  // namespace keystone

--- a/include/core/subject_validator.hpp
+++ b/include/core/subject_validator.hpp
@@ -42,11 +42,9 @@ inline const std::regex& natsTokenPattern() {
  * @throws std::invalid_argument if value is empty or contains unsafe
  * characters.
  */
-inline const std::string& validateSubjectToken(const std::string& value,
-                                               const std::string& label) {
+inline const std::string& validateSubjectToken(const std::string& value, const std::string& label) {
   if (value.empty() || !std::regex_match(value, safeIdPattern())) {
-    throw std::invalid_argument("Invalid " + label +
-                                ": unsafe characters in '" + value + "'");
+    throw std::invalid_argument("Invalid " + label + ": unsafe characters in '" + value + "'");
   }
   return value;
 }
@@ -79,9 +77,8 @@ inline const std::string& validateSubjectToken(const std::string& value,
 inline const std::string& validateNatsSubjectToken(const std::string& value,
                                                    const std::string& label) {
   if (value.empty() || !std::regex_match(value, natsTokenPattern())) {
-    throw std::invalid_argument(
-        "Invalid NATS token " + label +
-        ": must be [a-zA-Z0-9_-], '*', or '>' -- got '" + value + "'");
+    throw std::invalid_argument("Invalid NATS token " + label +
+                                ": must be [a-zA-Z0-9_-], '*', or '>' -- got '" + value + "'");
   }
   return value;
 }
@@ -115,8 +112,7 @@ inline const std::string& validateNatsSubjectToken(const std::string& value,
 inline const std::string& validateNatsSubject(const std::string& subject,
                                               const std::string& label) {
   if (subject.empty()) {
-    throw std::invalid_argument("Invalid NATS subject " + label +
-                                ": subject must not be empty");
+    throw std::invalid_argument("Invalid NATS subject " + label + ": subject must not be empty");
   }
 
   std::string_view remaining{subject};
@@ -126,8 +122,7 @@ inline const std::string& validateNatsSubject(const std::string& subject,
     if (saw_gt) {
       // A '>' token was already seen but there are more tokens after it.
       throw std::invalid_argument("Invalid NATS subject " + label +
-                                  ": '>' wildcard must be the last token in '" +
-                                  subject + "'");
+                                  ": '>' wildcard must be the last token in '" + subject + "'");
     }
 
     const auto dot_pos = remaining.find('.');
@@ -138,9 +133,8 @@ inline const std::string& validateNatsSubject(const std::string& subject,
     const std::string token{token_sv};
     // Validate the individual token (reuse natsTokenPattern).
     if (token.empty() || !std::regex_match(token, natsTokenPattern())) {
-      throw std::invalid_argument("Invalid NATS subject " + label +
-                                  ": token '" + token + "' in subject '" +
-                                  subject + "' contains invalid characters");
+      throw std::invalid_argument("Invalid NATS subject " + label + ": token '" + token +
+                                  "' in subject '" + subject + "' contains invalid characters");
     }
 
     if (token == ">") {

--- a/include/transport/nats_connection.hpp
+++ b/include/transport/nats_connection.hpp
@@ -14,14 +14,14 @@
 
 #pragma once
 
-#include <nats.h>
-
 #include <atomic>
 #include <chrono>
 #include <cstdint>
 #include <functional>
 #include <mutex>
 #include <string>
+
+#include <nats.h>
 
 namespace keystone {
 namespace transport {
@@ -204,7 +204,9 @@ class NatsConnection {
   // nats.c static callback shims — nats.c passes a void* user data pointer
   // which we cast back to NatsConnection*. Protected to allow test subclasses
   // to invoke them directly without a live nats.c connection.
-  static void onError(natsConnection* nc, natsSubscription* sub, natsStatus err,
+  static void onError(natsConnection* nc,
+                      natsSubscription* sub,
+                      natsStatus err,
                       void* closure) noexcept;
   static void onDisconnected(natsConnection* nc, void* closure) noexcept;
   static void onReconnected(natsConnection* nc, void* closure) noexcept;

--- a/include/transport/nats_connection.hpp
+++ b/include/transport/nats_connection.hpp
@@ -185,15 +185,15 @@ class NatsConnection {
    * @brief Acquire (and cache) a JetStream context for this connection
    *
    * On first call after a successful connect(), acquires a jsCtx* via
-   * js_Context() with default options and caches it. Subsequent calls return
+   * natsConnection_JetStream() and caches it. Subsequent calls return
    * the cached pointer without re-acquiring.
    *
    * @return Non-null jsCtx* on success, nullptr if not connected or if
-   *         js_Context() fails.
+   *         natsConnection_JetStream() fails.
    *
    * The returned pointer is owned by this NatsConnection and is destroyed
    * automatically in disconnect() / destructor. Callers must NOT call
-   * js_Destroy() on it.
+   * jsCtx_Destroy() on it.
    *
    * Thread-safety: this method is NOT thread-safe. Call it from the same
    * owner thread that calls connect() / disconnect().

--- a/src/agents/component_lead_agent.cpp
+++ b/src/agents/component_lead_agent.cpp
@@ -153,6 +153,7 @@ std::string ComponentLeadAgent::stateToString(State state) const {
   }
 }
 
+#ifdef ENABLE_GRPC
 void ComponentLeadAgent::initializeGrpc(const std::string& coordinator_address,
                                         const std::string& registry_address,
                                         const std::string& agent_type,
@@ -267,6 +268,7 @@ void ComponentLeadAgent::shutdown() {
   // Clean up component-specific resources
   result_aggregator_.reset();
 }
+#endif  // ENABLE_GRPC
 
 }  // namespace agents
 }  // namespace keystone

--- a/src/agents/component_lead_agent.cpp
+++ b/src/agents/component_lead_agent.cpp
@@ -1,24 +1,27 @@
 #include "agents/component_lead_agent.hpp"
 
+#include "concurrency/logger.hpp"
+#include "core/config.hpp"
+
 #include <algorithm>
 #include <chrono>
 #include <regex>
 #include <sstream>
 #include <thread>
 
-#include "concurrency/logger.hpp"
-#include "core/config.hpp"
-
 #ifdef ENABLE_GRPC
-#include "hmas_coordinator.pb.h"
+#  include "hmas_coordinator.pb.h"
 #endif
 
 namespace keystone {
 namespace agents {
 
 ComponentLeadAgent::ComponentLeadAgent(const std::string& agent_id)
-    : LeadAgentBase<State>(agent_id, State::IDLE, State::PLANNING,
-                           State::WAITING_FOR_MODULES, State::AGGREGATING,
+    : LeadAgentBase<State>(agent_id,
+                           State::IDLE,
+                           State::PLANNING,
+                           State::WAITING_FOR_MODULES,
+                           State::AGGREGATING,
                            State::ERROR) {
   // Base class constructor initializes coordination_ with IDLE state
 }
@@ -26,8 +29,7 @@ ComponentLeadAgent::ComponentLeadAgent(const std::string& agent_id)
 // processMessage() is now implemented in LeadAgentBase (template method
 // pattern)
 
-void ComponentLeadAgent::setAvailableModuleLeads(
-    const std::vector<std::string>& module_lead_ids) {
+void ComponentLeadAgent::setAvailableModuleLeads(const std::vector<std::string>& module_lead_ids) {
   available_module_leads_ = module_lead_ids;
 }
 
@@ -38,8 +40,7 @@ bool ComponentLeadAgent::isSubordinateResult(const core::KeystoneMessage& msg) {
   return msg.command == "module_result";
 }
 
-std::vector<std::string> ComponentLeadAgent::decomposeGoal(
-    const std::string& goal) {
+std::vector<std::string> ComponentLeadAgent::decomposeGoal(const std::string& goal) {
   std::vector<std::string> module_goals;
 
   // Parse component goal like "Implement Core component: Messaging(10+20+30)
@@ -47,8 +48,7 @@ std::vector<std::string> ComponentLeadAgent::decomposeGoal(
 
   // Pattern to match "ModuleName(numbers)"
   std::regex module_regex(R"((\w+)\(([0-9+]+)\))");
-  auto modules_begin =
-      std::sregex_iterator(goal.begin(), goal.end(), module_regex);
+  auto modules_begin = std::sregex_iterator(goal.begin(), goal.end(), module_regex);
   auto modules_end = std::sregex_iterator();
 
   for (std::sregex_iterator i = modules_begin; i != modules_end; ++i) {
@@ -64,8 +64,7 @@ std::vector<std::string> ComponentLeadAgent::decomposeGoal(
   return module_goals;
 }
 
-void ComponentLeadAgent::delegateSubtasks(
-    const std::vector<std::string>& subtasks) {
+void ComponentLeadAgent::delegateSubtasks(const std::vector<std::string>& subtasks) {
   // Assign module goals to available ModuleLeadAgents
   for (size_t i = 0; i < subtasks.size(); ++i) {
     if (available_module_leads_.empty()) {
@@ -80,8 +79,7 @@ void ComponentLeadAgent::delegateSubtasks(
     const std::string& module_lead_id = available_module_leads_[i];
 
     // Create and send module goal message
-    auto module_msg =
-        core::KeystoneMessage::create(agent_id_, module_lead_id, subtasks[i]);
+    auto module_msg = core::KeystoneMessage::create(agent_id_, module_lead_id, subtasks[i]);
 
     // Track pending module
     coordination_.trackPendingSubordinate(module_msg.msg_id, module_lead_id);
@@ -91,8 +89,7 @@ void ComponentLeadAgent::delegateSubtasks(
   }
 }
 
-void ComponentLeadAgent::processSubordinateResult(
-    const core::KeystoneMessage& result_msg) {
+void ComponentLeadAgent::processSubordinateResult(const core::KeystoneMessage& result_msg) {
   if (!result_msg.payload) {
     // No payload, skip
     return;
@@ -103,8 +100,7 @@ void ComponentLeadAgent::processSubordinateResult(
 
   // Check if we've received all module results
   if (all_complete) {
-    coordination_.transitionTo(State::AGGREGATING,
-                               stateToString(State::AGGREGATING));
+    coordination_.transitionTo(State::AGGREGATING, stateToString(State::AGGREGATING));
   }
 }
 
@@ -112,16 +108,14 @@ std::string ComponentLeadAgent::synthesizeComponentResult() {
   State current_state = coordination_.getCurrentState();
   if (current_state == State::ERROR) {
     auto failures = coordination_.getFailureMessages();
-    std::string msg =
-        "ERROR: " + std::to_string(coordination_.getFailureCount()) +
-        " subordinate module(s) failed";
+    std::string msg = "ERROR: " + std::to_string(coordination_.getFailureCount()) +
+                      " subordinate module(s) failed";
     if (!failures.empty()) {
       msg += ": " + failures.front();
     }
     return msg;
   }
-  if (current_state != State::AGGREGATING &&
-      current_state != State::WAITING_FOR_MODULES) {
+  if (current_state != State::AGGREGATING && current_state != State::WAITING_FOR_MODULES) {
     return "ERROR: Cannot synthesize in current state";
   }
 
@@ -164,10 +158,9 @@ void ComponentLeadAgent::initializeGrpc(const std::string& coordinator_address,
                                         const std::string& agent_type,
                                         uint8_t level) {
   // Delegate gRPC initialization to coordination template
-  std::vector<std::string> capabilities = {"module_coordination",
-                                           "component_synthesis"};
-  coordination_.initializeGrpc(agent_id_, coordinator_address, registry_address,
-                               agent_type, level, capabilities, 10);
+  std::vector<std::string> capabilities = {"module_coordination", "component_synthesis"};
+  coordination_.initializeGrpc(
+      agent_id_, coordinator_address, registry_address, agent_type, level, capabilities, 10);
 }
 
 void ComponentLeadAgent::processYamlComponent(const std::string& yaml_spec) {
@@ -182,8 +175,7 @@ void ComponentLeadAgent::processYamlComponent(const std::string& yaml_spec) {
   coordination_.transitionTo(State::PLANNING, stateToString(State::PLANNING));
 
   // Decompose component into modules using the hook method
-  auto module_goals =
-      decomposeGoal(spec.hierarchy.level1_directive.value_or(""));
+  auto module_goals = decomposeGoal(spec.hierarchy.level1_directive.value_or(""));
 
   if (module_goals.empty()) {
     submitFailureResult(spec, "Failed to decompose component goal");
@@ -191,8 +183,7 @@ void ComponentLeadAgent::processYamlComponent(const std::string& yaml_spec) {
   }
 
   // Query for available ModuleLeadAgents
-  available_module_leads_ =
-      coordination_.queryAvailableChildren("ModuleLeadAgent");
+  available_module_leads_ = coordination_.queryAvailableChildren("ModuleLeadAgent");
 
   if (available_module_leads_.empty()) {
     submitFailureResult(spec, "No ModuleLeadAgents available");
@@ -203,13 +194,11 @@ void ComponentLeadAgent::processYamlComponent(const std::string& yaml_spec) {
   auto timeout = network::YamlParser::parseDuration(spec.aggregation.timeout);
   result_aggregator_ = std::make_unique<network::ResultAggregator>(
       network::stringToStrategy(spec.aggregation.strategy),
-      std::chrono::milliseconds(
-          timeout.value_or(core::Config::DEFAULT_TASK_TIMEOUT_MS)),
+      std::chrono::milliseconds(timeout.value_or(core::Config::DEFAULT_TASK_TIMEOUT_MS)),
       module_goals.size());
 
   // Generate child module YAMLs and submit to ModuleLeadAgents
-  coordination_.transitionTo(State::WAITING_FOR_MODULES,
-                             stateToString(State::WAITING_FOR_MODULES));
+  coordination_.transitionTo(State::WAITING_FOR_MODULES, stateToString(State::WAITING_FOR_MODULES));
   coordination_.initializeCoordination(static_cast<int>(module_goals.size()));
 
   for (size_t i = 0; i < module_goals.size(); ++i) {
@@ -218,8 +207,7 @@ void ComponentLeadAgent::processYamlComponent(const std::string& yaml_spec) {
     child_spec.api_version = "v1";
     child_spec.kind = "HierarchicalTask";
     child_spec.metadata.name = "module-" + std::to_string(i);
-    child_spec.metadata.task_id =
-        spec.metadata.task_id + "-module-" + std::to_string(i);
+    child_spec.metadata.task_id = spec.metadata.task_id + "-module-" + std::to_string(i);
     child_spec.metadata.parent_task_id = spec.metadata.task_id;
     child_spec.metadata.session_id = spec.metadata.session_id;
 
@@ -245,16 +233,17 @@ void ComponentLeadAgent::processYamlComponent(const std::string& yaml_spec) {
 
     // Submit module via gRPC
     try {
-      auto deadline_ms = network::YamlParser::parseDuration(
-                             spec.metadata.deadline.value_or("25m"))
+      auto deadline_ms = network::YamlParser::parseDuration(spec.metadata.deadline.value_or("25m"))
                              .value_or(core::Config::DEFAULT_TASK_TIMEOUT_MS);
       auto coordinator_client = coordination_.getCoordinatorClient();
-      auto response = coordinator_client->submitTask(
-          child_yaml, spec.metadata.session_id.value_or(""), deadline_ms,
-          hmas::TASK_PRIORITY_NORMAL, coordination_.getCurrentTaskId());
+      auto response = coordinator_client->submitTask(child_yaml,
+                                                     spec.metadata.session_id.value_or(""),
+                                                     deadline_ms,
+                                                     hmas::TASK_PRIORITY_NORMAL,
+                                                     coordination_.getCurrentTaskId());
 
-      coordination_.trackPendingSubordinate(
-          child_spec.metadata.task_id, available_module_leads_[agent_index]);
+      coordination_.trackPendingSubordinate(child_spec.metadata.task_id,
+                                            available_module_leads_[agent_index]);
     } catch (const std::exception& e) {
       concurrency::Logger::error("Failed to submit module: {}", e.what());
     }

--- a/src/agents/component_lead_agent.cpp
+++ b/src/agents/component_lead_agent.cpp
@@ -267,7 +267,6 @@ void ComponentLeadAgent::shutdown() {
   // Clean up component-specific resources
   result_aggregator_.reset();
 }
-#endif
 
 }  // namespace agents
 }  // namespace keystone

--- a/src/agents/module_lead_agent.cpp
+++ b/src/agents/module_lead_agent.cpp
@@ -152,6 +152,7 @@ std::string ModuleLeadAgent::stateToString(State state) const {
   }
 }
 
+#ifdef ENABLE_GRPC
 void ModuleLeadAgent::initializeGrpc(const std::string& coordinator_address,
                                      const std::string& registry_address,
                                      const std::string& agent_type,
@@ -270,6 +271,7 @@ void ModuleLeadAgent::shutdown() {
   // Clean up module-specific resources
   result_aggregator_.reset();
 }
+#endif  // ENABLE_GRPC
 
 }  // namespace agents
 }  // namespace keystone

--- a/src/agents/module_lead_agent.cpp
+++ b/src/agents/module_lead_agent.cpp
@@ -270,7 +270,6 @@ void ModuleLeadAgent::shutdown() {
   // Clean up module-specific resources
   result_aggregator_.reset();
 }
-#endif
 
 }  // namespace agents
 }  // namespace keystone

--- a/src/agents/module_lead_agent.cpp
+++ b/src/agents/module_lead_agent.cpp
@@ -1,5 +1,8 @@
 #include "agents/module_lead_agent.hpp"
 
+#include "concurrency/logger.hpp"
+#include "core/config.hpp"
+
 #include <algorithm>
 #include <chrono>
 #include <cstdint>
@@ -8,19 +11,19 @@
 #include <sstream>
 #include <thread>
 
-#include "concurrency/logger.hpp"
-#include "core/config.hpp"
-
 #ifdef ENABLE_GRPC
-#include "hmas_coordinator.pb.h"
+#  include "hmas_coordinator.pb.h"
 #endif
 
 namespace keystone {
 namespace agents {
 
 ModuleLeadAgent::ModuleLeadAgent(const std::string& agent_id)
-    : LeadAgentBase<State>(agent_id, State::IDLE, State::PLANNING,
-                           State::WAITING_FOR_TASKS, State::SYNTHESIZING,
+    : LeadAgentBase<State>(agent_id,
+                           State::IDLE,
+                           State::PLANNING,
+                           State::WAITING_FOR_TASKS,
+                           State::SYNTHESIZING,
                            State::ERROR) {
   // Base class constructor initializes coordination_ with IDLE state
 }
@@ -28,8 +31,7 @@ ModuleLeadAgent::ModuleLeadAgent(const std::string& agent_id)
 // processMessage() is now implemented in LeadAgentBase (template method
 // pattern)
 
-void ModuleLeadAgent::setAvailableTaskAgents(
-    const std::vector<std::string>& task_agent_ids) {
+void ModuleLeadAgent::setAvailableTaskAgents(const std::vector<std::string>& task_agent_ids) {
   available_task_agents_ = task_agent_ids;
 }
 
@@ -40,8 +42,7 @@ bool ModuleLeadAgent::isSubordinateResult(const core::KeystoneMessage& msg) {
   return msg.command == "response";
 }
 
-std::vector<std::string> ModuleLeadAgent::decomposeGoal(
-    const std::string& goal) {
+std::vector<std::string> ModuleLeadAgent::decomposeGoal(const std::string& goal) {
   std::vector<std::string> tasks;
 
   // Parse module goal like "Calculate sum of: 10 + 20 + 30"
@@ -49,8 +50,7 @@ std::vector<std::string> ModuleLeadAgent::decomposeGoal(
 
   // Extract numbers using regex
   std::regex number_regex(R"(\d+)");
-  auto numbers_begin =
-      std::sregex_iterator(goal.begin(), goal.end(), number_regex);
+  auto numbers_begin = std::sregex_iterator(goal.begin(), goal.end(), number_regex);
   auto numbers_end = std::sregex_iterator();
 
   // Create a task for each number (echo the number)
@@ -63,8 +63,7 @@ std::vector<std::string> ModuleLeadAgent::decomposeGoal(
   return tasks;
 }
 
-void ModuleLeadAgent::delegateSubtasks(
-    const std::vector<std::string>& subtasks) {
+void ModuleLeadAgent::delegateSubtasks(const std::vector<std::string>& subtasks) {
   // Assign tasks to available TaskAgents in round-robin fashion
   for (size_t i = 0; i < subtasks.size(); ++i) {
     if (available_task_agents_.empty()) {
@@ -76,8 +75,7 @@ void ModuleLeadAgent::delegateSubtasks(
     const std::string& task_agent_id = available_task_agents_[agent_index];
 
     // Create and send task message
-    auto task_msg =
-        core::KeystoneMessage::create(agent_id_, task_agent_id, subtasks[i]);
+    auto task_msg = core::KeystoneMessage::create(agent_id_, task_agent_id, subtasks[i]);
 
     // Track pending task
     coordination_.trackPendingSubordinate(task_msg.msg_id, task_agent_id);
@@ -87,8 +85,7 @@ void ModuleLeadAgent::delegateSubtasks(
   }
 }
 
-void ModuleLeadAgent::processSubordinateResult(
-    const core::KeystoneMessage& result_msg) {
+void ModuleLeadAgent::processSubordinateResult(const core::KeystoneMessage& result_msg) {
   if (!result_msg.payload) {
     // No payload, skip
     return;
@@ -99,8 +96,7 @@ void ModuleLeadAgent::processSubordinateResult(
 
   // Check if we've received all results
   if (all_complete) {
-    coordination_.transitionTo(State::SYNTHESIZING,
-                               stateToString(State::SYNTHESIZING));
+    coordination_.transitionTo(State::SYNTHESIZING, stateToString(State::SYNTHESIZING));
   }
 }
 
@@ -108,16 +104,14 @@ std::string ModuleLeadAgent::synthesizeResults() {
   State current_state = coordination_.getCurrentState();
   if (current_state == State::ERROR) {
     auto failures = coordination_.getFailureMessages();
-    std::string msg =
-        "ERROR: " + std::to_string(coordination_.getFailureCount()) +
-        " subordinate task(s) failed";
+    std::string msg = "ERROR: " + std::to_string(coordination_.getFailureCount()) +
+                      " subordinate task(s) failed";
     if (!failures.empty()) {
       msg += ": " + failures.front();
     }
     return msg;
   }
-  if (current_state != State::SYNTHESIZING &&
-      current_state != State::WAITING_FOR_TASKS) {
+  if (current_state != State::SYNTHESIZING && current_state != State::WAITING_FOR_TASKS) {
     return "ERROR: Cannot synthesize in current state";
   }
 
@@ -163,10 +157,9 @@ void ModuleLeadAgent::initializeGrpc(const std::string& coordinator_address,
                                      const std::string& agent_type,
                                      uint8_t level) {
   // Delegate gRPC initialization to coordination template
-  std::vector<std::string> capabilities = {"task_coordination",
-                                           "result_synthesis"};
-  coordination_.initializeGrpc(agent_id_, coordinator_address, registry_address,
-                               agent_type, level, capabilities, 5);
+  std::vector<std::string> capabilities = {"task_coordination", "result_synthesis"};
+  coordination_.initializeGrpc(
+      agent_id_, coordinator_address, registry_address, agent_type, level, capabilities, 5);
 }
 
 void ModuleLeadAgent::processYamlModule(const std::string& yaml_spec) {
@@ -201,13 +194,11 @@ void ModuleLeadAgent::processYamlModule(const std::string& yaml_spec) {
   auto timeout = network::YamlParser::parseDuration(spec.aggregation.timeout);
   result_aggregator_ = std::make_unique<network::ResultAggregator>(
       network::stringToStrategy(spec.aggregation.strategy),
-      std::chrono::milliseconds(
-          timeout.value_or(core::Config::DEFAULT_TASK_TIMEOUT_MS)),
+      std::chrono::milliseconds(timeout.value_or(core::Config::DEFAULT_TASK_TIMEOUT_MS)),
       tasks.size());
 
   // Generate child task YAMLs and submit to TaskAgents
-  coordination_.transitionTo(State::WAITING_FOR_TASKS,
-                             stateToString(State::WAITING_FOR_TASKS));
+  coordination_.transitionTo(State::WAITING_FOR_TASKS, stateToString(State::WAITING_FOR_TASKS));
   coordination_.initializeCoordination(static_cast<int32_t>(tasks.size()));
 
   for (size_t i = 0; i < tasks.size(); ++i) {
@@ -216,8 +207,7 @@ void ModuleLeadAgent::processYamlModule(const std::string& yaml_spec) {
     child_spec.api_version = "v1";
     child_spec.kind = "HierarchicalTask";
     child_spec.metadata.name = "task-" + std::to_string(i);
-    child_spec.metadata.task_id =
-        spec.metadata.task_id + "-subtask-" + std::to_string(i);
+    child_spec.metadata.task_id = spec.metadata.task_id + "-subtask-" + std::to_string(i);
     child_spec.metadata.parent_task_id = spec.metadata.task_id;
     child_spec.metadata.session_id = spec.metadata.session_id;
 
@@ -243,16 +233,17 @@ void ModuleLeadAgent::processYamlModule(const std::string& yaml_spec) {
 
     // Submit task via gRPC
     try {
-      auto deadline_ms = network::YamlParser::parseDuration(
-                             spec.metadata.deadline.value_or("25m"))
+      auto deadline_ms = network::YamlParser::parseDuration(spec.metadata.deadline.value_or("25m"))
                              .value_or(core::Config::DEFAULT_TASK_TIMEOUT_MS);
       auto coordinator_client = coordination_.getCoordinatorClient();
-      auto response = coordinator_client->submitTask(
-          child_yaml, spec.metadata.session_id.value_or(""), deadline_ms,
-          hmas::TASK_PRIORITY_NORMAL, coordination_.getCurrentTaskId());
+      auto response = coordinator_client->submitTask(child_yaml,
+                                                     spec.metadata.session_id.value_or(""),
+                                                     deadline_ms,
+                                                     hmas::TASK_PRIORITY_NORMAL,
+                                                     coordination_.getCurrentTaskId());
 
-      coordination_.trackPendingSubordinate(
-          child_spec.metadata.task_id, available_task_agents_[agent_index]);
+      coordination_.trackPendingSubordinate(child_spec.metadata.task_id,
+                                            available_task_agents_[agent_index]);
     } catch (const std::exception& e) {
       concurrency::Logger::error("Failed to submit task: {}", e.what());
     }

--- a/src/transport/nats_connection.cpp
+++ b/src/transport/nats_connection.cpp
@@ -5,11 +5,11 @@
 
 #include "transport/nats_connection.hpp"
 
-#include <nats.h>
-#include <spdlog/spdlog.h>
-
 #include <cstdlib>
 #include <string>
+
+#include <nats.h>
+#include <spdlog/spdlog.h>
 
 namespace keystone {
 namespace transport {
@@ -27,10 +27,11 @@ std::string getEnvVar(const char* name) {
 // Construction / destruction
 // ---------------------------------------------------------------------------
 
-NatsConnection::NatsConnection(NatsConfig config)
-    : config_(std::move(config)) {}
+NatsConnection::NatsConnection(NatsConfig config) : config_(std::move(config)) {}
 
-NatsConnection::~NatsConnection() { disconnect(); }
+NatsConnection::~NatsConnection() {
+  disconnect();
+}
 
 // ---------------------------------------------------------------------------
 // Callback registration
@@ -85,10 +86,8 @@ bool NatsConnection::applyTlsOptions(natsOptions* opts) const {
     ca_path = tls.ca_cert_path;
   }
   if (!ca_path.empty()) {
-    if (natsOptions_LoadCATrustedCertificates(opts, ca_path.c_str()) !=
-        NATS_OK) {
-      spdlog::error("NatsConnection: failed to load CA certificate from {}",
-                    ca_path);
+    if (natsOptions_LoadCATrustedCertificates(opts, ca_path.c_str()) != NATS_OK) {
+      spdlog::error("NatsConnection: failed to load CA certificate from {}", ca_path);
       return false;
     }
   }
@@ -105,11 +104,10 @@ bool NatsConnection::applyTlsOptions(natsOptions* opts) const {
   }
 
   if (!cert_path.empty() && !key_path.empty()) {
-    if (natsOptions_LoadCertificatesChain(opts, cert_path.c_str(),
-                                          key_path.c_str()) != NATS_OK) {
-      spdlog::error(
-          "NatsConnection: failed to load client certificate from {} / {}",
-          cert_path, key_path);
+    if (natsOptions_LoadCertificatesChain(opts, cert_path.c_str(), key_path.c_str()) != NATS_OK) {
+      spdlog::error("NatsConnection: failed to load client certificate from {} / {}",
+                    cert_path,
+                    key_path);
       return false;
     }
   } else if (!cert_path.empty() || !key_path.empty()) {
@@ -118,7 +116,8 @@ bool NatsConnection::applyTlsOptions(natsOptions* opts) const {
         "NatsConnection: TLS client certificate requires both cert and key "
         "paths; "
         "cert_path='{}' key_path='{}'",
-        cert_path, key_path);
+        cert_path,
+        key_path);
     return false;
   }
 
@@ -150,8 +149,7 @@ bool NatsConnection::connect() {
   }
 
   // Reconnection policy
-  if (natsOptions_SetMaxReconnect(opts, config_.max_reconnect_attempts) !=
-      NATS_OK) {
+  if (natsOptions_SetMaxReconnect(opts, config_.max_reconnect_attempts) != NATS_OK) {
     return false;
   }
 
@@ -175,20 +173,16 @@ bool NatsConnection::connect() {
   }
 
   // Lifecycle callbacks — pass `this` as closure so static shims can dispatch
-  if (natsOptions_SetErrorHandler(opts, NatsConnection::onError, this) !=
-      NATS_OK) {
+  if (natsOptions_SetErrorHandler(opts, NatsConnection::onError, this) != NATS_OK) {
     return false;
   }
-  if (natsOptions_SetDisconnectedCB(opts, NatsConnection::onDisconnected,
-                                    this) != NATS_OK) {
+  if (natsOptions_SetDisconnectedCB(opts, NatsConnection::onDisconnected, this) != NATS_OK) {
     return false;
   }
-  if (natsOptions_SetReconnectedCB(opts, NatsConnection::onReconnected, this) !=
-      NATS_OK) {
+  if (natsOptions_SetReconnectedCB(opts, NatsConnection::onReconnected, this) != NATS_OK) {
     return false;
   }
-  if (natsOptions_SetClosedCB(opts, NatsConnection::onClosed, this) !=
-      NATS_OK) {
+  if (natsOptions_SetClosedCB(opts, NatsConnection::onClosed, this) != NATS_OK) {
     return false;
   }
 
@@ -225,8 +219,7 @@ jsCtx* NatsConnection::jsContext() noexcept {
   }
   const natsStatus status = js_Context(&js_ctx_, conn_, nullptr, nullptr);
   if (status != NATS_OK) {
-    spdlog::error("NatsConnection::jsContext: js_Context failed: {}",
-                  natsStatus_GetText(status));
+    spdlog::error("NatsConnection::jsContext: js_Context failed: {}", natsStatus_GetText(status));
     js_ctx_ = nullptr;
     return nullptr;
   }
@@ -245,15 +238,19 @@ bool NatsConnection::isConnected() const noexcept {
   return getState() == NatsConnectionState::CONNECTED;
 }
 
-natsConnection* NatsConnection::handle() const noexcept { return conn_; }
+natsConnection* NatsConnection::handle() const noexcept {
+  return conn_;
+}
 
 // ---------------------------------------------------------------------------
 // Static callback shims
 // ---------------------------------------------------------------------------
 
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
-void NatsConnection::onError(natsConnection* /*nc*/, natsSubscription* /*sub*/,
-                             natsStatus err, void* closure) noexcept {
+void NatsConnection::onError(natsConnection* /*nc*/,
+                             natsSubscription* /*sub*/,
+                             natsStatus err,
+                             void* closure) noexcept {
   auto* self = static_cast<NatsConnection*>(closure);
   ErrorCallback cb;
   {
@@ -266,11 +263,9 @@ void NatsConnection::onError(natsConnection* /*nc*/, natsSubscription* /*sub*/,
   }
 }
 
-void NatsConnection::onDisconnected(natsConnection* /*nc*/,
-                                    void* closure) noexcept {
+void NatsConnection::onDisconnected(natsConnection* /*nc*/, void* closure) noexcept {
   auto* self = static_cast<NatsConnection*>(closure);
-  self->state_.store(NatsConnectionState::RECONNECTING,
-                     std::memory_order_release);
+  self->state_.store(NatsConnectionState::RECONNECTING, std::memory_order_release);
   DisconnectedCallback cb;
   {
     std::lock_guard<std::mutex> lock(self->callbacks_mutex_);
@@ -281,8 +276,7 @@ void NatsConnection::onDisconnected(natsConnection* /*nc*/,
   }
 }
 
-void NatsConnection::onReconnected(natsConnection* /*nc*/,
-                                   void* closure) noexcept {
+void NatsConnection::onReconnected(natsConnection* /*nc*/, void* closure) noexcept {
   auto* self = static_cast<NatsConnection*>(closure);
   self->state_.store(NatsConnectionState::CONNECTED, std::memory_order_release);
   ReconnectedCallback cb;

--- a/src/transport/nats_connection.cpp
+++ b/src/transport/nats_connection.cpp
@@ -198,7 +198,7 @@ bool NatsConnection::connect() {
 
 void NatsConnection::disconnect() {
   if (js_ctx_ != nullptr) {
-    js_Destroy(js_ctx_);
+    jsCtx_Destroy(js_ctx_);
     js_ctx_ = nullptr;
   }
   if (conn_ != nullptr) {
@@ -217,9 +217,10 @@ jsCtx* NatsConnection::jsContext() noexcept {
     spdlog::error("NatsConnection::jsContext: called before connect()");
     return nullptr;
   }
-  const natsStatus status = js_Context(&js_ctx_, conn_, nullptr, nullptr);
+  const natsStatus status = natsConnection_JetStream(&js_ctx_, conn_, nullptr);
   if (status != NATS_OK) {
-    spdlog::error("NatsConnection::jsContext: js_Context failed: {}", natsStatus_GetText(status));
+    spdlog::error("NatsConnection::jsContext: natsConnection_JetStream failed: {}",
+                  natsStatus_GetText(status));
     js_ctx_ = nullptr;
     return nullptr;
   }

--- a/tests/unit/test_nats_connection.cpp
+++ b/tests/unit/test_nats_connection.cpp
@@ -22,12 +22,12 @@
  * the NatsConnectionTestPeer helper below.
  */
 
-#include <gtest/gtest.h>
+#include "transport/nats_connection.hpp"
 
 #include <atomic>
 #include <string>
 
-#include "transport/nats_connection.hpp"
+#include <gtest/gtest.h>
 
 using namespace keystone::transport;
 
@@ -39,9 +39,7 @@ class NatsConnectionTestPeer : public NatsConnection {
  public:
   using NatsConnection::NatsConnection;
 
-  void fireError() {
-    NatsConnection::onError(nullptr, nullptr, static_cast<natsStatus>(0), this);
-  }
+  void fireError() { NatsConnection::onError(nullptr, nullptr, static_cast<natsStatus>(0), this); }
 
   void fireDisconnected() { NatsConnection::onDisconnected(nullptr, this); }
   void fireReconnected() { NatsConnection::onReconnected(nullptr, this); }

--- a/tests/unit/test_security_regression.cpp
+++ b/tests/unit/test_security_regression.cpp
@@ -171,7 +171,7 @@ TEST(SecurityRegressionTest, AgentIdInterningOverflow) {
 TEST(SecurityRegressionTest, ConfigWatermarkValidation) {
   // Test that watermark configuration is validated at compile time
 
-  size_t watermark = core::Config::getQueueLowWatermark();
+  size_t watermark = static_cast<size_t>(core::Config::AGENT_MAX_QUEUE_SIZE * core::Config::AGENT_QUEUE_LOW_WATERMARK_PERCENT);
   size_t max_size = core::Config::AGENT_MAX_QUEUE_SIZE;
 
   // Watermark must be less than max size
@@ -246,7 +246,7 @@ TEST(SecurityRegressionTest, StaticAssertCompileTime) {
   // Verify that static_assert validations don't affect runtime
 
   // Config watermark validation (compile-time check)
-  size_t watermark = core::Config::getQueueLowWatermark();
+  size_t watermark = static_cast<size_t>(core::Config::AGENT_MAX_QUEUE_SIZE * core::Config::AGENT_QUEUE_LOW_WATERMARK_PERCENT);
   EXPECT_GT(watermark, 0u);
 
   // If static_assert failed, this code wouldn't compile

--- a/tests/unit/test_security_regression.cpp
+++ b/tests/unit/test_security_regression.cpp
@@ -171,7 +171,8 @@ TEST(SecurityRegressionTest, AgentIdInterningOverflow) {
 TEST(SecurityRegressionTest, ConfigWatermarkValidation) {
   // Test that watermark configuration is validated at compile time
 
-  size_t watermark = static_cast<size_t>(core::Config::AGENT_MAX_QUEUE_SIZE * core::Config::AGENT_QUEUE_LOW_WATERMARK_PERCENT);
+  size_t watermark = static_cast<size_t>(core::Config::AGENT_MAX_QUEUE_SIZE *
+                                         core::Config::AGENT_QUEUE_LOW_WATERMARK_PERCENT);
   size_t max_size = core::Config::AGENT_MAX_QUEUE_SIZE;
 
   // Watermark must be less than max size
@@ -246,7 +247,8 @@ TEST(SecurityRegressionTest, StaticAssertCompileTime) {
   // Verify that static_assert validations don't affect runtime
 
   // Config watermark validation (compile-time check)
-  size_t watermark = static_cast<size_t>(core::Config::AGENT_MAX_QUEUE_SIZE * core::Config::AGENT_QUEUE_LOW_WATERMARK_PERCENT);
+  size_t watermark = static_cast<size_t>(core::Config::AGENT_MAX_QUEUE_SIZE *
+                                         core::Config::AGENT_QUEUE_LOW_WATERMARK_PERCENT);
   EXPECT_GT(watermark, 0u);
 
   // If static_assert failed, this code wouldn't compile

--- a/tests/unit/test_subject_validator.cpp
+++ b/tests/unit/test_subject_validator.cpp
@@ -11,11 +11,11 @@
  * (Issue #280).
  */
 
-#include <gtest/gtest.h>
-
 #include "agents/task_agent.hpp"
 #include "core/message_bus.hpp"
 #include "core/subject_validator.hpp"
+
+#include <gtest/gtest.h>
 
 // =============================================================================
 // Valid identifiers -- must pass without throwing
@@ -38,8 +38,8 @@ TEST(SubjectValidatorTest, AcceptsUnderscores) {
 }
 
 TEST(SubjectValidatorTest, AcceptsUuid) {
-  EXPECT_NO_THROW(keystone::core::validateSubjectToken(
-      "550e8400-e29b-41d4-a716-446655440000", "team_id"));
+  EXPECT_NO_THROW(
+      keystone::core::validateSubjectToken("550e8400-e29b-41d4-a716-446655440000", "team_id"));
 }
 
 TEST(SubjectValidatorTest, ReturnsValueUnchanged) {
@@ -57,8 +57,7 @@ TEST(SubjectValidatorTest, RejectsPathTraversalDotDot) {
 }
 
 TEST(SubjectValidatorTest, RejectsSlash) {
-  EXPECT_THROW(keystone::core::validateSubjectToken("foo/bar", "team_id"),
-               std::invalid_argument);
+  EXPECT_THROW(keystone::core::validateSubjectToken("foo/bar", "team_id"), std::invalid_argument);
 }
 
 TEST(SubjectValidatorTest, RejectsLeadingSlash) {
@@ -71,23 +70,19 @@ TEST(SubjectValidatorTest, RejectsLeadingSlash) {
 // =============================================================================
 
 TEST(SubjectValidatorTest, RejectsSpace) {
-  EXPECT_THROW(keystone::core::validateSubjectToken("team id", "id"),
-               std::invalid_argument);
+  EXPECT_THROW(keystone::core::validateSubjectToken("team id", "id"), std::invalid_argument);
 }
 
 TEST(SubjectValidatorTest, RejectsNewline) {
-  EXPECT_THROW(keystone::core::validateSubjectToken("team\nid", "id"),
-               std::invalid_argument);
+  EXPECT_THROW(keystone::core::validateSubjectToken("team\nid", "id"), std::invalid_argument);
 }
 
 TEST(SubjectValidatorTest, RejectsSemicolon) {
-  EXPECT_THROW(keystone::core::validateSubjectToken("team;id", "id"),
-               std::invalid_argument);
+  EXPECT_THROW(keystone::core::validateSubjectToken("team;id", "id"), std::invalid_argument);
 }
 
 TEST(SubjectValidatorTest, RejectsDot) {
-  EXPECT_THROW(keystone::core::validateSubjectToken("team.id", "id"),
-               std::invalid_argument);
+  EXPECT_THROW(keystone::core::validateSubjectToken("team.id", "id"), std::invalid_argument);
 }
 
 // =============================================================================
@@ -95,8 +90,7 @@ TEST(SubjectValidatorTest, RejectsDot) {
 // =============================================================================
 
 TEST(SubjectValidatorTest, RejectsEmptyString) {
-  EXPECT_THROW(keystone::core::validateSubjectToken("", "id"),
-               std::invalid_argument);
+  EXPECT_THROW(keystone::core::validateSubjectToken("", "id"), std::invalid_argument);
 }
 
 TEST(SubjectValidatorTest, ErrorMessageContainsLabel) {
@@ -138,8 +132,7 @@ TEST(SubjectValidatorTest, MessageBusAcceptsValidAgentId) {
 TEST(NatsSubjectTokenTest, AcceptsAlphanumericToken) {
   EXPECT_NO_THROW(keystone::core::validateNatsSubjectToken("foo", "tok"));
   EXPECT_NO_THROW(keystone::core::validateNatsSubjectToken("abc123", "tok"));
-  EXPECT_NO_THROW(
-      keystone::core::validateNatsSubjectToken("agent-core_7", "tok"));
+  EXPECT_NO_THROW(keystone::core::validateNatsSubjectToken("agent-core_7", "tok"));
 }
 
 TEST(NatsSubjectTokenTest, AcceptsSingleStarWildcard) {
@@ -152,29 +145,24 @@ TEST(NatsSubjectTokenTest, AcceptsGreaterThanWildcard) {
 
 TEST(NatsSubjectTokenTest, RejectsDotInSingleToken) {
   // Dots are subject separators and must not appear inside a single token.
-  EXPECT_THROW(keystone::core::validateNatsSubjectToken("foo.bar", "tok"),
-               std::invalid_argument);
+  EXPECT_THROW(keystone::core::validateNatsSubjectToken("foo.bar", "tok"), std::invalid_argument);
 }
 
 TEST(NatsSubjectTokenTest, RejectsEmptyToken) {
-  EXPECT_THROW(keystone::core::validateNatsSubjectToken("", "tok"),
-               std::invalid_argument);
+  EXPECT_THROW(keystone::core::validateNatsSubjectToken("", "tok"), std::invalid_argument);
 }
 
 TEST(NatsSubjectTokenTest, RejectsSlashInToken) {
-  EXPECT_THROW(keystone::core::validateNatsSubjectToken("foo/bar", "tok"),
-               std::invalid_argument);
+  EXPECT_THROW(keystone::core::validateNatsSubjectToken("foo/bar", "tok"), std::invalid_argument);
 }
 
 TEST(NatsSubjectTokenTest, RejectsSpaceInToken) {
-  EXPECT_THROW(keystone::core::validateNatsSubjectToken("foo bar", "tok"),
-               std::invalid_argument);
+  EXPECT_THROW(keystone::core::validateNatsSubjectToken("foo bar", "tok"), std::invalid_argument);
 }
 
 TEST(NatsSubjectTokenTest, RejectsDoubleWildcard) {
   // "**" is not a valid NATS token.
-  EXPECT_THROW(keystone::core::validateNatsSubjectToken("**", "tok"),
-               std::invalid_argument);
+  EXPECT_THROW(keystone::core::validateNatsSubjectToken("**", "tok"), std::invalid_argument);
 }
 
 TEST(NatsSubjectTokenTest, ReturnsValueUnchanged) {
@@ -196,8 +184,7 @@ TEST(NatsSubjectTokenTest, ErrorMessageContainsLabel) {
 // =============================================================================
 
 TEST(NatsSubjectTest, AcceptsSimpleSubject) {
-  EXPECT_NO_THROW(
-      keystone::core::validateNatsSubject("hi.agents.task-1", "subj"));
+  EXPECT_NO_THROW(keystone::core::validateNatsSubject("hi.agents.task-1", "subj"));
 }
 
 TEST(NatsSubjectTest, AcceptsSingleToken) {
@@ -205,8 +192,7 @@ TEST(NatsSubjectTest, AcceptsSingleToken) {
 }
 
 TEST(NatsSubjectTest, AcceptsStarWildcardInMiddle) {
-  EXPECT_NO_THROW(
-      keystone::core::validateNatsSubject("hi.myrmidon.*.status", "subj"));
+  EXPECT_NO_THROW(keystone::core::validateNatsSubject("hi.myrmidon.*.status", "subj"));
 }
 
 TEST(NatsSubjectTest, AcceptsGtWildcardAtEnd) {
@@ -218,18 +204,15 @@ TEST(NatsSubjectTest, AcceptsGtAloneAsSubject) {
 }
 
 TEST(NatsSubjectTest, RejectsGtNotAtEnd) {
-  EXPECT_THROW(keystone::core::validateNatsSubject("hi.>.extra", "subj"),
-               std::invalid_argument);
+  EXPECT_THROW(keystone::core::validateNatsSubject("hi.>.extra", "subj"), std::invalid_argument);
 }
 
 TEST(NatsSubjectTest, RejectsEmptySubject) {
-  EXPECT_THROW(keystone::core::validateNatsSubject("", "subj"),
-               std::invalid_argument);
+  EXPECT_THROW(keystone::core::validateNatsSubject("", "subj"), std::invalid_argument);
 }
 
 TEST(NatsSubjectTest, RejectsEmptyTokenBetweenDots) {
-  EXPECT_THROW(keystone::core::validateNatsSubject("hi..agents", "subj"),
-               std::invalid_argument);
+  EXPECT_THROW(keystone::core::validateNatsSubject("hi..agents", "subj"), std::invalid_argument);
 }
 
 TEST(NatsSubjectTest, RejectsSpaceInToken) {


### PR DESCRIPTION
## Summary

Three pre-existing bugs on \`main\` that were cascading — each masked the next:

1. **clang-format v18 mismatch** — 11 C++ files reformatted by CI's clang-format-18 (local toolchain differs). Also fixes a shell quoting bug in the CMake cycle-check step where \`python3 -c \"...\"\` with inner double-quotes broke arg parsing; converted to heredoc syntax.

2. **\`config.hpp\` truncated struct** — Commit \`a5712eb\` removed scheduler constants but accidentally stripped everything from \`DEFAULT_TASK_TIMEOUT_MS\` onward, including the struct \`};\` and namespace closers. Caused \`error: missing '}' at end of definition of 'keystone::core::Config'\` which cascaded into namespace pollution across all builds.

3. **Orphaned \`#endif\` in two agent files** — \`component_lead_agent.cpp\` and \`module_lead_agent.cpp\` each had an unmatched \`#endif\` at file end from a prior refactor that removed \`#ifdef ENABLE_GRPC\` guards but left the closing directive. Caused \`error: #endif without #if\` which was masked by bug #2.

## Test plan
- [x] Code Quality (clang-format-18, cycle check) — should pass
- [ ] Test (asan/tsan/ubsan/lsan) — builds should now compile and tests pass
- [ ] Benchmarks — release build should compile
- [ ] Code Coverage — debug+coverage build should compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)