### PR TITLE
fix(ci): add integration-tests fan-in job to unify sanitizer checks

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -286,11 +286,10 @@ jobs:
           retention-days: 7
 
   # ============================================================
-  # 3. integration-tests
-  #    C++ integration/sample/example/application tests
-  #    + all sanitizer builds (asan, ubsan, tsan, lsan) as matrix
+  # 3. integration-tests-sanitizer (matrix: asan, ubsan, tsan, lsan)
+  #    Fan-in job `integration-tests` below is the single required check.
   # ============================================================
-  integration-tests:
+  integration-tests-sanitizer:
     name: integration-tests (${{ matrix.sanitizer }})
     runs-on: ubuntu-24.04
     timeout-minutes: 40
@@ -355,6 +354,24 @@ jobs:
           name: integration-test-logs-${{ matrix.sanitizer }}
           path: build/x86.debug.${{ matrix.sanitizer }}/Testing/
           retention-days: 7
+
+  # Fan-in: single required-check context "integration-tests".
+  # Passes only when every sanitizer leg above succeeds.
+  integration-tests:
+    name: integration-tests
+    runs-on: ubuntu-24.04
+    needs: integration-tests-sanitizer
+    if: always()
+    steps:
+      - name: Check sanitizer results
+        env:
+          SANITIZER_RESULT: ${{ needs.integration-tests-sanitizer.result }}
+        run: |
+          if [ "$SANITIZER_RESULT" != "success" ]; then
+            echo "One or more sanitizer builds failed: $SANITIZER_RESULT"
+            exit 1
+          fi
+          echo "All sanitizer builds passed"
 
   # ============================================================
   # 4. build


### PR DESCRIPTION
## Problem

The `integration-tests` job used a matrix over `[asan, ubsan, tsan, lsan]`, producing 4 separate check contexts:
- `integration-tests (asan)`
- `integration-tests (ubsan)`
- `integration-tests (tsan)`
- `integration-tests (lsan)`

The `homeric-main-baseline` ruleset requires a single context named `integration-tests`, so that context was never satisfied — all PRs stayed BLOCKED even when every sanitizer run passed.

## Fix

- Renamed the matrix job key from `integration-tests` to `integration-tests-sanitizer` (display names stay `integration-tests (asan)` etc. for readability)
- Added a fan-in job named exactly `integration-tests` that `needs: integration-tests-sanitizer` and fails if any leg fails

The required check context `integration-tests` now resolves to a single job that passes only when all 4 sanitizer legs succeed.

## Test plan

- [ ] CI on this PR shows `integration-tests (asan/ubsan/tsan/lsan)` plus a single `integration-tests` check
- [ ] `integration-tests` passes when all sanitizer legs pass
- [ ] After merge, re-check that open PRs see `integration-tests` as a passing required check

🤖 Generated with [Claude Code](https://claude.com/claude-code)