### PR TITLE
ci: normalize _required.yml to 9 canonical required contexts

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -126,78 +126,6 @@ jobs:
           path: cppcheck-report.xml
           retention-days: 30
 
-      - name: Install build dependencies (with static analysis)
-        uses: ./.github/actions/install-build-deps
-        with:
-          include-static-analysis: "true"
-
-      - name: Cache Conan packages (clang-tidy)
-        uses: actions/cache@v5
-        with:
-          path: ~/.conan2
-          key: conan-${{ runner.os }}-${{ hashFiles('conanfile.py') }}
-          restore-keys: |
-            conan-${{ runner.os }}-
-
-      - name: Cache FetchContent (clang-tidy)
-        uses: actions/cache@v5
-        with:
-          path: build/x86.debug.clang-tidy/_deps
-          key: fetchcontent-clang-tidy-${{ runner.os }}-${{ hashFiles('CMakeLists.txt') }}
-          restore-keys: |
-            fetchcontent-clang-tidy-${{ runner.os }}-
-
-      - name: Set up sccache
-        uses: mozilla-actions/sccache-action@v0.0.10
-
-      - name: Configure sccache
-        run: |
-          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
-          echo "CMAKE_C_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
-          echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
-
-      - name: Install Conan dependencies
-        run: make deps.native
-
-      - name: Configure CMake with clang-tidy
-        run: |
-          CONAN_TOOLCHAIN=""
-          if [ -f build/conan-deps/conan_toolchain.cmake ]; then
-            CONAN_TOOLCHAIN="-DCMAKE_TOOLCHAIN_FILE=build/conan-deps/conan_toolchain.cmake"
-          fi
-          cmake -S . -B build/x86.debug.clang-tidy \
-            -G Ninja \
-            -DCMAKE_BUILD_TYPE=Debug \
-            -DENABLE_CLANG_TIDY=ON \
-            $CONAN_TOOLCHAIN
-
-      - name: Build with clang-tidy
-        run: cmake --build build/x86.debug.clang-tidy -j$(nproc) 2>&1 | tee clang-tidy-output.txt
-        continue-on-error: true
-
-      - name: Fail on clang-tidy errors
-        run: |
-          # Filter out CMake integration false positives: clang-tidy is invoked on
-          # generated cmake files and non-source inputs, producing "no input files"
-          # and "no such file or directory" diagnostics that are not real code errors.
-          # Only fail on errors that reference actual source files (src/ or include/).
-          REAL_ERRORS=$(grep -E "error:" clang-tidy-output.txt \
-            | grep -v "no input files\|no such file or directory\|unable to handle compilation" \
-            || true)
-          if [ -n "$REAL_ERRORS" ]; then
-            echo "::error::clang-tidy reported errors in source files"
-            echo "$REAL_ERRORS"
-            exit 1
-          fi
-          echo "clang-tidy passed"
-
-      - name: Show sccache stats
-        if: always()
-        run: sccache --show-stats
-
-      - name: Run mypy (Python typecheck)
-        run: mypy conanfile.py
-
   # ============================================================
   # 2. unit-tests
   #    C++ unit tests + Python pytest
@@ -286,19 +214,15 @@ jobs:
           retention-days: 7
 
   # ============================================================
-  # 3. integration-tests-sanitizer (matrix: asan, ubsan, tsan, lsan)
-  #    Fan-in job `integration-tests` below is the single required check.
+  # 3. integration-tests
+  #    C++ integration/sample/example/application tests
+  #    + all sanitizer builds (asan, ubsan, tsan, lsan) as matrix
   # ============================================================
-  integration-tests-sanitizer:
-    name: integration-tests (${{ matrix.sanitizer }})
+  integration-tests:
+    name: integration-tests
     runs-on: ubuntu-24.04
-    timeout-minutes: 40
+    timeout-minutes: 90
     needs: lint
-
-    strategy:
-      fail-fast: false
-      matrix:
-        sanitizer: [asan, ubsan, tsan, lsan]
 
     steps:
       - name: Checkout code
@@ -315,14 +239,6 @@ jobs:
           restore-keys: |
             conan-${{ runner.os }}-
 
-      - name: Cache FetchContent downloads
-        uses: actions/cache@v5
-        with:
-          path: build/x86.debug.${{ matrix.sanitizer }}/_deps
-          key: fetchcontent-${{ matrix.sanitizer }}-${{ runner.os }}-${{ hashFiles('CMakeLists.txt') }}
-          restore-keys: |
-            fetchcontent-${{ matrix.sanitizer }}-${{ runner.os }}-
-
       - name: Set up sccache
         uses: mozilla-actions/sccache-action@v0.0.10
 
