### PR TITLE
ci: bundle ci.yml improvements (sccache pin, cache monitoring, conan.lock, CLAUDE.md sync, composite action)

### DIFF
--- a/.github/actions/install-build-deps/action.yml
+++ b/.github/actions/install-build-deps/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: Install Conan 2 and detect compiler profile
     required: false
     default: 'true'
+  cache-conan:
+    description: Cache ~/.conan2 using actions/cache
+    required: false
+    default: 'false'
 
 runs:
   using: composite
@@ -45,6 +49,15 @@ runs:
         pip install conan
         conan profile detect --force
       shell: bash
+
+    - name: Cache Conan packages
+      if: inputs.cache-conan == 'true'
+      uses: actions/cache@v5
+      with:
+        path: ~/.conan2
+        key: conan-${{ runner.os }}-${{ hashFiles('conanfile.py') }}
+        restore-keys: |
+          conan-${{ runner.os }}-
 
     - name: Install coverage tools
       if: inputs.include-coverage == 'true'

--- a/.github/workflows/profiling-weekly.yml
+++ b/.github/workflows/profiling-weekly.yml
@@ -34,7 +34,7 @@ jobs:
             fetchcontent-profiling-${{ runner.os }}-
 
       - name: Set up sccache
-        uses: mozilla-actions/sccache-action@v0.0.10
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696  # v0.0.10
 
       - name: Configure sccache
         run: echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV

--- a/conan.lock
+++ b/conan.lock
@@ -1,0 +1,18 @@
+{
+    "version": "0.5",
+    "requires": [
+        "zlib/1.3.1#cac0f6daea041b0ccf42934163defb20%1765284699.337",
+        "spdlog/1.12.0#492ea1d5dce6a5a4c985c3f36db8b354%1767604746.066",
+        "openssl/3.6.2#36f92686a9285adfe2ccd1c1dbf9ea35%1775635547.022",
+        "gtest/1.14.0#f8f0757a574a8dd747d16af62d6eb1b7%1743410807.169",
+        "fmt/10.2.1#658771bb858b77f380be2ebb22c338e9%1735899167.615",
+        "concurrentqueue/1.0.4#1e48e1c712bcfd892087c9c622a51502%1687274728.048",
+        "cnats/3.9.3#95ae1a5cfd65fd182a9e93d4f9f42553%1762325186.055",
+        "benchmark/1.8.3#1a2ce62c99e2b3feaa57b1f0c15a8c46%1724323740.181"
+    ],
+    "build_requires": [
+        "cmake/3.31.11#f325c933f618a1fcebc1e1c0babfd1ba%1769622857.944"
+    ],
+    "python_requires": [],
+    "config_requires": []
+}

--- a/justfile
+++ b/justfile
@@ -78,6 +78,25 @@ typecheck:
     mypy conanfile.py
 
 
+# Check that the tests/ directory structure matches what is documented in CLAUDE.md
+check-docs-tree:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    ACTUAL=$(find tests/ -maxdepth 1 -mindepth 1 -type d | sed 's|tests/||' | sort)
+    DOCUMENTED=$(grep -A20 'Test Structure' CLAUDE.md | grep '├──\|└──' | sed 's/.*── //;s|/.*||' | sort)
+    DIFF=$(diff <(echo "$DOCUMENTED") <(echo "$ACTUAL") || true)
+    if [ -n "$DIFF" ]; then
+        echo "CLAUDE.md 'Test Structure' block is out of sync with actual tests/ subdirectories."
+        echo "Diff (documented vs actual):"
+        echo "$DIFF"
+        exit 1
+    fi
+    echo "CLAUDE.md Test Structure block matches actual tests/ layout."
+
+# Regenerate conan.lock from conanfile.py
+update-conan-lock:
+    conan lock create conanfile.py --lockfile-out conan.lock
+
 clean:
   make clean
 


### PR DESCRIPTION
## Summary

- **#350**: Pin `mozilla-actions/sccache-action` to commit SHA `9e7fa8a12102821edf02ca5dbea1acd0f89a2696` (v0.0.10) in `ci.yml`, `build-and-test.yml`, and `profiling-weekly.yml` to prevent supply-chain attacks via mutable tags
- **#353**: Add `cache-conan` input to `.github/actions/install-build-deps/action.yml` composite action; remove 3 duplicate `actions/cache@v5` Conan steps from `ci.yml` and 1 from `build-and-test.yml`, replacing them with `cache-conan: 'true'`
- **#351**: Add "Monitor GitHub cache usage" step to the `summary` job that queries the GH Cache API and emits `::warning::` when usage exceeds 7 GB
- **#247**: Add `conan lock create` check step to the `quality` job in `ci.yml`; commit initial `conan.lock`; add `just update-conan-lock` target to `justfile`
- **#232**: Add `just check-docs-tree` justfile target that diffs `find tests/ -maxdepth 1 -type d` against the CLAUDE.md Test Structure block; wire it into the `quality` job

## Test plan

- [ ] CI run on this PR passes the `quality` job (formatting, docs-tree, conan-lock checks)
- [ ] Verify `sccache-action` references use the SHA not the floating tag
- [ ] Verify no duplicate `Cache Conan packages` steps exist in workflow jobs
- [ ] Verify `summary` job emits cache usage line in logs
- [ ] Verify `conan.lock` is present at repo root

Closes #350
Closes #351
Closes #232
Closes #247
Closes #353

🤖 Generated with [Claude Code](https://claude.com/claude-code)