### PR TITLE
chore: increase coverage threshold from 85% to 90%

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ source = ["src/keystone"]
 omit = ["src/keystone/__main__.py"]
 
 [tool.coverage.report]
-fail_under = 85
+fail_under = 90
 exclude_lines = [
     "pragma: no cover",
     "if TYPE_CHECKING:",


### PR DESCRIPTION
## Summary

Increase the code coverage threshold from 85% to 90% as per issue #341.

This is the first step in the incremental approach to raise coverage thresholds:
- 85% → 90% (this PR)
- 90% → 95% (future PR)

## Test plan

- [x] Verify pyproject.toml coverage fail_under threshold updated
- [x] CI/coverage checks will enforce new threshold