### PR TITLE
fix(network): TASK_PHASE_ERROR handling, CancelTask notification, yaml phase validation

### DIFF
--- a/include/network/hmas_coordinator_service.hpp
+++ b/include/network/hmas_coordinator_service.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "core/i_message_router.hpp"
 #include "network/service_registry.hpp"
 #include "network/task_phase_utils.hpp"
 #include "network/task_router.hpp"
@@ -104,12 +105,21 @@ class HMASCoordinatorServiceImpl final : public hmas::HMASCoordinator::Service {
   /// @return Number of tasks cleaned up
   int32_t cleanupOldTasks(int64_t age_threshold_ms = 3600000);  // Default: 1 hour
 
+  /// Set the message router used to notify agents of task lifecycle events.
+  /// When set, CancelTask sends a CANCEL_TASK KeystoneMessage to the assigned agent.
+  /// @param router Pointer to IMessageRouter (must outlive this object; may be nullptr)
+  void setMessageRouter(core::IMessageRouter* router);
+
  private:
   /// Generate unique task ID
   std::string generateTaskId() const;
 
   std::shared_ptr<ServiceRegistry> registry_;
   std::shared_ptr<TaskRouter> router_;
+
+  /// Optional message router for agent notifications (e.g., cancellation).
+  /// Not owned by this object.
+  core::IMessageRouter* message_router_{nullptr};
 
   /// Active tasks map: task_id -> TaskState
   std::unordered_map<std::string, TaskState> active_tasks_;

--- a/include/network/task_phase_utils.hpp
+++ b/include/network/task_phase_utils.hpp
@@ -74,8 +74,18 @@ inline hmas::TaskPhase stringToPhase(const std::string& phase_str) {
     return hmas::TASK_PHASE_CANCELLED;
   if (phase_str == "ERROR")
     return hmas::TASK_PHASE_ERROR;
-
+  if (phase_str == "UNSPECIFIED")
+    return hmas::TASK_PHASE_UNSPECIFIED;
   return hmas::TASK_PHASE_UNSPECIFIED;
+}
+
+/// Returns true if the string maps to a known (non-UNSPECIFIED) TaskPhase value.
+inline bool isKnownPhaseString(const std::string& phase_str) {
+  if (phase_str.empty())
+    return false;
+  if (phase_str == "UNSPECIFIED")
+    return false;
+  return stringToPhase(phase_str) != hmas::TASK_PHASE_UNSPECIFIED;
 }
 
 }  // namespace keystone::network

--- a/src/network/yaml_parser.cpp
+++ b/src/network/yaml_parser.cpp
@@ -1,7 +1,10 @@
 #include "network/yaml_parser.hpp"
 
+#include "network/task_phase_utils.hpp"
+
 #include <regex>
 #include <sstream>
+#include <stdexcept>
 
 namespace keystone::network {
 
@@ -52,6 +55,8 @@ std::optional<HierarchicalTaskSpec> YamlParser::parseTaskSpec(const YAML::Node& 
 
     return spec;
   } catch (const YAML::Exception& e) {
+    return std::nullopt;
+  } catch (const std::exception& e) {
     return std::nullopt;
   }
 }
@@ -297,7 +302,14 @@ TaskStatus YamlParser::parseStatus(const YAML::Node& node) {
   TaskStatus status;
 
   if (node["phase"]) {
-    status.phase = node["phase"].as<std::string>();
+    const std::string phase_str = node["phase"].as<std::string>();
+    // Validate phase string against the known TaskPhase enum values.
+    // An empty string defaults to "PENDING" (struct default); any non-empty
+    // string that does not map to a valid phase is rejected.
+    if (!phase_str.empty() && !isKnownPhaseString(phase_str)) {
+      throw std::runtime_error("Unknown task phase string: '" + phase_str + "'");
+    }
+    status.phase = phase_str;
   }
   if (node["startTime"]) {
     status.start_time = node["startTime"].as<std::string>();


### PR DESCRIPTION
## Summary

- **#225**: `GetTaskResult` now returns a distinct, descriptive error message when a task ends in `TASK_PHASE_ERROR` (infrastructure/unexpected error), differentiating it from other non-completed terminal states.
- **#224**: `CancelTask` sends a `CANCEL_TASK` `KeystoneMessage` to the assigned agent via the (optionally-wired) `IMessageRouter` after marking a task cancelled, enabling cooperative cancellation. A new `setMessageRouter()` method exposes this wiring point.
- **#222**: `yaml_parser::parseStatus` now validates the phase string against the known `hmas::TaskPhase` enum values using the new public `isKnownPhaseString()` / `stringToPhase()` utilities in `include/network/task_phase_utils.hpp`. Unknown phase strings cause `parseTaskSpec` to return `std::nullopt`.

## Changes

- `include/network/task_phase_utils.hpp`: Added public `phaseToString`, `stringToPhase`, and `isKnownPhaseString` inline functions (previously only private static methods on `HMASCoordinatorServiceImpl`).
- `include/network/hmas_coordinator_service.hpp`: Added optional `IMessageRouter*` member and `setMessageRouter()` setter.
- `src/network/hmas_coordinator_service.cpp`: Implemented `setMessageRouter`; updated `GetTaskResult` and `CancelTask` as described above.
- `src/network/yaml_parser.cpp`: Added phase validation in `parseStatus`; catch block broadened to `std::exception` so the validation error propagates correctly.

## Test plan

- [ ] Existing `test_task_phase_utils.cpp` continues to pass (terminal state detection, cleanup, etc.)
- [ ] Build with `cmake --preset debug && cmake --build --preset debug` — no new warnings
- [ ] `GetTaskResult` test: set task to `TASK_PHASE_ERROR`, call `GetTaskResult`, verify response contains the infrastructure-error message
- [ ] `CancelTask` test: wire a mock `IMessageRouter`, cancel a task, verify `routeMessage` was called with a `CANCEL_TASK` message addressed to the assigned agent
- [ ] `yaml_parser` test: parse a spec with `status.phase: "BOGUS_PHASE"` — `parseTaskSpec` returns `std::nullopt`; valid phase strings still parse correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)