### PR TITLE
fix(deps): use build_folder_vars in tsan profile to prevent CMakeUserPresets re-inclusion

### DIFF
--- a/conan/profiles/tsan
+++ b/conan/profiles/tsan
@@ -12,3 +12,9 @@ tools.build:cxxflags=["-fsanitize=thread", "-fno-omit-frame-pointer"]
 tools.build:cflags=["-fsanitize=thread", "-fno-omit-frame-pointer"]
 tools.build:sharedlinkflags=["-fsanitize=thread"]
 tools.build:exelinkflags=["-fsanitize=thread"]
+# Give this profile a unique build-folder discriminator so Conan generates a
+# preset named "conan-debug-tsan" instead of "conan-debug", preventing a
+# duplicate-preset collision with the plain debug profile in
+# CMakeUserPresets.json (see issue #324).
+user.keystone.sanitizer=tsan
+tools.cmake.cmake_layout:build_folder_vars=["settings.build_type", "user.keystone.sanitizer"]

--- a/justfile
+++ b/justfile
@@ -9,16 +9,17 @@ build:
 test:
   make test NATIVE=1
 
-# Install Conan dependencies (tsan profile)
-# Removes the Conan-generated CMakePresets.json from the tsan output folder to prevent
-# a duplicate "conan-debug" preset collision with the debug build in CMakeUserPresets.json.
+# Install Conan dependencies (tsan profile).
+# The tsan Conan profile sets user.keystone.sanitizer=tsan and
+# tools.cmake.cmake_layout:build_folder_vars so Conan names its generated
+# preset "conan-debug-tsan" rather than "conan-debug", preventing a
+# duplicate-preset collision with the plain debug build in CMakeUserPresets.json
+# regardless of whether conan install is invoked via just or directly.
 deps-tsan:
     conan install . \
         --output-folder=build/tsan \
         --profile=conan/profiles/tsan \
         --build=missing
-    rm -f build/tsan/CMakePresets.json
-    python3 scripts/remove-preset-include.py CMakeUserPresets.json build/tsan/CMakePresets.json
 
 # Build with ThreadSanitizer
 build-tsan: deps-tsan


### PR DESCRIPTION
## Summary

- Adds `user.keystone.sanitizer=tsan` and `tools.cmake.cmake_layout:build_folder_vars=["settings.build_type", "user.keystone.sanitizer"]` to `conan/profiles/tsan` so Conan generates preset name `conan-debug-tsan` instead of `conan-debug`, eliminating the duplicate-preset collision with the plain debug build in `CMakeUserPresets.json`.
- This fix is idempotent and holds even when `conan install` is run directly (bypassing `just`), addressing the root cause described in #324.
- Removes the now-unnecessary post-install cleanup steps (`rm -f build/tsan/CMakePresets.json` and `python3 scripts/remove-preset-include.py ...`) from the `deps-tsan` justfile recipe.

## Test plan

- [ ] Run `conan install . --output-folder=build/tsan --profile=conan/profiles/tsan --build=missing` directly and verify `CMakeUserPresets.json` contains `conan-debug-tsan` (not `conan-debug`).
- [ ] Run `just deps-tsan` and verify no collision with a pre-existing debug build.
- [ ] Run `just build-tsan` to confirm the TSan build completes successfully.
- [ ] Run `just format-check` — passes.

Closes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)