### PR TITLE
chore(deps): add softprops/action-gh-release to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,10 @@ updates:
         patterns:
           - "*"
 
+    # Explicitly track critical actions
+    allow:
+      - dependency-name: "softprops/action-gh-release"
+
     # Limit concurrent PRs
     open-pull-requests-limit: 3
 


### PR DESCRIPTION
Explicitly tracks the `softprops/action-gh-release` action in Dependabot so automated version-bump PRs are generated when new releases are published.

Closes #369