### PR TITLE
feat: add Logger::init() call to monitoring server startup paths

### DIFF
--- a/src/monitoring/health_check_server.cpp
+++ b/src/monitoring/health_check_server.cpp
@@ -71,6 +71,9 @@ bool HealthCheckServer::start() {
     return false;  // Already running
   }
 
+  // Initialize logger (ensures spdlog is ready before first log call)
+  concurrency::Logger::init();
+
   // Create socket
   server_fd_ = socket(AF_INET, SOCK_STREAM, 0);
   if (server_fd_.load() < 0) {

--- a/src/monitoring/prometheus_exporter.cpp
+++ b/src/monitoring/prometheus_exporter.cpp
@@ -65,6 +65,9 @@ bool PrometheusExporter::start() {
     return false;  // Already running
   }
 
+  // Initialize logger (ensures spdlog is ready before first log call)
+  concurrency::Logger::init();
+
   // Create socket
   server_fd_ = socket(AF_INET, SOCK_STREAM, 0);
   if (server_fd_ < 0) {


### PR DESCRIPTION
## Summary

Initializes the logger explicitly in both `HealthCheckServer::start()` and `PrometheusExporter::start()` methods to ensure spdlog is ready before the first log message is emitted.

This implements explicit startup initialization rather than relying on the lazy initialization guard in `Logger::log()`, providing a clearer and more explicit initialization contract.

## Changes

- Added `Logger::init()` call to `HealthCheckServer::start()` immediately after the running flag check
- Added `Logger::init()` call to `PrometheusExporter::start()` immediately after the running flag check
- Both calls are idempotent (Logger::init() checks for existing logger before creating a new one)

## Testing

- Format check passed
- No compilation changes required (Logger::init() is already available and idempotent)

Closes #336