### PR TITLE
refactor(benchmarks): convert unsized integer types to explicit-width types

### DIFF
--- a/benchmarks/distributed_work_stealing.cpp
+++ b/benchmarks/distributed_work_stealing.cpp
@@ -2,6 +2,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <cstdint>
 #include <thread>
 #include <vector>
 
@@ -25,8 +26,8 @@ static void BM_WorkStealing_LocalOnly(benchmark::State& state) {
     for (size_t i = 0; i < num_tasks; ++i) {
       cluster.submitToNode(0, [&completed]() {
         // Simulate work
-        volatile int sum = 0;
-        for (int j = 0; j < 100; ++j) {
+        volatile int32_t sum = 0;
+        for (int32_t j = 0; j < 100; ++j) {
           sum += j;
         }
         completed++;
@@ -63,8 +64,8 @@ static void BM_WorkStealing_TwoNodes_100us(benchmark::State& state) {
     // Submit tasks to both nodes (round-robin)
     for (size_t i = 0; i < num_tasks; ++i) {
       cluster.submitToNode(i % 2, [&completed]() {
-        volatile int sum = 0;
-        for (int j = 0; j < 100; ++j) {
+        volatile int32_t sum = 0;
+        for (int32_t j = 0; j < 100; ++j) {
           sum += j;
         }
         completed++;
@@ -100,8 +101,8 @@ static void BM_WorkStealing_TwoNodes_500us(benchmark::State& state) {
 
     for (size_t i = 0; i < num_tasks; ++i) {
       cluster.submitToNode(i % 2, [&completed]() {
-        volatile int sum = 0;
-        for (int j = 0; j < 100; ++j) {
+        volatile int32_t sum = 0;
+        for (int32_t j = 0; j < 100; ++j) {
           sum += j;
         }
         completed++;
@@ -136,8 +137,8 @@ static void BM_WorkStealing_TwoNodes_1ms(benchmark::State& state) {
 
     for (size_t i = 0; i < num_tasks; ++i) {
       cluster.submitToNode(i % 2, [&completed]() {
-        volatile int sum = 0;
-        for (int j = 0; j < 100; ++j) {
+        volatile int32_t sum = 0;
+        for (int32_t j = 0; j < 100; ++j) {
           sum += j;
         }
         completed++;
@@ -171,8 +172,8 @@ static void BM_LoadBalancing_Imbalanced(benchmark::State& state) {
     // Submit all tasks to node 0 (creates imbalance)
     for (size_t i = 0; i < num_tasks; ++i) {
       cluster.submitToNode(0, [&completed]() {
-        volatile int sum = 0;
-        for (int j = 0; j < 100; ++j) {
+        volatile int32_t sum = 0;
+        for (int32_t j = 0; j < 100; ++j) {
           sum += j;
         }
         completed++;
@@ -266,8 +267,8 @@ static void BM_AgentAffinity_Registered(benchmark::State& state) {
     std::vector<std::string> agents = {"agent_A", "agent_B", "agent_C", "agent_D"};
     for (size_t i = 0; i < num_tasks; ++i) {
       cluster.submit(agents[i % 4], [&completed]() {
-        volatile int sum = 0;
-        for (int j = 0; j < 100; ++j) {
+        volatile int32_t sum = 0;
+        for (int32_t j = 0; j < 100; ++j) {
           sum += j;
         }
         completed++;

--- a/benchmarks/hierarchy_performance.cpp
+++ b/benchmarks/hierarchy_performance.cpp
@@ -20,6 +20,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <cstdint>
 #include <memory>
 #include <thread>
 #include <vector>
@@ -84,7 +85,7 @@ static void BM_4LayerHierarchy_MessageFlow(benchmark::State& state) {
   module2->setMessageBus(&bus);
 
   std::vector<std::shared_ptr<TaskAgent>> tasks;
-  for (int i = 1; i <= 6; ++i) {
+  for (int32_t i = 1; i <= 6; ++i) {
     auto task = std::make_shared<TaskAgent>("task" + std::to_string(i));
     bus.registerAgent(task->getAgentId(), task);
     task->setMessageBus(&bus);
@@ -107,20 +108,20 @@ BENCHMARK(BM_4LayerHierarchy_MessageFlow);
 
 // Benchmark: Task Agent Registry Lookup Scalability
 static void BM_TaskAgent_RegistryLookup(benchmark::State& state) {
-  int num_agents = state.range(0);
+  int32_t num_agents = static_cast<int32_t>(state.range(0));
 
   MessageBus bus;
   std::vector<std::shared_ptr<TaskAgent>> agents;
 
   // Register N task agents
-  for (int i = 0; i < num_agents; ++i) {
+  for (int32_t i = 0; i < num_agents; ++i) {
     auto agent = std::make_shared<TaskAgent>("task" + std::to_string(i));
     bus.registerAgent(agent->getAgentId(), agent);
     agents.push_back(agent);
   }
 
   // Benchmark lookup operations
-  int lookup_idx = 0;
+  int32_t lookup_idx = 0;
   for (auto _ : state) {
     std::string agent_id = "task" + std::to_string(lookup_idx % num_agents);
     benchmark::DoNotOptimize(bus.hasAgent(agent_id));
@@ -134,15 +135,15 @@ BENCHMARK(BM_TaskAgent_RegistryLookup)->Range(10, 1000);
 
 // Benchmark: Scheduler Submission Rate (Work-Stealing)
 static void BM_Scheduler_SubmissionRate(benchmark::State& state) {
-  const int num_workers = state.range(0);
+  const int32_t num_workers = static_cast<int32_t>(state.range(0));
 
   WorkStealingScheduler scheduler(num_workers);
   scheduler.start();
 
   // Warmup: get workers ready
-  for (int i = 0; i < num_workers; ++i) {
+  for (int32_t i = 0; i < num_workers; ++i) {
     scheduler.submit([]() {
-      volatile int x = 42;
+      volatile int32_t x = 42;
       (void)x;
     });
   }
@@ -151,8 +152,8 @@ static void BM_Scheduler_SubmissionRate(benchmark::State& state) {
   // Benchmark submission rate
   for (auto _ : state) {
     scheduler.submit([]() {
-      volatile int sum = 0;
-      for (int j = 0; j < 10; ++j) {
+      volatile int32_t sum = 0;
+      for (int32_t j = 0; j < 10; ++j) {
         sum += j;
       }
     });
@@ -189,7 +190,7 @@ BENCHMARK(BM_Agent_MessageProcessing);
 
 // Benchmark: Component Leadership with Multiple Modules
 static void BM_ComponentLead_MultiModule(benchmark::State& state) {
-  const int num_modules = state.range(0);
+  const int32_t num_modules = static_cast<int32_t>(state.range(0));
 
   MessageBus bus;
   auto comp_lead = std::make_shared<ComponentLeadAgent>("comp_lead");
@@ -197,7 +198,7 @@ static void BM_ComponentLead_MultiModule(benchmark::State& state) {
   comp_lead->setMessageBus(&bus);
 
   std::vector<std::shared_ptr<ModuleLeadAgent>> modules;
-  for (int i = 0; i < num_modules; ++i) {
+  for (int32_t i = 0; i < num_modules; ++i) {
     auto module = std::make_shared<ModuleLeadAgent>("module" + std::to_string(i));
     bus.registerAgent(module->getAgentId(), module);
     module->setMessageBus(&bus);
@@ -219,7 +220,7 @@ BENCHMARK(BM_ComponentLead_MultiModule)->Range(2, 16);
 
 // Benchmark: Module Leadership with Multiple Tasks
 static void BM_ModuleLead_MultiTask(benchmark::State& state) {
-  const int num_tasks = state.range(0);
+  const int32_t num_tasks = static_cast<int32_t>(state.range(0));
 
   MessageBus bus;
   auto module = std::make_shared<ModuleLeadAgent>("module");
@@ -227,7 +228,7 @@ static void BM_ModuleLead_MultiTask(benchmark::State& state) {
   module->setMessageBus(&bus);
 
   std::vector<std::shared_ptr<TaskAgent>> tasks;
-  for (int i = 0; i < num_tasks; ++i) {
+  for (int32_t i = 0; i < num_tasks; ++i) {
     auto task = std::make_shared<TaskAgent>("task" + std::to_string(i));
     bus.registerAgent(task->getAgentId(), task);
     task->setMessageBus(&bus);

--- a/benchmarks/message_bus_performance.cpp
+++ b/benchmarks/message_bus_performance.cpp
@@ -14,6 +14,7 @@
 #include "core/message_bus.hpp"
 
 #include <atomic>
+#include <cstdint>
 #include <memory>
 #include <thread>
 #include <vector>
@@ -46,12 +47,12 @@ BENCHMARK(BM_MessageRouting_SingleAgent);
 
 // Benchmark: Routing to many agents (fan-out)
 static void BM_MessageRouting_FanOut(benchmark::State& state) {
-  int num_agents = state.range(0);
+  int32_t num_agents = static_cast<int32_t>(state.range(0));
 
   MessageBus bus;
   std::vector<std::shared_ptr<TaskAgent>> agents;
 
-  for (int i = 0; i < num_agents; ++i) {
+  for (int32_t i = 0; i < num_agents; ++i) {
     auto agent = std::make_shared<TaskAgent>("agent-" + std::to_string(i));
     bus.registerAgent(agent->getAgentId(), agent);
     agent->setMessageBus(&bus);
@@ -89,21 +90,21 @@ BENCHMARK(BM_AgentRegistration);
 
 // Benchmark: Agent unregistration overhead
 static void BM_AgentUnregistration(benchmark::State& state) {
-  int num_agents = 1000;
+  int32_t num_agents = 1000;
 
   for (auto _ : state) {
     state.PauseTiming();
     MessageBus bus;
     std::vector<std::shared_ptr<TaskAgent>> agents;
 
-    for (int i = 0; i < num_agents; ++i) {
+    for (int32_t i = 0; i < num_agents; ++i) {
       auto agent = std::make_shared<TaskAgent>("agent-" + std::to_string(i));
       bus.registerAgent(agent->getAgentId(), agent);
       agents.push_back(agent);
     }
     state.ResumeTiming();
 
-    for (int i = 0; i < num_agents; ++i) {
+    for (int32_t i = 0; i < num_agents; ++i) {
       bus.unregisterAgent("agent-" + std::to_string(i));
     }
   }
@@ -114,12 +115,12 @@ BENCHMARK(BM_AgentUnregistration);
 
 // Benchmark: Agent lookup (hasAgent)
 static void BM_AgentLookup(benchmark::State& state) {
-  int num_agents = state.range(0);
+  int32_t num_agents = static_cast<int32_t>(state.range(0));
 
   MessageBus bus;
   std::vector<std::shared_ptr<TaskAgent>> agents;
 
-  for (int i = 0; i < num_agents; ++i) {
+  for (int32_t i = 0; i < num_agents; ++i) {
     auto agent = std::make_shared<TaskAgent>("agent-" + std::to_string(i));
     bus.registerAgent(agent->getAgentId(), agent);
     agents.push_back(agent);
@@ -138,12 +139,12 @@ BENCHMARK(BM_AgentLookup)->Range(8, 1024);
 
 // Benchmark: List all agents
 static void BM_ListAgents(benchmark::State& state) {
-  int num_agents = state.range(0);
+  int32_t num_agents = static_cast<int32_t>(state.range(0));
 
   MessageBus bus;
   std::vector<std::shared_ptr<TaskAgent>> agents;
 
-  for (int i = 0; i < num_agents; ++i) {
+  for (int32_t i = 0; i < num_agents; ++i) {
     auto agent = std::make_shared<TaskAgent>("agent-" + std::to_string(i));
     bus.registerAgent(agent->getAgentId(), agent);
     agents.push_back(agent);
@@ -179,7 +180,7 @@ BENCHMARK(BM_ConcurrentRouting)->ThreadRange(1, 8);
 
 // Benchmark: Message routing with payload (varying sizes)
 static void BM_MessageRouting_WithPayload(benchmark::State& state) {
-  int payload_size = state.range(0);  // Size in bytes
+  int32_t payload_size = static_cast<int32_t>(state.range(0));  // Size in bytes
 
   MessageBus bus;
   auto agent = std::make_shared<TaskAgent>("test-agent");
@@ -226,12 +227,12 @@ BENCHMARK(BM_MessageRoundTrip);
 
 // Benchmark: Broadcast to multiple agents
 static void BM_MessageBroadcast(benchmark::State& state) {
-  int num_agents = state.range(0);
+  int32_t num_agents = static_cast<int32_t>(state.range(0));
 
   MessageBus bus;
   std::vector<std::shared_ptr<TaskAgent>> agents;
 
-  for (int i = 0; i < num_agents; ++i) {
+  for (int32_t i = 0; i < num_agents; ++i) {
     auto agent = std::make_shared<TaskAgent>("agent-" + std::to_string(i));
     bus.registerAgent(agent->getAgentId(), agent);
     agent->setMessageBus(&bus);
@@ -240,7 +241,7 @@ static void BM_MessageBroadcast(benchmark::State& state) {
 
   for (auto _ : state) {
     // Broadcast: send message to all agents
-    for (int i = 0; i < num_agents; ++i) {
+    for (int32_t i = 0; i < num_agents; ++i) {
       auto msg = KeystoneMessage::create("broadcaster", "agent-" + std::to_string(i), "broadcast");
       bus.routeMessage(msg);
     }

--- a/benchmarks/message_pool_performance.cpp
+++ b/benchmarks/message_pool_performance.cpp
@@ -8,6 +8,8 @@
 #include "core/message.hpp"
 #include "core/message_pool.hpp"
 
+#include <cstdint>
+
 #include <benchmark/benchmark.h>
 
 using namespace keystone::core;
@@ -32,7 +34,7 @@ BENCHMARK(BM_MessageCreation_NoPooing);
  */
 static void BM_MessageCreation_WithPooling(benchmark::State& state) {
   // Warmup pool
-  for (int i = 0; i < 100; ++i) {
+  for (int32_t i = 0; i < 100; ++i) {
     auto msg = MessagePool::acquire();
     MessagePool::release(std::move(msg));
   }
@@ -56,14 +58,14 @@ BENCHMARK(BM_MessageCreation_WithPooling);
  * Burst pattern: Create many messages then destroy them (no pooling)
  */
 static void BM_MessageBurst_NoPooling(benchmark::State& state) {
-  const int burst_size = state.range(0);
+  const int32_t burst_size = static_cast<int32_t>(state.range(0));
 
   for (auto _ : state) {
     std::vector<KeystoneMessage> messages;
-    messages.reserve(burst_size);
+    messages.reserve(static_cast<size_t>(burst_size));
 
     // Create burst
-    for (int i = 0; i < burst_size; ++i) {
+    for (int32_t i = 0; i < burst_size; ++i) {
       messages.push_back(KeystoneMessage::create("sender", "receiver", "cmd"));
     }
 
@@ -78,21 +80,21 @@ BENCHMARK(BM_MessageBurst_NoPooling)->Arg(10)->Arg(100)->Arg(1000);
  * Burst pattern: Acquire many messages then release them (with pooling)
  */
 static void BM_MessageBurst_WithPooling(benchmark::State& state) {
-  const int burst_size = state.range(0);
+  const int32_t burst_size = static_cast<int32_t>(state.range(0));
 
   // Warmup pool
   MessagePool::clear();
-  for (int i = 0; i < burst_size; ++i) {
+  for (int32_t i = 0; i < burst_size; ++i) {
     auto msg = MessagePool::acquire();
     MessagePool::release(std::move(msg));
   }
 
   for (auto _ : state) {
     std::vector<KeystoneMessage> messages;
-    messages.reserve(burst_size);
+    messages.reserve(static_cast<size_t>(burst_size));
 
     // Acquire burst
-    for (int i = 0; i < burst_size; ++i) {
+    for (int32_t i = 0; i < burst_size; ++i) {
       messages.push_back(MessagePool::acquire());
     }
 
@@ -124,7 +126,7 @@ BENCHMARK(BM_SteadyState_NoPooling);
  */
 static void BM_SteadyState_WithPooling(benchmark::State& state) {
   // Warmup
-  for (int i = 0; i < 10; ++i) {
+  for (int32_t i = 0; i < 10; ++i) {
     auto msg = MessagePool::acquire();
     MessagePool::release(std::move(msg));
   }
@@ -147,7 +149,7 @@ BENCHMARK(BM_SteadyState_WithPooling);
  */
 static void BM_PoolStatistics(benchmark::State& state) {
   // Warmup
-  for (int i = 0; i < 100; ++i) {
+  for (int32_t i = 0; i < 100; ++i) {
     auto msg = MessagePool::acquire();
     MessagePool::release(std::move(msg));
   }
@@ -169,7 +171,7 @@ static void BM_PoolHitRate(benchmark::State& state) {
 
   // Build up pool
   std::vector<KeystoneMessage> warmup;
-  for (int i = 0; i < 100; ++i) {
+  for (int32_t i = 0; i < 100; ++i) {
     warmup.push_back(MessagePool::acquire());
   }
   for (auto& msg : warmup) {
@@ -201,7 +203,7 @@ static void BM_ThreadLocalPooling(benchmark::State& state) {
   }
 
   // Warmup per-thread pool
-  for (int i = 0; i < 10; ++i) {
+  for (int32_t i = 0; i < 10; ++i) {
     auto msg = MessagePool::acquire();
     MessagePool::release(std::move(msg));
   }

--- a/benchmarks/profile_allocations.cpp
+++ b/benchmarks/profile_allocations.cpp
@@ -7,19 +7,20 @@
 
 #include "core/message.hpp"
 
+#include <cstdint>
 #include <vector>
 
 using namespace keystone::core;
 
 int main() {
   // Simulate realistic workload for profiling
-  const int num_messages = 10000;
+  const int32_t num_messages = 10000;
 
   std::vector<KeystoneMessage> messages;
-  messages.reserve(num_messages);
+  messages.reserve(static_cast<size_t>(num_messages));
 
   // Create many messages (typical hot path)
-  for (int i = 0; i < num_messages; ++i) {
+  for (int32_t i = 0; i < num_messages; ++i) {
     messages.push_back(
         KeystoneMessage::create("sender-agent-001", "receiver-agent-002", "EXECUTE"));
   }
@@ -28,7 +29,7 @@ int main() {
   messages.clear();
 
   // Test with payloads
-  for (int i = 0; i < num_messages; ++i) {
+  for (int32_t i = 0; i < num_messages; ++i) {
     auto msg = KeystoneMessage::create("sender",
                                        "receiver",
                                        "EXECUTE",

--- a/benchmarks/registry_performance.cpp
+++ b/benchmarks/registry_performance.cpp
@@ -2,6 +2,7 @@
 #include "core/agent_id_interning.hpp"
 #include "core/message_bus.hpp"
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -68,7 +69,7 @@ class IntegerBasedRegistry {
 
 static void BM_RegisterAgent_StringBased(benchmark::State& state) {
   StringBasedRegistry registry;
-  int agent_count = 0;
+  int32_t agent_count = 0;
 
   for (auto _ : state) {
     std::string agent_id = "agent_" + std::to_string(agent_count++);
@@ -82,7 +83,7 @@ BENCHMARK(BM_RegisterAgent_StringBased);
 
 static void BM_RegisterAgent_IntegerBased(benchmark::State& state) {
   IntegerBasedRegistry registry;
-  int agent_count = 0;
+  int32_t agent_count = 0;
 
   for (auto _ : state) {
     std::string agent_id = "agent_" + std::to_string(agent_count++);
@@ -102,13 +103,13 @@ static void BM_LookupAgent_StringBased(benchmark::State& state) {
   StringBasedRegistry registry;
 
   // Pre-register 1000 agents
-  for (int i = 0; i < 1000; ++i) {
+  for (int32_t i = 0; i < 1000; ++i) {
     std::string agent_id = "agent_" + std::to_string(i);
     auto agent = std::make_shared<TaskAgent>(agent_id);
     registry.registerAgent(agent_id, agent);
   }
 
-  int lookup_idx = 0;
+  int32_t lookup_idx = 0;
   for (auto _ : state) {
     std::string agent_id = "agent_" + std::to_string(lookup_idx++ % 1000);
     benchmark::DoNotOptimize(registry.hasAgent(agent_id));
@@ -122,13 +123,13 @@ static void BM_LookupAgent_IntegerBased(benchmark::State& state) {
   IntegerBasedRegistry registry;
 
   // Pre-register 1000 agents
-  for (int i = 0; i < 1000; ++i) {
+  for (int32_t i = 0; i < 1000; ++i) {
     std::string agent_id = "agent_" + std::to_string(i);
     auto agent = std::make_shared<TaskAgent>(agent_id);
     registry.registerAgent(agent_id, agent);
   }
 
-  int lookup_idx = 0;
+  int32_t lookup_idx = 0;
   for (auto _ : state) {
     std::string agent_id = "agent_" + std::to_string(lookup_idx++ % 1000);
     benchmark::DoNotOptimize(registry.hasAgent(agent_id));
@@ -146,13 +147,13 @@ static void BM_GetAgent_StringBased(benchmark::State& state) {
   StringBasedRegistry registry;
 
   // Pre-register 1000 agents
-  for (int i = 0; i < 1000; ++i) {
+  for (int32_t i = 0; i < 1000; ++i) {
     std::string agent_id = "agent_" + std::to_string(i);
     auto agent = std::make_shared<TaskAgent>(agent_id);
     registry.registerAgent(agent_id, agent);
   }
 
-  int lookup_idx = 0;
+  int32_t lookup_idx = 0;
   for (auto _ : state) {
     std::string agent_id = "agent_" + std::to_string(lookup_idx++ % 1000);
     auto agent = registry.getAgent(agent_id);
@@ -167,13 +168,13 @@ static void BM_GetAgent_IntegerBased(benchmark::State& state) {
   IntegerBasedRegistry registry;
 
   // Pre-register 1000 agents
-  for (int i = 0; i < 1000; ++i) {
+  for (int32_t i = 0; i < 1000; ++i) {
     std::string agent_id = "agent_" + std::to_string(i);
     auto agent = std::make_shared<TaskAgent>(agent_id);
     registry.registerAgent(agent_id, agent);
   }
 
-  int lookup_idx = 0;
+  int32_t lookup_idx = 0;
   for (auto _ : state) {
     std::string agent_id = "agent_" + std::to_string(lookup_idx++ % 1000);
     auto agent = registry.getAgent(agent_id);
@@ -192,13 +193,13 @@ static void BM_RouteMessage_MessageBus(benchmark::State& state) {
   MessageBus bus;
 
   // Pre-register 1000 agents
-  for (int i = 0; i < 1000; ++i) {
+  for (int32_t i = 0; i < 1000; ++i) {
     std::string agent_id = "agent_" + std::to_string(i);
     auto agent = std::make_shared<TaskAgent>(agent_id);
     bus.registerAgent(agent_id, agent);
   }
 
-  int msg_idx = 0;
+  int32_t msg_idx = 0;
   for (auto _ : state) {
     std::string receiver_id = "agent_" + std::to_string(msg_idx++ % 1000);
     KeystoneMessage msg = KeystoneMessage::create("sender", receiver_id, "test_command");
@@ -215,16 +216,16 @@ BENCHMARK(BM_RouteMessage_MessageBus);
 
 static void BM_Lookup_Scalability_StringBased(benchmark::State& state) {
   StringBasedRegistry registry;
-  int num_agents = state.range(0);
+  int32_t num_agents = static_cast<int32_t>(state.range(0));
 
   // Pre-register agents
-  for (int i = 0; i < num_agents; ++i) {
+  for (int32_t i = 0; i < num_agents; ++i) {
     std::string agent_id = "agent_" + std::to_string(i);
     auto agent = std::make_shared<TaskAgent>(agent_id);
     registry.registerAgent(agent_id, agent);
   }
 
-  int lookup_idx = 0;
+  int32_t lookup_idx = 0;
   for (auto _ : state) {
     std::string agent_id = "agent_" + std::to_string(lookup_idx++ % num_agents);
     benchmark::DoNotOptimize(registry.hasAgent(agent_id));
@@ -236,16 +237,16 @@ BENCHMARK(BM_Lookup_Scalability_StringBased)->Range(100, 10000);
 
 static void BM_Lookup_Scalability_IntegerBased(benchmark::State& state) {
   IntegerBasedRegistry registry;
-  int num_agents = state.range(0);
+  int32_t num_agents = static_cast<int32_t>(state.range(0));
 
   // Pre-register agents
-  for (int i = 0; i < num_agents; ++i) {
+  for (int32_t i = 0; i < num_agents; ++i) {
     std::string agent_id = "agent_" + std::to_string(i);
     auto agent = std::make_shared<TaskAgent>(agent_id);
     registry.registerAgent(agent_id, agent);
   }
 
-  int lookup_idx = 0;
+  int32_t lookup_idx = 0;
   for (auto _ : state) {
     std::string agent_id = "agent_" + std::to_string(lookup_idx++ % num_agents);
     benchmark::DoNotOptimize(registry.hasAgent(agent_id));

--- a/benchmarks/resilience_performance.cpp
+++ b/benchmarks/resilience_performance.cpp
@@ -13,6 +13,7 @@
 #include "core/retry_policy.hpp"
 
 #include <chrono>
+#include <cstdint>
 #include <thread>
 
 #include <benchmark/benchmark.h>
@@ -65,13 +66,13 @@ BENCHMARK(BM_RetryPolicy_BackoffCalculation);
 
 // Benchmark: Exponential backoff sequence
 static void BM_RetryPolicy_FullSequence(benchmark::State& state) {
-  int max_retries = state.range(0);
+  int32_t max_retries = static_cast<int32_t>(state.range(0));
 
   for (auto _ : state) {
     auto policy =
         RetryPolicy(max_retries, std::chrono::milliseconds(10), 2.0, std::chrono::seconds(10));
 
-    for (int attempt = 0; attempt < max_retries; ++attempt) {
+    for (int32_t attempt = 0; attempt < max_retries; ++attempt) {
       if (!policy.shouldRetry(attempt))
         break;
       auto delay = policy.getBackoffDelay(attempt);
@@ -91,7 +92,7 @@ static void BM_RetryPolicy_VaryingMultiplier(benchmark::State& state) {
       RetryPolicy(20, std::chrono::milliseconds(100), multiplier, std::chrono::seconds(30));
 
   for (auto _ : state) {
-    for (int attempt = 0; attempt < 10; ++attempt) {
+    for (int32_t attempt = 0; attempt < 10; ++attempt) {
       auto delay = policy.getBackoffDelay(attempt);
       benchmark::DoNotOptimize(delay);
     }
@@ -155,7 +156,7 @@ BENCHMARK(BM_CircuitBreaker_RecordFailure);
 
 // Benchmark: State transition (closed -> open)
 static void BM_CircuitBreaker_StateTransition(benchmark::State& state) {
-  int failure_threshold = state.range(0);
+  int32_t failure_threshold = static_cast<int32_t>(state.range(0));
 
   for (auto _ : state) {
     auto cb = CircuitBreaker("test",
@@ -164,7 +165,7 @@ static void BM_CircuitBreaker_StateTransition(benchmark::State& state) {
                              std::chrono::seconds(5));
 
     // Trigger failures to open circuit
-    for (int i = 0; i < failure_threshold; ++i) {
+    for (int32_t i = 0; i < failure_threshold; ++i) {
       cb.recordFailure();
     }
 
@@ -261,11 +262,11 @@ BENCHMARK(BM_HeartbeatMonitor_IsAgentAlive);
 
 // Benchmark: getDeadAgents
 static void BM_HeartbeatMonitor_GetDeadAgents(benchmark::State& state) {
-  int num_agents = state.range(0);
+  int32_t num_agents = static_cast<int32_t>(state.range(0));
 
   HeartbeatMonitor monitor(std::chrono::milliseconds(100));
 
-  for (int i = 0; i < num_agents; ++i) {
+  for (int32_t i = 0; i < num_agents; ++i) {
     monitor.registerAgent("agent-" + std::to_string(i));
   }
 
@@ -287,12 +288,12 @@ static void BM_HeartbeatMonitor_ConcurrentHeartbeat(benchmark::State& state) {
   static std::atomic<bool> initialized{false};
 
   if (!initialized.exchange(true)) {
-    for (int i = 0; i < 100; ++i) {
+    for (int32_t i = 0; i < 100; ++i) {
       monitor.registerAgent("agent-" + std::to_string(i));
     }
   }
 
-  int agent_idx = state.thread_index() % 100;
+  int32_t agent_idx = static_cast<int32_t>(state.thread_index()) % 100;
   std::string agent_id = "agent-" + std::to_string(agent_idx);
 
   for (auto _ : state) {

--- a/benchmarks/scheduler_backoff_benchmark.cpp
+++ b/benchmarks/scheduler_backoff_benchmark.cpp
@@ -13,6 +13,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <cstdint>
 #include <thread>
 
 #include <benchmark/benchmark.h>
@@ -55,7 +56,7 @@ static void BM_LatencyUnderLoad(benchmark::State& state) {
   scheduler.start();
 
   auto total_latency_ns = std::make_shared<std::atomic<int64_t>>(0);
-  auto task_count = std::make_shared<std::atomic<int>>(0);
+  auto task_count = std::make_shared<std::atomic<int32_t>>(0);
 
   for (auto _ : state) {
     auto submit_time = std::chrono::steady_clock::now();
@@ -75,7 +76,7 @@ static void BM_LatencyUnderLoad(benchmark::State& state) {
   // Wait for all work to complete
   std::this_thread::sleep_for(100ms);
 
-  int count = task_count->load();
+  int32_t count = task_count->load();
   if (count > 0) {
     int64_t avg_latency_ns = total_latency_ns->load() / count;
     state.counters["avg_latency_us"] = benchmark::Counter(avg_latency_ns / 1000.0);
@@ -146,11 +147,11 @@ static void BM_WorkStealingDuringBackoff(benchmark::State& state) {
   WorkStealingScheduler scheduler(4);
   scheduler.start();
 
-  auto counter = std::make_shared<std::atomic<int>>(0);
+  auto counter = std::make_shared<std::atomic<int32_t>>(0);
 
   for (auto _ : state) {
     // Submit all work to worker 0 (others will steal)
-    for (int i = 0; i < 100; ++i) {
+    for (int32_t i = 0; i < 100; ++i) {
       scheduler.submitTo(0, [counter]() {
         counter->fetch_add(1);
         std::this_thread::sleep_for(10us);  // Small work

--- a/benchmarks/string_allocation_profiling.cpp
+++ b/benchmarks/string_allocation_profiling.cpp
@@ -13,6 +13,7 @@
 
 #include "core/message.hpp"
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <unordered_set>
@@ -40,7 +41,7 @@ BENCHMARK(BM_MessageCreation_Baseline);
  * Measure string allocation overhead by varying sender/receiver ID lengths
  */
 static void BM_MessageCreation_VariableIDLength(benchmark::State& state) {
-  int id_length = state.range(0);
+  int32_t id_length = static_cast<int32_t>(state.range(0));
   std::string sender(id_length, 'a');
   std::string receiver(id_length, 'b');
 
@@ -62,7 +63,7 @@ BENCHMARK(BM_MessageCreation_VariableIDLength)
  * Measure allocation overhead with payload strings
  */
 static void BM_MessageCreation_WithPayload(benchmark::State& state) {
-  int payload_size = state.range(0);
+  int32_t payload_size = static_cast<int32_t>(state.range(0));
   std::string payload_data(payload_size, 'x');
 
   for (auto _ : state) {
@@ -85,13 +86,13 @@ BENCHMARK(BM_MessageCreation_WithPayload)
  * This measures allocation rate under realistic load
  */
 static void BM_HighFrequency_MessageCreation(benchmark::State& state) {
-  const int burst_size = state.range(0);
+  const int32_t burst_size = static_cast<int32_t>(state.range(0));
 
   for (auto _ : state) {
     std::vector<KeystoneMessage> messages;
-    messages.reserve(burst_size);
+    messages.reserve(static_cast<size_t>(burst_size));
 
-    for (int i = 0; i < burst_size; ++i) {
+    for (int32_t i = 0; i < burst_size; ++i) {
       messages.push_back(KeystoneMessage::create("sender-agent", "receiver-agent", "EXECUTE"));
     }
 
@@ -224,14 +225,14 @@ BENCHMARK(BM_Concurrent_MessageCreation)->Threads(1)->Threads(2)->Threads(4)->Th
  * Memory pressure test: Create and hold many messages
  */
 static void BM_Memory_Pressure(benchmark::State& state) {
-  const int message_count = state.range(0);
+  const int32_t message_count = static_cast<int32_t>(state.range(0));
 
   for (auto _ : state) {
     std::vector<KeystoneMessage> messages;
-    messages.reserve(message_count);
+    messages.reserve(static_cast<size_t>(message_count));
 
     // Allocate many messages
-    for (int i = 0; i < message_count; ++i) {
+    for (int32_t i = 0; i < message_count; ++i) {
       messages.push_back(KeystoneMessage::create("sender-" + std::to_string(i),
                                                  "receiver-" + std::to_string(i),
                                                  "EXECUTE"));


### PR DESCRIPTION
## Summary

- Replace bare `int` loop counters and sizing variables with `int32_t` (or `size_t` for `reserve()`/capacity calls) in all 9 benchmark `.cpp` files
- Add `#include <cstdint>` to each affected file
- Follow-up from #65; benchmark files were inadvertently excluded in that implementation

## Test plan

- [ ] `just format-check` passes (verified — no formatting diffs)
- [ ] No functional logic changed — explicit-width types are semantically equivalent for the value ranges used in benchmarks

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)