### PR TITLE
docs: update CLAUDE.md and ADR cross-references after Python migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,7 +123,9 @@ Keystone enforces pull-based, rate-limited delivery to prevent myrmidon overload
 
 ---
 
-## What Was Moved to ProjectAgamemnon (ADR-006)
+## What Was Moved to ProjectAgamemnon (ADR-006, ADR-015)
+
+### C++ Agent Layer (ADR-015)
 
 The following are **no longer part of Keystone**. They live in ProjectAgamemnon:
 
@@ -134,6 +136,25 @@ The following are **no longer part of Keystone**. They live in ProjectAgamemnon:
 - Delegation and escalation logic
 - Work-stealing scheduler
 - HMAS 4-layer hierarchy design
+
+### Python Orchestration Layer (ADR-015, 2026)
+
+The following Python modules were also extracted from Keystone into ProjectAgamemnon
+as part of the ADR-015 follow-up (HomericIntelligence/Odysseus#143):
+
+- `dag_walker.py` — DAGWalker (task ready-set computation, cycle detection)
+- `task_claimer.py` — TaskClaimer (per-team concurrency guard, drain)
+- `nats_listener.py` — NATSListener (NATS subject subscriber, `hi.tasks.>`)
+- `maestro_client.py` — MaestroClient (AI Maestro REST client)
+- `models.py` — Task, Agent, TaskEvent domain models
+- `daemon.py` — orchestration daemon entry point
+- `config.py`, `logging.py`, `validation.py` — supporting utilities
+
+These modules are now part of `agamemnon.orchestration` in ProjectAgamemnon.
+Keystone retains sole ownership of the NATS subject schema but no longer runs
+a Python subscriber.
+
+---
 
 Keystone's only concern is moving bytes from publisher to subscriber, reliably and
 transparently.
@@ -331,5 +352,5 @@ Before opening a PR:
 ---
 
 **Last Updated**: 2026-04-25
-**Version**: 2.0 (Pure Transport — HMAS extracted to ProjectAgamemnon per ADR-006)
+**Version**: 3.0 (Pure Transport — HMAS and Python orchestration extracted to ProjectAgamemnon per ADR-015)
 **Project**: ProjectKeystone

--- a/docs/plan/adr/ADR-016-python-orchestration-migration-to-projectagamemnon.md
+++ b/docs/plan/adr/ADR-016-python-orchestration-migration-to-projectagamemnon.md
@@ -1,0 +1,127 @@
+# ADR-016: Python Orchestration Migration to ProjectAgamemnon
+
+**Status**: Accepted
+**Date**: 2026-04-25
+**Deciders**: ProjectKeystone Development Team
+**Tags**: architecture, extraction, orchestration, python, projectagamemnon, decoupling
+**Related**: ADR-015
+
+## Context
+
+ProjectKeystone originally contained Python orchestration modules alongside its C++ transport layer:
+
+- `dag_walker.py` — DAGWalker (task ready-set computation, cycle detection)
+- `task_claimer.py` — TaskClaimer (per-team concurrency guard, drain)
+- `nats_listener.py` — NATSListener (NATS subject subscriber, `hi.tasks.>`)
+- `maestro_client.py` — MaestroClient (AI Maestro REST client)
+- `models.py` — Task, Agent, TaskEvent domain models
+- `daemon.py` — orchestration daemon entry point
+- `config.py`, `logging.py`, `validation.py` — supporting utilities
+
+These modules were part of the Python subscriber that consumed task events from the `homeric-tasks` NATS stream and advanced the DAG through AI Maestro.
+
+### Problems with Co-location
+
+1. **Language mixing**: ProjectKeystone's CLAUDE.md mandates C++20 only for implementation.
+   Python orchestration modules violated this principle.
+2. **Scope creep**: Keystone's mandate is invisible, zero-configuration message routing.
+   Task scheduling, DAG advancement, and Maestro integration are orchestration concerns
+   that belong in a dedicated orchestration system.
+3. **Dependency bloat**: Consumers of Keystone's C++ transport library were forced to
+   manage Python dependencies (asyncio, aiohttp, pydantic, etc.) even when using only C++.
+4. **Testability**: Python orchestration tests required complex async test fixtures and
+   were brittle across different Python versions.
+5. **Deployment**: Python and C++ components required separate deployment, version,
+   and configuration management.
+
+### Relationship to ADR-015
+
+ADR-015 documented the extraction of the C++ agent hierarchy (HMAS 4-layer agents).
+This ADR documents the parallel extraction of Python orchestration modules. Together,
+they complete the decoupling of ProjectKeystone from all non-transport concerns.
+
+## Decision
+
+Extract all Python orchestration modules from ProjectKeystone into **ProjectAgamemnon**'s
+`agamemnon.orchestration` package:
+
+- Move `dag_walker.py` to `agamemnon/orchestration/dag_walker.py`
+- Move `task_claimer.py` to `agamemnon/orchestration/task_claimer.py`
+- Move `nats_listener.py` to `agamemnon/orchestration/nats_listener.py`
+- Move `maestro_client.py` to `agamemnon/orchestration/maestro_client.py`
+- Move `models.py` to `agamemnon/orchestration/models.py`
+- Move `daemon.py` to `agamemnon/orchestration/daemon.py`
+- Move supporting modules (`config.py`, `logging.py`, `validation.py`) to `agamemnon/orchestration/`
+
+ProjectKeystone retains sole ownership of:
+
+- NATS subject schema (`homeric-research`, `homeric-myrmidon`, `homeric-pipeline`,
+  `homeric-agents`, `homeric-tasks`, `homeric-logs`)
+- Python dependencies limited to: `nats-py` (for subject schema validation only)
+
+ProjectAgamemnon now owns the complete orchestration stack, including:
+
+- DAG traversal and ready-set computation
+- Per-team concurrency control
+- Task claiming and batch pulling
+- Maestro integration
+- Configuration and logging
+
+## Consequences
+
+### Positive
+
+- **Pure C++20 mandate**: ProjectKeystone is now exclusively C++20. All transport
+  primitives are implemented in C++ with modern language features and strong type safety.
+- **Clear language boundaries**: ProjectAgamemnon is now the exclusive home for both
+  C++ agent coordination logic and Python orchestration logic.
+- **Dependency isolation**: Consumers of Keystone's C++ library do not pull Python
+  dependencies (asyncio, aiohttp, pydantic, etc.).
+- **Independent evolution**: Orchestration algorithms (DAG traversal, task claiming,
+  concurrency control) can evolve independently from transport routing logic.
+- **Single responsibility**: Each system owns its complete domain:
+  - Keystone: message routing and delivery
+  - Agamemnon: task scheduling and DAG advancement
+- **CLAUDE.md alignment**: The project description now correctly reflects ProjectKeystone
+  as a pure C++20 transport library with no Python components.
+
+### Negative / Trade-offs
+
+- **Cross-system coordination**: Tasks that touch both transport protocol (Keystone) and
+  orchestration behavior (Agamemnon) require coordinated PRs in both repositories.
+- **Version management**: Agamemnon must pin or track a compatible version of Keystone's
+  NATS subject schema and transport contracts.
+- **Async/await patterns**: Python async patterns in Agamemnon are now separate from
+  C++ coroutine patterns in Keystone, requiring careful interface design at the boundary.
+
+### Neutral
+
+- Related ADR-015 (C++ agent extraction) remains valid and unchanged.
+- NATS subject schema remains owned and documented in Keystone; Agamemnon consumes it.
+
+## Validation
+
+### Checklist
+
+- ✅ All Python modules moved to `agamemnon.orchestration`
+- ✅ Keystone's `pyproject.toml` updated to remove orchestration dependencies
+- ✅ Agamemnon's `pyproject.toml` updated to include orchestration dependencies
+- ✅ NATS subject schema documentation retained in Keystone
+- ✅ Import paths updated in Agamemnon's orchestration code
+- ✅ Python tests migrated to Agamemnon
+- ✅ CI/CD pipelines updated to test each repository independently
+- ✅ CLAUDE.md updated to reflect Python extraction
+
+## References
+
+- ADR-015: Agent Layer Extraction to ProjectAgamemnon
+- HomericIntelligence/Odysseus#143: Move Python orchestration layer from Keystone to ProjectAgamemnon
+- HomericIntelligence/ProjectKeystone: NATS Subject Schema (owner: Keystone)
+- HomericIntelligence/ProjectAgamemnon: agamemnon.orchestration package
+
+---
+
+**Last Updated**: 2026-04-25
+**Version**: 1.0
+**Project**: ProjectKeystone
+**Status**: Accepted (2026-04-25)

--- a/docs/plan/build-system.md
+++ b/docs/plan/build-system.md
@@ -2,76 +2,107 @@
 
 ## Overview
 
-ProjectKeystone uses CMake 3.28+ with C++20 module support to manage compilation, dependencies, and multi-platform builds. This document outlines the build configuration, toolchain requirements, and development workflows.
+ProjectKeystone uses **CMake 3.20+** with **Conan 2** for dependency management and **CMakePresets.json** (v8) for preset-based builds. Traditional C++ headers are used (not C++20 modules). This document outlines the build configuration, toolchain requirements, and development workflows.
+
+See also: `/CLAUDE.md` for project scope and architecture.
+
+---
 
 ## Toolchain Requirements
 
 ### Compiler Support
 
-| Compiler | Minimum Version | C++20 Modules | Coroutines | Recommended |
-|----------|----------------|---------------|------------|-------------|
-| **GCC** | 13.0 | ✅ Full | ✅ Full | 13.2+ |
-| **Clang** | 16.0 | ✅ Full | ✅ Full | 17.0+ |
-| **MSVC** | 17.5 (VS 2022) | ✅ Full | ✅ Full | 17.8+ |
+| Compiler | Minimum Version | Recommended |
+|----------|----------------|-------------|
+| **GCC** | 11.0 | 13.0+ |
+| **Clang** | 15.0 | 17.0+ |
+| **MSVC** | 17.0 (VS 2022) | 17.8+ |
+
+All compilers must support C++20 (e.g., `std::latch`, `std::barrier`, `std::atomic<T>`).
 
 ### Build Tools
 
-- **CMake**: 3.28 or later (required for module support)
+- **CMake**: 3.20 or later (see CMakePresets section below)
 - **Ninja**: 1.11+ (recommended build system)
 - **Make**: 4.3+ (alternative to Ninja)
+- **Just** (optional): Unified build commands via `justfile`
 
-### Package Managers
+### Package Manager: Conan 2
 
-**Primary Choice: vcpkg** (recommended for C++20 module compatibility)
+ProjectKeystone uses **Conan 2** for C++ dependency management:
 
 ```bash
-# Install vcpkg
-git clone https://github.com/Microsoft/vcpkg.git
-cd vcpkg
-./bootstrap-vcpkg.sh  # Linux/macOS
-# or
-./bootstrap-vcpkg.bat  # Windows
+# Install Conan 2
+pip install conan>=2.0
+
+# Configure profile (one-time)
+conan profile detect --force
+
+# Install dependencies
+conan install . --build=missing
 ```
 
-**Alternative: Conan** (v2.0+)
+**Dependencies** (see `conanfile.py`):
+
+- **nats.c** v3.12.0 — NATS JetStream C client
+- **concurrentqueue** — Lock-free queue (moodycamel)
+- **spdlog** — Structured logging
+- **fmt** — Format library (as spdlog's text formatting backend)
+- **GoogleTest** — Unit testing (dev dependency)
+
+---
 
 ## Project Structure
 
 ```
 ProjectKeystone/
 ├── CMakeLists.txt              # Root CMake configuration
-├── CMakePresets.json           # Build presets
-├── vcpkg.json                  # Dependency manifest
+├── CMakePresets.json           # Build presets (v8 schema)
+├── conanfile.py                # Conan 2 dependency manifest
+├── conanfile.lock              # Locked dependency versions
+├── pixi.toml                   # Pixi environment (optional)
+├── justfile                    # Build command shortcuts (optional)
+├── .clang-format               # Code formatting rules
+├── .clang-tidy                 # Static analysis rules
 ├── cmake/
-│   ├── Keystone.cmake          # Custom CMake functions
-│   ├── CompilerWarnings.cmake  # Warning configurations
-│   └── Sanitizers.cmake        # Sanitizer configurations
-├── modules/
-│   ├── Keystone.Core/
-│   │   ├── CMakeLists.txt
-│   │   ├── Core.cppm           # Module interface
-│   │   └── impl/               # Implementation files
-│   ├── Keystone.Protocol/
-│   ├── Keystone.Agents/
-│   └── Keystone.Integration/
+│   └── FindNATS.cmake          # NATS.c library finder
+├── src/
+│   ├── core/                   # Message routing, KIM protocol
+│   ├── concurrency/            # Thread pools, synchronization
+│   ├── network/                # NATS JetStream integration
+│   ├── transport/              # Transport abstraction
+│   ├── monitoring/             # Logging, metrics, health
+│   ├── simulation/             # Test simulation framework
+│   ├── agents/                 # Minimal agent stubs (tests/examples)
+│   ├── daemon/                 # Keystone daemon process
+│   └── keystone/               # Main library interface
 ├── tests/
 │   ├── CMakeLists.txt
-│   ├── unit/
-│   ├── integration/
-│   └── performance/
+│   ├── unit/                   # Unit tests per component
+│   ├── integration/            # Cross-component integration tests
+│   ├── e2e/                    # End-to-end distributed tests
+│   ├── load/                   # Load and throughput tests
+│   ├── fixtures/               # Shared test fixtures
+│   └── mocks/                  # Mock implementations
+├── docs/
+│   ├── plan/                   # Planning and design docs
+│   ├── api/                    # API documentation
+│   └── architecture/           # Architecture decisions
 ├── examples/
-│   └── CMakeLists.txt
-└── third_party/                # Git submodules if needed
+│   └── *.cpp                   # Example programs
+└── CHANGELOG.md                # Release notes
 ```
+
+---
 
 ## Root CMakeLists.txt
 
 ```cmake
-cmake_minimum_required(VERSION 3.28)
+cmake_minimum_required(VERSION 3.20)
 
 project(ProjectKeystone
-    VERSION 1.0.0
-    DESCRIPTION "High-Performance Hierarchical Multi-Agent System"
+    VERSION 0.1.0
+    DESCRIPTION "Pure Invisible Transport Layer for HomericIntelligence"
     LANGUAGES CXX
 )
 
@@ -80,62 +111,66 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-# Enable C++20 Modules (experimental)
-set(CMAKE_EXPERIMENTAL_CXX_MODULE_CMAKE_API "aa1f7df0-828a-4fcd-9afc-2dc80491aca7")
-set(CMAKE_EXPERIMENTAL_CXX_MODULE_DYNDEP ON)
+# Export compile commands for clang-tidy, clang-format, etc.
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# Compiler warnings (C++ only, to avoid breaking nats.c FetchContent)
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+  add_compile_options(
+    $<$<COMPILE_LANGUAGE:CXX>:-Wall>
+    $<$<COMPILE_LANGUAGE:CXX>:-Wextra>
+    $<$<COMPILE_LANGUAGE:CXX>:-Wpedantic>
+    $<$<COMPILE_LANGUAGE:CXX>:-Werror>
+  )
+endif()
 
 # Build options
-option(KEYSTONE_BUILD_TESTS "Build tests" ON)
-option(KEYSTONE_BUILD_EXAMPLES "Build examples" ON)
-option(KEYSTONE_BUILD_BENCHMARKS "Build benchmarks" ON)
-option(KEYSTONE_ENABLE_ASAN "Enable AddressSanitizer" OFF)
-option(KEYSTONE_ENABLE_TSAN "Enable ThreadSanitizer" OFF)
-option(KEYSTONE_ENABLE_UBSAN "Enable UndefinedBehaviorSanitizer" OFF)
-option(KEYSTONE_ENABLE_LTO "Enable Link-Time Optimization" OFF)
+option(ENABLE_COVERAGE "Enable code coverage instrumentation" OFF)
+option(ENABLE_GRPC "Enable gRPC support for distributed nodes" OFF)
+option(ENABLE_PROFILING "Enable profiling tests (slow)" OFF)
+option(ENABLE_CLANG_TIDY "Enable clang-tidy static analysis" OFF)
 
-# Include custom CMake modules
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
-include(Keystone)
-include(CompilerWarnings)
-include(Sanitizers)
+# Code coverage setup
+if(ENABLE_COVERAGE)
+  if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    add_compile_options(--coverage -fprofile-arcs -ftest-coverage -O0)
+    add_link_options(--coverage)
+  else()
+    message(WARNING "Code coverage only supported with GCC or Clang")
+  endif()
+endif()
 
 # Find dependencies
-find_package(concurrentqueue CONFIG REQUIRED)
-find_package(cista CONFIG REQUIRED)
-find_package(gRPC CONFIG REQUIRED)
-find_package(Protobuf CONFIG REQUIRED)
-find_package(spdlog CONFIG REQUIRED)
+find_package(NATS REQUIRED)
+find_package(concurrentqueue REQUIRED)
+find_package(spdlog REQUIRED)
+find_package(fmt REQUIRED)
 
-# Optional dependencies
-if(KEYSTONE_BUILD_TESTS)
-    find_package(GTest CONFIG REQUIRED)
+# Optional gRPC support
+if(ENABLE_GRPC)
+  find_package(gRPC REQUIRED)
+  find_package(Protobuf REQUIRED)
 endif()
 
-if(KEYSTONE_BUILD_BENCHMARKS)
-    find_package(benchmark CONFIG REQUIRED)
-endif()
+# Testing
+enable_testing()
+find_package(GTest REQUIRED)
 
 # Add subdirectories
-add_subdirectory(modules/Keystone.Core)
-add_subdirectory(modules/Keystone.Protocol)
-add_subdirectory(modules/Keystone.Agents)
-add_subdirectory(modules/Keystone.Integration)
+add_subdirectory(src)
+add_subdirectory(tests)
+add_subdirectory(examples)
 
-if(KEYSTONE_BUILD_TESTS)
-    enable_testing()
-    add_subdirectory(tests)
-endif()
-
-if(KEYSTONE_BUILD_EXAMPLES)
-    add_subdirectory(examples)
-endif()
-
-# Installation rules
+# Installation
 include(GNUInstallDirs)
-install(TARGETS Keystone.Core Keystone.Protocol Keystone.Agents Keystone.Integration
+install(TARGETS keystone_core
     EXPORT KeystoneTargets
-    FILE_SET CXX_MODULES DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
+
+install(DIRECTORY src/keystone/include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 install(EXPORT KeystoneTargets
     FILE KeystoneTargets.cmake
@@ -144,15 +179,18 @@ install(EXPORT KeystoneTargets
 )
 ```
 
+---
+
 ## CMake Presets (CMakePresets.json)
+
+ProjectKeystone uses **CMakePresets.json v8** for preset-based builds with parallel build output directories:
 
 ```json
 {
-    "version": 6,
+    "version": 8,
     "cmakeMinimumRequired": {
         "major": 3,
-        "minor": 28,
-        "patch": 0
+        "minor": 20
     },
     "configurePresets": [
         {
@@ -169,8 +207,7 @@ install(EXPORT KeystoneTargets
             "inherits": "default",
             "displayName": "Debug Build",
             "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Debug",
-                "KEYSTONE_ENABLE_ASAN": "ON"
+                "CMAKE_BUILD_TYPE": "Debug"
             }
         },
         {
@@ -178,25 +215,34 @@ install(EXPORT KeystoneTargets
             "inherits": "default",
             "displayName": "Release Build",
             "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Release",
-                "KEYSTONE_ENABLE_LTO": "ON"
+                "CMAKE_BUILD_TYPE": "Release"
             }
         },
         {
-            "name": "relwithdebinfo",
+            "name": "asan",
             "inherits": "default",
-            "displayName": "Release with Debug Info",
+            "displayName": "Debug + AddressSanitizer",
             "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+                "CMAKE_BUILD_TYPE": "Debug",
+                "CMAKE_CXX_FLAGS": "-fsanitize=address -fno-omit-frame-pointer"
             }
         },
         {
             "name": "tsan",
             "inherits": "default",
-            "displayName": "ThreadSanitizer Build",
+            "displayName": "Debug + ThreadSanitizer",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Debug",
-                "KEYSTONE_ENABLE_TSAN": "ON"
+                "CMAKE_CXX_FLAGS": "-fsanitize=thread -fno-omit-frame-pointer"
+            }
+        },
+        {
+            "name": "ubsan",
+            "inherits": "default",
+            "displayName": "Debug + UBSanitizer",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "CMAKE_CXX_FLAGS": "-fsanitize=undefined -fno-omit-frame-pointer"
             }
         }
     ],
@@ -208,6 +254,14 @@ install(EXPORT KeystoneTargets
         {
             "name": "release",
             "configurePreset": "release"
+        },
+        {
+            "name": "asan",
+            "configurePreset": "asan"
+        },
+        {
+            "name": "tsan",
+            "configurePreset": "tsan"
         }
     ],
     "testPresets": [
@@ -217,248 +271,71 @@ install(EXPORT KeystoneTargets
             "output": {
                 "outputOnFailure": true
             }
+        },
+        {
+            "name": "asan",
+            "configurePreset": "asan",
+            "output": {
+                "outputOnFailure": true
+            }
+        },
+        {
+            "name": "tsan",
+            "configurePreset": "tsan",
+            "output": {
+                "outputOnFailure": true
+            }
         }
     ]
 }
 ```
 
-## Module CMakeLists.txt Example
+**Build Output Structure**:
 
-### Keystone.Core Module
-
-```cmake
-# modules/Keystone.Core/CMakeLists.txt
-
-add_library(Keystone.Core)
-add_library(Keystone::Core ALIAS Keystone.Core)
-
-# Module interface files
-target_sources(Keystone.Core
-    PUBLIC
-        FILE_SET CXX_MODULES FILES
-            Core.cppm
-            Concurrency.cppm
-            Messaging.cppm
-            Synchronization.cppm
-            Utilities.cppm
-)
-
-# Implementation files
-target_sources(Keystone.Core
-    PRIVATE
-        impl/ThreadPool.cpp
-        impl/MessageQueue.cpp
-        impl/Synchronization.cpp
-        impl/Logger.cpp
-        impl/Metrics.cpp
-)
-
-# Include directories for implementation files
-target_include_directories(Keystone.Core
-    PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/impl
-)
-
-# Link dependencies
-target_link_libraries(Keystone.Core
-    PUBLIC
-        concurrentqueue::concurrentqueue
-        spdlog::spdlog
-    PRIVATE
-        Threads::Threads
-)
-
-# Compiler features
-target_compile_features(Keystone.Core PUBLIC cxx_std_20)
-
-# Warnings
-keystone_set_warnings(Keystone.Core)
-
-# Sanitizers
-keystone_enable_sanitizers(Keystone.Core)
+```
+build/
+├── debug/      # Debug build
+├── release/    # Release build
+├── asan/       # AddressSanitizer + UBSanitizer
+├── tsan/       # ThreadSanitizer
+└── ubsan/      # UndefinedBehaviorSanitizer
 ```
 
-## Dependency Management (vcpkg.json)
-
-```json
-{
-    "name": "project-keystone",
-    "version": "1.0.0",
-    "dependencies": [
-        {
-            "name": "concurrentqueue",
-            "version>=": "1.0.4"
-        },
-        {
-            "name": "cista",
-            "version>=": "0.14"
-        },
-        {
-            "name": "grpc",
-            "version>=": "1.54.0"
-        },
-        {
-            "name": "protobuf",
-            "version>=": "3.21.0"
-        },
-        {
-            "name": "spdlog",
-            "version>=": "1.12.0",
-            "features": ["fmt-external"]
-        },
-        {
-            "name": "onnxruntime",
-            "version>=": "1.15.0",
-            "platform": "!uwp"
-        },
-        {
-            "name": "prometheus-cpp",
-            "version>=": "1.1.0"
-        }
-    ],
-    "builtin-baseline": "TBD",
-    "overrides": []
-}
-```
-
-## Custom CMake Modules
-
-### cmake/Keystone.cmake
-
-```cmake
-# Helper functions for Keystone project
-
-function(keystone_add_module MODULE_NAME)
-    add_library(${MODULE_NAME})
-    add_library(Keystone::${MODULE_NAME} ALIAS ${MODULE_NAME})
-
-    target_compile_features(${MODULE_NAME} PUBLIC cxx_std_20)
-
-    # Apply common settings
-    keystone_set_warnings(${MODULE_NAME})
-
-    if(KEYSTONE_ENABLE_LTO)
-        set_property(TARGET ${MODULE_NAME} PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
-    endif()
-endfunction()
-```
-
-### cmake/CompilerWarnings.cmake
-
-```cmake
-function(keystone_set_warnings TARGET_NAME)
-    if(MSVC)
-        target_compile_options(${TARGET_NAME} PRIVATE
-            /W4          # High warning level
-            /WX          # Treat warnings as errors
-            /permissive- # Strict standards compliance
-        )
-    else()
-        target_compile_options(${TARGET_NAME} PRIVATE
-            -Wall
-            -Wextra
-            -Wpedantic
-            -Werror      # Treat warnings as errors
-            -Wconversion
-            -Wsign-conversion
-            -Wnull-dereference
-            -Wdouble-promotion
-            -Wformat=2
-        )
-
-        if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-            target_compile_options(${TARGET_NAME} PRIVATE
-                -Wmost
-                -Wthread-safety
-            )
-        endif()
-    endif()
-endfunction()
-```
-
-### cmake/Sanitizers.cmake
-
-```cmake
-function(keystone_enable_sanitizers TARGET_NAME)
-    if(KEYSTONE_ENABLE_ASAN)
-        target_compile_options(${TARGET_NAME} PRIVATE
-            -fsanitize=address
-            -fno-omit-frame-pointer
-        )
-        target_link_options(${TARGET_NAME} PRIVATE -fsanitize=address)
-    endif()
-
-    if(KEYSTONE_ENABLE_TSAN)
-        target_compile_options(${TARGET_NAME} PRIVATE
-            -fsanitize=thread
-            -fno-omit-frame-pointer
-        )
-        target_link_options(${TARGET_NAME} PRIVATE -fsanitize=thread)
-    endif()
-
-    if(KEYSTONE_ENABLE_UBSAN)
-        target_compile_options(${TARGET_NAME} PRIVATE
-            -fsanitize=undefined
-            -fno-omit-frame-pointer
-        )
-        target_link_options(${TARGET_NAME} PRIVATE -fsanitize=undefined)
-    endif()
-endfunction()
-```
+---
 
 ## Build Workflows
 
 ### Using Justfile (Recommended)
 
-ProjectKeystone uses `just` for unified build commands. All commands run in Docker by default, with native mode available.
+ProjectKeystone uses `just` for unified build commands:
 
 ```bash
 # Show all available commands
-make help
-make help
+just help
 
-# Build with AddressSanitizer (Docker)
-make compile.debug.asan
+# Build with AddressSanitizer
+just build debug.asan
 
 # Build release mode
-make compile.release
+just build release
 
 # Build debug mode
-make compile.debug
+just build debug
 
 # Build with ThreadSanitizer
-make compile.debug.tsan
+just build debug.tsan
 
 # Run all tests
-make test.debug.asan
+just test debug.asan
 
 # Run specific test suites
-make test.basic
-make test.module
-make test.unit
+just test basic
+just test module
+just test unit
 
 # Run linters
-make lint
-make format
-
-# Native mode (run on host instead of Docker)
-make compile.debug.asan.native
-make test.debug.asan.native
-# or
-NATIVE=1 make compile.debug.asan
-```
-
-**Build Directory Structure:**
-
-Justfile uses `build/<mode>/` for parallel builds:
-```
-build/
-├── debug/      # Debug build
-├── release/    # Release build
-├── asan/       # AddressSanitizer + UBSan
-├── tsan/       # ThreadSanitizer
-├── grpc/       # With gRPC support (optional)
-└── coverage/   # With coverage instrumentation
+just lint
+just format
 ```
 
 ### Manual CMake Workflow (without justfile)
@@ -466,6 +343,9 @@ build/
 #### Local Development Build
 
 ```bash
+# Install dependencies
+conan install . --build=missing
+
 # Configure with debug preset
 cmake --preset debug
 
@@ -489,6 +369,20 @@ cmake --build build/release --parallel
 cmake --install build/release --prefix /usr/local
 ```
 
+#### With AddressSanitizer
+
+```bash
+# Configure
+cmake --preset asan
+
+# Build
+cmake --build build/asan --parallel
+
+# Run tests (will detect memory errors)
+cd build/asan
+ctest --output-on-failure
+```
+
 #### With ThreadSanitizer
 
 ```bash
@@ -503,56 +397,57 @@ cd build/tsan
 ctest --output-on-failure
 ```
 
+---
+
+## Code Quality
+
+### clang-format
+
+All C++ code must pass `clang-format` with the project `.clang-format` config:
+
+```bash
+just format        # Format all source files in-place
+just format-check  # Check formatting without modifying (CI gate)
+```
+
+### clang-tidy
+
+Static analysis is enforced via `clang-tidy`:
+
+```bash
+just lint          # Run clang-tidy on all targets
+```
+
+### Sanitizers
+
+| Sanitizer | Purpose | Preset |
+|-----------|---------|--------|
+| **ASan** | Use-after-free, buffer overflows, heap corruption | `asan` |
+| **UBSan** | Undefined behavior (signed overflow, null deref, etc.) | `ubsan` |
+| **TSan** | Data races, lock-order inversions | `tsan` |
+
+Run sanitizer builds before every PR merge:
+
+```bash
+cmake --preset asan && cmake --build --preset asan && ctest --preset asan
+cmake --preset tsan && cmake --build --preset tsan && ctest --preset tsan
+```
+
+---
+
 ## CI/CD Integration
 
-### GitHub Actions Workflow
+GitHub Actions workflows run:
 
-```yaml
-# .github/workflows/build.yml
-name: Build and Test
+1. **Build** with GCC 13 and Clang 17 on Linux
+2. **Test** all tests under sanitizers
+3. **Code coverage** on Linux builds
+4. **Format check** (`just format-check`)
+5. **Static analysis** (`just lint`)
 
-on: [push, pull_request]
+All must pass before PR merge.
 
-jobs:
-  build:
-    strategy:
-      matrix:
-        os: [ubuntu-22.04, windows-2022, macos-13]
-        compiler:
-          - { name: gcc, version: 13 }
-          - { name: clang, version: 17 }
-          - { name: msvc, version: latest }
-        exclude:
-          - os: windows-2022
-            compiler: { name: gcc }
-          - os: ubuntu-22.04
-            compiler: { name: msvc }
-          - os: macos-13
-            compiler: { name: msvc }
-
-    runs-on: ${{ matrix.os }}
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install vcpkg
-        uses: lukka/run-vcpkg@v11
-        with:
-          vcpkgGitCommitId: 'latest'
-
-      - name: Configure CMake
-        run: cmake --preset debug
-
-      - name: Build
-        run: cmake --build build/debug --parallel
-
-      - name: Test
-        run: ctest --preset default
-
-      - name: Upload coverage
-        if: matrix.os == 'ubuntu-22.04'
-        uses: codecov/codecov-action@v3
-```
+---
 
 ## Platform-Specific Considerations
 
@@ -567,88 +462,86 @@ sudo apt-get install -y \
     ninja-build \
     gcc-13 \
     g++-13 \
-    git
+    git \
+    python3-pip
+
+# Install Conan
+pip3 install conan
 
 # Set default compiler
 export CC=gcc-13
 export CXX=g++-13
+
+# Build
+conan install . --build=missing
+cmake --preset debug
+cmake --build build/debug
 ```
 
 ### macOS
 
 ```bash
 # Install via Homebrew
-brew install cmake ninja llvm@17
+brew install cmake ninja llvm@17 python3
+
+# Install Conan
+pip3 install conan
 
 # Use LLVM toolchain
 export CC=/usr/local/opt/llvm@17/bin/clang
 export CXX=/usr/local/opt/llvm@17/bin/clang++
+
+# Build
+conan install . --build=missing
+cmake --preset debug
+cmake --build build/debug
 ```
 
 ### Windows
 
 ```powershell
 # Install Visual Studio 2022 with C++ workload
-# Install CMake and Ninja via Visual Studio installer
+# Install CMake and Ninja via Visual Studio installer or winget
+# Install Python from python.org
+
+# Install Conan
+pip install conan
 
 # Use Developer Command Prompt
+conan install . --build=missing
 cmake --preset debug
 cmake --build build/debug
 ```
 
-## Performance Optimization Flags
-
-### GCC/Clang Release Flags
-
-```cmake
-if(CMAKE_BUILD_TYPE STREQUAL "Release")
-    target_compile_options(${TARGET_NAME} PRIVATE
-        -O3                    # Maximum optimization
-        -march=native          # CPU-specific optimizations
-        -flto                  # Link-time optimization
-        -ffast-math            # Fast floating-point math
-        -funroll-loops         # Loop unrolling
-    )
-endif()
-```
-
-### MSVC Release Flags
-
-```cmake
-if(MSVC AND CMAKE_BUILD_TYPE STREQUAL "Release")
-    target_compile_options(${TARGET_NAME} PRIVATE
-        /O2                    # Maximum optimization
-        /GL                    # Whole program optimization
-        /arch:AVX2             # AVX2 instructions
-    )
-    target_link_options(${TARGET_NAME} PRIVATE
-        /LTCG                  # Link-time code generation
-    )
-endif()
-```
+---
 
 ## Troubleshooting
 
-### Module Build Issues
+### CMake Not Found
 
-**Problem**: "C++20 modules not supported"
-**Solution**: Upgrade CMake to 3.28+ and compiler to minimum version
+**Problem**: `cmake: command not found`
 
-**Problem**: Module dependency errors
-**Solution**: Clean build directory: `rm -rf build && cmake --preset debug`
+**Solution**: Install CMake 3.20+ or use package manager (apt, brew, choco)
 
-**Problem**: Slow module compilation
-**Solution**: Use Ninja instead of Make: `-G Ninja`
+### Conan Dependencies Not Found
 
-### Dependency Issues
+**Problem**: `find_package(nats.c) not found`
 
-**Problem**: vcpkg packages not found
-**Solution**: Specify vcpkg toolchain: `-DCMAKE_TOOLCHAIN_FILE=/path/to/vcpkg/scripts/buildsystems/vcpkg.cmake`
+**Solution**: Run `conan install . --build=missing` before cmake
 
-**Problem**: Version conflicts
-**Solution**: Update `vcpkg.json` baseline and run `vcpkg update`
+### Ninja Build Failures
+
+**Problem**: Build errors with Ninja
+
+**Solution**: Try Make instead: `cmake --preset debug -G "Unix Makefiles"`
+
+### Compiler Not Supporting C++20
+
+**Problem**: "C++20 not supported" error
+
+**Solution**: Upgrade compiler to minimum versions (GCC 11, Clang 15, MSVC 17)
 
 ---
 
-**Document Version**: 1.0
-**Last Updated**: 2025-11-17
+**Document Version**: 2.0 (Pure Transport — Conan 2 + CMakePresets)
+**Last Updated**: 2026-04-25

--- a/docs/plan/modules.md
+++ b/docs/plan/modules.md
@@ -1,35 +1,240 @@
-# ProjectKeystone Module Structure
+# ProjectKeystone Component Architecture
 
 ## Overview
 
-ProjectKeystone uses C++20 Modules instead of traditional header files for better compile times, stronger encapsulation, and clearer architectural boundaries. The system is organized into four primary modules, each with well-defined responsibilities and minimal coupling.
+ProjectKeystone is a **pure invisible transport layer** for HomericIntelligence. It provides transparent, zero-configuration message routing using two complementary transports:
 
-## Why C++20 Modules?
+1. **Local Transport** (intra-host): BlazingMQ + lock-free concurrent queue via `concurrentqueue`
+2. **Cross-Host Transport** (via Tailscale mesh): NATS JetStream v3.12.0
 
-### Advantages Over Headers
+The two transports are automatically bridged via the **Transparent Bridge** — components publish and subscribe to logical NATS subjects without awareness of whether peers are local or remote.
 
-1. **Faster Compilation**: Modules are compiled once and reused (no repeated parsing)
-2. **Better Encapsulation**: Private implementation details truly hidden
-3. **No Include Order Issues**: Modules are order-independent
-4. **Reduced Build Times**: 40-60% faster builds in typical scenarios
-5. **Explicit Dependencies**: Clear module interface vs implementation
+> **Note**: The 4-layer HMAS agent hierarchy (ChiefArchitectAgent → ComponentLeadAgent → ModuleLeadAgent → TaskAgent) was extracted and moved to **ProjectAgamemnon** per ADR-006/ADR-015. Keystone retains only transport primitives.
 
-### Toolchain Requirements
+---
 
-- **GCC**: 13.0 or later
-- **Clang**: 16.0 or later
-- **MSVC**: Visual Studio 2022 17.5 or later
-- **CMake**: 3.28 or later
+## Source Layout
 
-## Module Hierarchy
+ProjectKeystone is organized by transport and infrastructure concerns:
 
 ```
-Keystone (namespace)
-├── Keystone.Core              # Foundation infrastructure
-├── Keystone.Protocol          # Communication protocols
-├── Keystone.Agents            # Agent implementations
-└── Keystone.Integration       # External integrations
+src/
+├── core/               # Message routing, KIM protocol, transport bridge
+├── concurrency/        # Thread pools, synchronization primitives
+├── network/            # NATS JetStream client integration
+├── transport/          # Transport abstraction (local/remote)
+├── monitoring/         # Logging, metrics, health checks
+├── simulation/         # Test simulation framework
+├── agents/             # Minimal agent stubs (for tests/examples)
+├── daemon/             # Keystone daemon process
+└── keystone/           # Primary library interface
 ```
+
+## Core Components
+
+### 1. Message Bus (`src/core/`)
+
+The **MessageBus** is the central coordination layer:
+
+- Routes KIM (Keystone Interchange Message) protocol messages
+- Enforces backpressure on local queues
+- Delegates to **Transparent Bridge** for off-host routing
+- Target: **<500 ns local routing latency**, **>2 M msg/sec throughput**
+
+**Key Classes**:
+
+- `MessageBus` — Central message coordinator
+- `KIM` — Keystone Interchange Message structure
+- `Router` — Routing logic for local/remote destinations
+
+### 2. Concurrency Utilities (`src/concurrency/`)
+
+Thread-safe building blocks for high-performance message handling:
+
+- **ThreadPool** — Fixed-size worker threads
+- **Synchronization primitives** — Barriers, latches, atomic state
+- **Lock-free queuing** — Via `concurrentqueue` library
+
+### 3. Network / NATS Integration (`src/network/`)
+
+NATS JetStream client integration:
+
+- Durable consumer streams (per myrmidon / consumer)
+- Pull-based, rate-limited delivery (`MaxAckPending=1`)
+- Automatic reconnection and message deduplication
+- Subject-based routing to `hi.*` streams
+
+**Managed Streams**:
+
+| Stream | Subject | Consumer Type |
+|--------|---------|---------------|
+| `homeric-research` | `hi.research.>` | PULL |
+| `homeric-myrmidon` | `hi.myrmidon.{type}.>` | PULL |
+| `homeric-pipeline` | `hi.pipeline.>` | PUB/SUB |
+| `homeric-agents` | `hi.agents.>` | PUB/SUB |
+| `homeric-tasks` | `hi.tasks.>` | PUB/SUB |
+| `homeric-logs` | `hi.logs.>` | PUB |
+
+### 4. Transparent Bridge
+
+Automatically promotes messages between local MessageBus and NATS JetStream:
+
+```
+Publisher (local)
+    ↓
+MessageBus.route(msg)
+    ↓
+    ├─ local destination → deliver via concurrentqueue
+    │
+    └─ remote destination → publish to NATS subject
+```
+
+Consumer receives identically whether peer is local or remote.
+
+### 5. Monitoring (`src/monitoring/`)
+
+Logging, metrics, and health checks:
+
+- **Logger** — spdlog-based structured logging
+- **Metrics** — Performance counters and histograms
+- **Health checks** — Agent and transport readiness probes
+
+### 6. Simulation Framework (`src/simulation/`)
+
+Test harness for deterministic testing:
+
+- Virtual time control
+- Fault injection (network delays, message drops)
+- Deterministic scheduling
+
+### 7. Agents Module (`src/agents/`)
+
+Minimal agent implementations for testing and examples. **Note**: Real agent implementations (ChiefArchitectAgent, etc.) are in **ProjectAgamemnon**.
+
+---
+
+## Transport Decision Flow
+
+```
+Publisher calls:
+    MessageBus::publish(message, destination_subject)
+                            ↓
+                Does destination_subject route locally?
+                    ├─ YES → deliver via lock-free queue
+                    └─ NO → publish to NATS subject
+                              ↓
+                          Remote NATS broker
+                              ↓
+                          Remote MessageBus receives
+                              ↓
+                          Local delivery on remote host
+```
+
+No component needs to know whether a peer is local or remote. The bridge handles routing transparently.
+
+---
+
+## Message Flow Example
+
+**Scenario**: Local publisher → remote subscriber (off-host)
+
+1. Publisher calls: `bus.publish(msg, "hi.agents.commander-1")`
+2. MessageBus routes to **Transparent Bridge**
+3. Bridge promotes message to NATS: `publish("hi.agents.commander-1", msg_bytes)`
+4. NATS broker stores in `homeric-agents` stream
+5. Remote host's MessageBus pulls from stream via durable consumer
+6. Remote subscriber receives via lock-free queue
+7. Subscriber sends ACK back to NATS
+8. Message removed from stream after durable consumer ACK
+
+---
+
+## Backpressure and Flow Control
+
+Keystone enforces pull-based, rate-limited delivery:
+
+- `MaxAckPending = 1` per consumer (one in-flight message per myrmidon)
+- Each consumer calls `natsSubscription_Fetch(batch=1)` — explicit pull
+- Slow consumers don't block publishers
+- Messages accumulate in NATS stream until consumer is ready
+- No drop, no loss — durable delivery guaranteed
+
+---
+
+## Key Dependencies
+
+| Dependency | Version | Purpose |
+|------------|---------|---------|
+| **BlazingMQ** | latest | Local durable queue (optional, can use in-memory queue) |
+| **concurrentqueue** | latest | Lock-free intra-host message queue |
+| **nats.c** | 3.12.0 | NATS JetStream C client |
+| **spdlog** | latest | Structured logging |
+| **CMake** | 3.20+ | Build system |
+
+---
+
+## Build Configuration
+
+ProjectKeystone uses **CMake 3.20+** with traditional C++ header-based organization (not C++20 modules):
+
+```cmake
+cmake_minimum_required(VERSION 3.20)
+project(ProjectKeystone CXX)
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_STANDARD_EXTENSIONS OFF)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+```
+
+**Target Library**: `keystone_core` — the main transport library
+
+**Optional Features**:
+
+- `ENABLE_GRPC` — Distributed multi-node gRPC support (Phase 8)
+- `ENABLE_COVERAGE` — Code coverage instrumentation
+- `ENABLE_PROFILING` — Profiling test suite
+- `ENABLE_CLANG_TIDY` — Static analysis
+
+---
+
+## What Was Moved to ProjectAgamemnon
+
+The following **are NOT part of Keystone** — they live in ProjectAgamemnon:
+
+- L0 **ChiefArchitectAgent** (system coordinator)
+- L1 **ComponentLeadAgent** (component lifecycle)
+- L2 **ModuleLeadAgent** (module orchestration)
+- L3 **TaskAgent** (task execution)
+- Delegation and escalation logic
+- Work-stealing scheduler
+- HMAS 4-layer hierarchy
+
+Keystone's only concern: **moving bytes from publisher to subscriber, reliably and transparently**.
+
+---
+
+## Concurrency Model
+
+- **ThreadPool** — Fixed-size worker threads for I/O and message handling
+- **Lock-free queuing** — `concurrentqueue` for intra-thread message passing
+- **C++20 synchronization** — `std::latch`, `std::barrier`, `std::atomic<T>`
+- **No coroutines** (in transport layer) — synchronous messaging primitives
+
+---
+
+## Design Principles
+
+1. **Invisible Transport**: Components never address Keystone directly — they publish to NATS subjects
+2. **Transparent Bridging**: Local MessageBus and NATS seamlessly bridge — no component awareness needed
+3. **Pull-Based, Rate-Limited**: Myrmidons pull at their own pace; Keystone never overloads
+4. **Durable Delivery**: NATS JetStream ensures at-least-once; consumer ACKs track progress
+5. **C++20 Only**: Pure C++20 with BlazingMQ and nats.c — no Python, gRPC middleware, or agents
+6. **Tailscale Required**: All cross-host NATS traffic runs via WireGuard mesh (`tail8906b5.ts.net`)
+
+---
+
+**Document Version**: 2.0 (Pure Transport — HMAS moved to ProjectAgamemnon)
+**Last Updated**: 2026-04-25
 
 ---
 


### PR DESCRIPTION
Closes #433
Closes #366

Updates CLAUDE.md to document Python orchestration extraction to ProjectAgamemnon (ADR-015/ADR-016), updates modules.md and build-system.md to reflect pure transport scope.