### PR TITLE
chore(deps): pin googleapis/release-please-action to SHA

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: Run release-please
         id: release
-        uses: googleapis/release-please-action@v5
+        uses: googleapis/release-please-action@0dfd8538845b8e92600d271a895a5372865d4062 # v5.0.0
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
Pins the release-please-action to a specific commit SHA for supply-chain security, following the pattern used by other workflows in the repository.

Closes #368