@@ -335,43 +251,31 @@ jobs:
       - name: Install Conan dependencies
         run: make deps.native
 
-      - name: Build with ${{ matrix.sanitizer }}
-        run: make compile.debug.${{ matrix.sanitizer }}.native
+      - name: Build + test (ASan)
+        run: make compile.debug.asan.native && make test.debug.asan.native
+
+      - name: Build + test (UBSan)
+        run: make compile.debug.ubsan.native && make test.debug.ubsan.native
+
+      - name: Build + test (TSan)
+        run: make compile.debug.tsan.native && make test.debug.tsan.native
+        env:
+          TSAN_OPTIONS: "suppressions=${{ github.workspace }}/tsan.supp:second_deadlock_stack=1"
+
+      - name: Build + test (LSan)
+        run: make compile.debug.lsan.native && make test.debug.lsan.native
 
       - name: Show sccache stats
         if: always()
         run: sccache --show-stats
 
-      - name: Run all tests with ${{ matrix.sanitizer }}
-        run: make test.debug.${{ matrix.sanitizer }}.native
-        env:
-          TSAN_OPTIONS: ${{ matrix.sanitizer == 'tsan' && format('suppressions={0}/tsan.supp:second_deadlock_stack=1', github.workspace) || '' }}
-
       - name: Upload test logs
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: integration-test-logs-${{ matrix.sanitizer }}
-          path: build/x86.debug.${{ matrix.sanitizer }}/Testing/
+          name: integration-test-logs
+          path: build/x86.debug.*/Testing/
           retention-days: 7
-
-  # Fan-in: single required-check context "integration-tests".
-  # Passes only when every sanitizer leg above succeeds.
-  integration-tests:
-    name: integration-tests
-    runs-on: ubuntu-24.04
-    needs: integration-tests-sanitizer
-    if: always()
-    steps:
-      - name: Check sanitizer results
-        env:
-          SANITIZER_RESULT: ${{ needs.integration-tests-sanitizer.result }}
-        run: |
-          if [ "$SANITIZER_RESULT" != "success" ]; then
-            echo "One or more sanitizer builds failed: $SANITIZER_RESULT"
-            exit 1
-          fi
-          echo "All sanitizer builds passed"
 
   # ============================================================
   # 4. build
@@ -425,86 +329,33 @@ jobs:
         run: sccache --show-stats
 
   # ============================================================
-  # 5. benchmarks
+  # 5. typecheck
+  #    clang-tidy (C++ static analysis) + mypy (Python)
   # ============================================================
-  benchmarks:
-    name: benchmarks
-    runs-on: ubuntu-24.04
-    timeout-minutes: 20
-    needs: build
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Install build dependencies
-        uses: ./.github/actions/install-build-deps
-
-      - name: Cache Conan packages
-        uses: actions/cache@v5
-        with:
-          path: ~/.conan2
-          key: conan-${{ runner.os }}-${{ hashFiles('conanfile.py') }}
-          restore-keys: |
-            conan-${{ runner.os }}-
-
-      - name: Cache FetchContent downloads
-        uses: actions/cache@v5
-        with:
-          path: build/x86.release/_deps
-          key: fetchcontent-release-${{ runner.os }}-${{ hashFiles('CMakeLists.txt') }}
-          restore-keys: |
-            fetchcontent-release-${{ runner.os }}-
-
-      - name: Set up sccache
-        uses: mozilla-actions/sccache-action@v0.0.10
-
-      - name: Configure sccache
-        run: |
-          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
-          echo "CMAKE_C_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
-          echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
-
-      - name: Install Conan dependencies
-        run: make deps.native
-
-      - name: Build release
-        run: make compile.release.native
-
-      - name: Show sccache stats
-        if: always()
-        run: sccache --show-stats
-
-      - name: Run benchmarks
-        run: make benchmark.native || true
-
-      - name: Upload benchmark results
-        uses: actions/upload-artifact@v7
-        with:
-          name: benchmark-results
-          path: build/reports/benchmarks/
-          retention-days: 30
-          if-no-files-found: ignore
-
-  # ============================================================
-  # 6. coverage
-  # ============================================================
-  coverage:
-    name: coverage
+  typecheck:
+    name: typecheck
     runs-on: ubuntu-24.04
     timeout-minutes: 25
-    needs: build
+    needs: lint
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Install build dependencies
+      - name: Install build dependencies (with static analysis)
         uses: ./.github/actions/install-build-deps
         with:
-          include-coverage: "true"
+          include-static-analysis: "true"
 
-      - name: Cache Conan packages
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install mypy
+        run: pip install "mypy>=1.8.0,<2" "conan>=2.0.0"
+
+      - name: Cache Conan packages (clang-tidy)
         uses: actions/cache@v5
         with:
           path: ~/.conan2
