### PR TITLE
fix(config): restore accidentally truncated Config struct

### DIFF
--- a/include/core/config.hpp
+++ b/include/core/config.hpp
@@ -99,3 +99,50 @@ struct Config {
   static constexpr size_t METRICS_QUEUE_DEPTH_CRITICAL = 10000;
 
   // ========================================================================
+  // Task / Coordination Configuration
+  // ========================================================================
+
+  /**
+   * @brief Default task execution timeout (25 minutes in milliseconds)
+   *
+   * Used as fallback when no explicit deadline is specified in a task spec.
+   * 25 minutes allows for complex multi-level coordination chains while
+   * preventing indefinite hangs.
+   */
+  static constexpr int DEFAULT_TASK_TIMEOUT_MS = 25 * 60 * 1000;
+
+  // ========================================================================
+  // HTTP Server Configuration (PrometheusExporter)
+  // ========================================================================
+
+  /**
+   * @brief HTTP request buffer size
+   *
+   * Maximum size of HTTP request that can be read in one call.
+   * Requests larger than this are truncated.
+   *
+   * Default: 1024 bytes (sufficient for GET /metrics requests)
+   */
+  static constexpr size_t HTTP_REQUEST_BUFFER_SIZE = 1024;
+
+  /**
+   * @brief HTTP socket read timeout
+   *
+   * Prevents slowloris attacks by limiting time spent waiting for data.
+   *
+   * Default: 5 seconds
+   */
+  static constexpr std::chrono::seconds HTTP_READ_TIMEOUT{5};
+
+  /**
+   * @brief Maximum concurrent HTTP connections
+   *
+   * Listen backlog size for the HTTP server.
+   *
+   * Default: 10 connections
+   */
+  static constexpr int HTTP_MAX_PENDING_CONNECTIONS = 10;
+};
+
+}  // namespace core
+}  // namespace keystone


### PR DESCRIPTION
## Summary

- Commit `a5712eb` removed scheduler constants from `Config` but accidentally stripped everything from `DEFAULT_TASK_TIMEOUT_MS` onward, including the struct closing brace and both namespace closers
- This caused `error: missing '}' at end of definition of 'keystone::core::Config'` which cascaded into namespace pollution and compilation failure across all sanitizer, benchmark, and coverage builds
- Restores the 4 missing constants (`DEFAULT_TASK_TIMEOUT_MS`, `HTTP_REQUEST_BUFFER_SIZE`, `HTTP_READ_TIMEOUT`, `HTTP_MAX_PENDING_CONNECTIONS`) plus `};` and namespace closers — does NOT re-add the scheduler constants that `a5712eb` intentionally removed

## Test plan
- [ ] Code Quality passes (clang-format, no logic changes)
- [ ] All sanitizer builds compile and pass (asan/tsan/ubsan/lsan)
- [ ] Benchmarks compile and run
- [ ] Code Coverage compiles and runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)