### PR TITLE
fix(concurrency): drain queue by design before shutdown signals worker exit

### DIFF
--- a/include/concurrency/thread_pool.hpp
+++ b/include/concurrency/thread_pool.hpp
@@ -127,6 +127,7 @@ class ThreadPool {
   std::queue<WorkItem> work_queue_;
   std::mutex queue_mutex_;
   std::condition_variable condition_;
+  std::condition_variable drain_cv_;
   std::atomic<bool> shutdown_requested_{false};
 };
 

--- a/src/concurrency/thread_pool.cpp
+++ b/src/concurrency/thread_pool.cpp
@@ -54,7 +54,18 @@ void ThreadPool::shutdown() {
     shutdown_requested_.store(true);
   }
 
-  // Wake up all threads
+  // Wake workers so they process remaining items (drain phase).
+  condition_.notify_all();
+
+  // Explicitly wait for the queue to drain before signalling workers to exit.
+  // This makes the "all pending work completes before shutdown" guarantee
+  // explicit and by-design, not merely incidental.
+  {
+    std::unique_lock<std::mutex> lock(queue_mutex_);
+    drain_cv_.wait(lock, [this]() { return work_queue_.empty(); });
+  }
+
+  // Queue is now empty — wake all workers so they see the exit condition.
   condition_.notify_all();
 
   // Join all worker threads
@@ -89,6 +100,11 @@ void ThreadPool::worker_loop() {
         work_queue_.pop();
       } else {
         continue;  // Spurious wakeup
+      }
+
+      // Notify drain waiters when the queue becomes empty after dequeueing.
+      if (work_queue_.empty()) {
+        drain_cv_.notify_all();
       }
     }
 

--- a/tests/unit/test_thread_pool.cpp
+++ b/tests/unit/test_thread_pool.cpp
@@ -202,6 +202,25 @@ TEST(ThreadPoolTest, ConcurrentSubmissions) {
   EXPECT_EQ(counter.load(), 100);
 }
 
+// Test: GracefulShutdown drains queue by design, not incidentally.
+// Submits bursts of work and then calls shutdown() immediately; all submitted
+// work must be counted even though shutdown() races with the workers.
+TEST(ThreadPoolTest, GracefulShutdownDrainsQueueExplicitly) {
+  ThreadPool pool(4);
+  std::atomic<int> counter{0};
+
+  // Submit a burst of short-lived tasks before calling shutdown().
+  for (int32_t i = 0; i < 20; ++i) {
+    pool.submit([&]() { counter.fetch_add(1); });
+  }
+
+  // shutdown() must not return until every submitted task has executed.
+  pool.shutdown();
+
+  EXPECT_EQ(counter.load(), 20);
+  EXPECT_TRUE(pool.is_shutting_down());
+}
+
 // Test: Destructor calls shutdown
 TEST(ThreadPoolTest, DestructorShutdown) {
   std::atomic<int> counter{0};


### PR DESCRIPTION
## Summary

- Add `drain_cv_` condition variable to `ThreadPool` so `shutdown()` explicitly waits for the work queue to empty before waking workers to exit.
- Workers notify `drain_cv_` (under the queue lock) immediately after dequeueing the last item, making the drain observable without any polling.
- Add `GracefulShutdownDrainsQueueExplicitly` test that submits 20 tasks then calls `shutdown()` immediately — asserts all 20 complete with no `sleep_for` reliance.

**Root cause (issue #322):** The previous `shutdown()` set `shutdown_requested_` first and relied on the worker exit-condition check (`work_queue_.empty()`) to drain remaining items. This was correct but incidental — if the exit condition were ever changed, the drain guarantee would silently vanish. The fix promotes the guarantee to an explicit, observable drain phase.

## Test plan

- [ ] `GracefulShutdownDrainsQueueExplicitly` passes (new test)
- [ ] `GracefulShutdown` continues to pass (existing test)
- [ ] `DestructorShutdown` continues to pass (existing test)
- [ ] `NoWorkAfterShutdown` continues to pass (existing test)
- [ ] Format check: `just format-check`

Closes #322.

🤖 Generated with [Claude Code](https://claude.com/claude-code)