@@ -512,13 +363,13 @@ jobs:
           restore-keys: |
             conan-${{ runner.os }}-
 
-      - name: Cache FetchContent downloads
+      - name: Cache FetchContent (clang-tidy)
         uses: actions/cache@v5
         with:
-          path: build/x86.debug.coverage/_deps
-          key: fetchcontent-coverage-${{ runner.os }}-${{ hashFiles('CMakeLists.txt') }}
+          path: build/x86.debug.clang-tidy/_deps
+          key: fetchcontent-clang-tidy-${{ runner.os }}-${{ hashFiles('CMakeLists.txt') }}
           restore-keys: |
-            fetchcontent-coverage-${{ runner.os }}-
+            fetchcontent-clang-tidy-${{ runner.os }}-
 
       - name: Set up sccache
         uses: mozilla-actions/sccache-action@v0.0.10
@@ -532,41 +383,47 @@ jobs:
       - name: Install Conan dependencies
         run: make deps.native
 
-      - name: Build with coverage
-        run: make compile.debug.coverage.native
+      - name: Configure CMake with clang-tidy
+        run: |
+          CONAN_TOOLCHAIN=""
+          if [ -f build/conan-deps/conan_toolchain.cmake ]; then
+            CONAN_TOOLCHAIN="-DCMAKE_TOOLCHAIN_FILE=build/conan-deps/conan_toolchain.cmake"
+          fi
+          cmake -S . -B build/x86.debug.clang-tidy \
+            -G Ninja \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DENABLE_CLANG_TIDY=ON \
+            $CONAN_TOOLCHAIN
+
+      - name: Build with clang-tidy
+        run: cmake --build build/x86.debug.clang-tidy -j$(nproc) 2>&1 | tee clang-tidy-output.txt
+        continue-on-error: true
+
+      - name: Fail on clang-tidy errors
+        run: |
+          # Filter out CMake integration false positives: clang-tidy is invoked on
+          # generated cmake files and non-source inputs, producing "no input files"
+          # and "no such file or directory" diagnostics that are not real code errors.
+          # Only fail on errors that reference actual source files (src/ or include/).
+          REAL_ERRORS=$(grep -E "error:" clang-tidy-output.txt \
+            | grep -v "no input files\|no such file or directory\|unable to handle compilation" \
+            || true)
+          if [ -n "$REAL_ERRORS" ]; then
+            echo "::error::clang-tidy reported errors in source files"
+            echo "$REAL_ERRORS"
+            exit 1
+          fi
+          echo "clang-tidy passed"
+
+      - name: Run mypy (Python typecheck)
+        run: mypy conanfile.py
 
       - name: Show sccache stats
         if: always()
         run: sccache --show-stats
 
-      - name: Run tests for coverage
-        run: make test.debug.coverage.native
-
-      - name: Generate coverage report
-        run: |
-          chmod +x scripts/generate_coverage.sh
-          BUILD_DIR=build/x86.coverage.debug ./scripts/generate_coverage.sh
-
-      - name: Upload coverage report
-        uses: actions/upload-artifact@v7
-        with:
-          name: coverage-report
-          path: build/coverage/html/
-          retention-days: 30
-          if-no-files-found: ignore
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
-        with:
-          files: build/coverage/coverage_filtered.info
-          flags: unittests
-          name: codecov-umbrella
-          fail_ci_if_error: false
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
   # ============================================================
-  # 7. schema-validation
+  # 6. schema-validation
   # ============================================================
   schema-validation:
     name: schema-validation
@@ -596,7 +453,7 @@ jobs:
           [ -z "${FAILED}" ] || exit 1
 
   # ============================================================
-  # 8. deps/version-sync
+  # 7. deps/version-sync
   # ============================================================
   deps-version-sync:
     name: deps/version-sync
@@ -662,7 +519,7 @@ jobs:
           PYEOF
 
   # ============================================================
-  # 9. security/dependency-scan
+  # 8. security/dependency-scan
   #    pip-audit + Trivy FS + supply-chain dependency-review
   #    + Docker image scan (Trivy container)
   # ============================================================
@@ -796,7 +653,7 @@ jobs:
           if-no-files-found: ignore
 
   # ============================================================
-  # 10. security/secrets-scan
+  # 9. security/secrets-scan
   #     gitleaks + Semgrep SAST + CodeQL (c-cpp + python)
   #     + aggregation report gate
   # ============================================================

--- a/.github/workflows/extras.yml
+++ b/.github/workflows/extras.yml
@@ -1,0 +1,152 @@
+name: Extras (non-blocking)
+
+# Benchmarks and coverage — informational only, not required for merge.
+# These jobs produce build artifacts and Codecov reports but do not block PRs.
+
+on:
+  push:
+    branches: [main, develop, "claude/**"]
+  pull_request:
+    branches: [main, develop]
+  workflow_dispatch:
+
+concurrency:
+  group: extras-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  benchmarks:
+    name: benchmarks
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install build dependencies
+        uses: ./.github/actions/install-build-deps
+
+      - name: Cache Conan packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.conan2
+          key: conan-${{ runner.os }}-${{ hashFiles('conanfile.py') }}
+          restore-keys: |
+            conan-${{ runner.os }}-
+
+      - name: Cache FetchContent downloads
+        uses: actions/cache@v5
+        with:
+          path: build/x86.release/_deps
+          key: fetchcontent-release-${{ runner.os }}-${{ hashFiles('CMakeLists.txt') }}
+          restore-keys: |
+            fetchcontent-release-${{ runner.os }}-
+
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+
+      - name: Configure sccache
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+          echo "CMAKE_C_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+          echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+
+      - name: Install Conan dependencies
+        run: make deps.native
+
+      - name: Build release
+        run: make compile.release.native
+
+      - name: Show sccache stats
+        if: always()
+        run: sccache --show-stats
+
+      - name: Run benchmarks
+        run: make benchmark.native || true
+
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v7
+        with:
+          name: benchmark-results
+          path: build/reports/benchmarks/
+          retention-days: 30
+          if-no-files-found: ignore
+
+  coverage:
+    name: coverage
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install build dependencies
+        uses: ./.github/actions/install-build-deps
+        with:
+          include-coverage: "true"
+
+      - name: Cache Conan packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.conan2
+          key: conan-${{ runner.os }}-${{ hashFiles('conanfile.py') }}
+          restore-keys: |
+            conan-${{ runner.os }}-
+
+      - name: Cache FetchContent downloads
+        uses: actions/cache@v5
+        with:
+          path: build/x86.debug.coverage/_deps
+          key: fetchcontent-coverage-${{ runner.os }}-${{ hashFiles('CMakeLists.txt') }}
+          restore-keys: |
+            fetchcontent-coverage-${{ runner.os }}-
+
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+
+      - name: Configure sccache
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+          echo "CMAKE_C_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+          echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+
+      - name: Install Conan dependencies
+        run: make deps.native
+
+      - name: Build with coverage
+        run: make compile.debug.coverage.native
+
+      - name: Show sccache stats
+        if: always()
+        run: sccache --show-stats
+
+      - name: Run tests for coverage
+        run: make test.debug.coverage.native
+
+      - name: Generate coverage report
+        run: |
+          chmod +x scripts/generate_coverage.sh
+          BUILD_DIR=build/x86.coverage.debug ./scripts/generate_coverage.sh
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-report
+          path: build/coverage/html/
+          retention-days: 30
+          if-no-files-found: ignore
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: build/coverage/coverage_filtered.info
+          flags: unittests
+          name: codecov-umbrella
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary

- Collapses the `integration-tests` sanitizer matrix (4 contexts: `asan`, `ubsan`, `tsan`, `lsan`) into a single sequential job, so the workflow registers the canonical `Required Checks / integration-tests` context instead of 4 non-canonical matrix-expanded names
- Extracts `clang-tidy` and `mypy` steps from the `lint` job into a new dedicated `typecheck` job, adding the missing canonical `Required Checks / typecheck` context
- Deletes `benchmarks` and `coverage` from `_required.yml` (non-canonical contexts not in `configs/github/canonical-checks.md`)
- Adds `extras.yml` to preserve benchmarks and coverage as informational, non-blocking jobs (artifacts + Codecov reporting continue unchanged)

After this PR merges, `apply-repo-rulesets.sh --active` will be run from Odysseus to update ProjectKeystone's `homeric-main-baseline` ruleset from 13 divergent bare-name contexts to the canonical 9 `Required Checks / *` contexts.

## Note on merging this PR

Keystone's current ruleset requires the old 13 contexts (including `benchmarks` and `coverage` which will no longer exist). Auto-merge will be blocked. An admin needs to use the RepositoryRole bypass to merge once CI on this branch is green.

## Test plan

- [ ] Verify `_required.yml` YAML is valid
- [ ] Confirm 9 jobs appear in the PR checks UI: `lint`, `unit-tests`, `integration-tests`, `build`, `typecheck`, `schema-validation`, `deps/version-sync`, `security/dependency-scan`, `security/secrets-scan`
- [ ] Confirm `extras.yml` benchmarks and coverage run but do not block merge
- [ ] After merge: run `tools/github/apply-repo-rulesets.sh --active` from Odysseus to update the ruleset to the canonical 9 contexts

🤖 Generated with [Claude Code](https://claude.com/claude-code)