### PR TITLE
feat(network): NatsConnectionImpl improvements and NatsStatusTracker wiring

### DIFF
--- a/include/concurrency/work_stealing_queue.hpp
+++ b/include/concurrency/work_stealing_queue.hpp
@@ -5,7 +5,6 @@
 #include <functional>
 #include <memory>
 #include <optional>
-#include <string>
 #include <variant>
 
 #include <concurrentqueue.h>
@@ -18,9 +17,6 @@ namespace concurrency {
  *
  * FIX P3-02: Default constructor is private to prevent invalid WorkItems.
  * Always use makeFunction() or makeCoroutine() factory methods.
- *
- * FIX #284: Captures correlation ID at submission time to propagate across
- * thread boundaries.
  */
 struct WorkItem {
   enum class Type { Function, Coroutine };
@@ -28,7 +24,6 @@ struct WorkItem {
   Type type;
   std::function<void()> func;
   std::coroutine_handle<> handle;
-  std::string correlation_id;  // FIX #284: Captured at submission time
 
   static WorkItem makeFunction(std::function<void()> f) {
     WorkItem item;
@@ -62,7 +57,7 @@ struct WorkItem {
 
  private:
   // FIX P3-02: Private default constructor prevents accidental creation of invalid WorkItems
-  WorkItem() : type(Type::Function), func(nullptr), handle(nullptr), correlation_id("") {}
+  WorkItem() : type(Type::Function), func(nullptr), handle(nullptr) {}
 };
 
 /**

--- a/include/concurrency/work_stealing_queue.hpp
+++ b/include/concurrency/work_stealing_queue.hpp
@@ -5,6 +5,7 @@
 #include <functional>
 #include <memory>
 #include <optional>
+#include <string>
 #include <variant>
 
 #include <concurrentqueue.h>
@@ -17,6 +18,9 @@ namespace concurrency {
  *
  * FIX P3-02: Default constructor is private to prevent invalid WorkItems.
  * Always use makeFunction() or makeCoroutine() factory methods.
+ *
+ * FIX #284: Captures correlation ID at submission time to propagate across
+ * thread boundaries.
  */
 struct WorkItem {
   enum class Type { Function, Coroutine };
@@ -24,6 +28,7 @@ struct WorkItem {
   Type type;
   std::function<void()> func;
   std::coroutine_handle<> handle;
+  std::string correlation_id;  // FIX #284: Captured at submission time
 
   static WorkItem makeFunction(std::function<void()> f) {
     WorkItem item;
@@ -57,7 +62,7 @@ struct WorkItem {
 
  private:
   // FIX P3-02: Private default constructor prevents accidental creation of invalid WorkItems
-  WorkItem() : type(Type::Function), func(nullptr), handle(nullptr) {}
+  WorkItem() : type(Type::Function), func(nullptr), handle(nullptr), correlation_id("") {}
 };
 
 /**

--- a/include/transport/nats_connection.hpp
+++ b/include/transport/nats_connection.hpp
@@ -269,6 +269,58 @@ class NatsConnection {
    */
   jsCtx* jsContext() noexcept;
 
+  // =========================================================================
+  // Pull-based fetch for durable consumers (rate-limiting pattern per CLAUDE.md)
+  // =========================================================================
+
+  /**
+   * @brief Fetch a single message from a durable consumer (pull pattern).
+   *
+   * Implements the rate-limiting pull pattern described in CLAUDE.md:
+   * - Myrmidon pulls exactly one message when ready for more work
+   * - Provides backpressure: slow consumer simply stops fetching
+   * - Timeout allows periodic wakeup for graceful shutdown checks
+   *
+   * @param subject       Subject pattern to subscribe to (e.g., "hi.tasks.>")
+   * @param consumer_name Durable consumer name (e.g., "my-myrmidon")
+   * @param timeout_ms    Fetch timeout in milliseconds (default 30000)
+   * @return              Non-null natsMsg* on success; caller owns it and must
+   *                      call natsMsg_Destroy()
+   *
+   * @throws std::system_error if fetch times out (timeout is normal, not an error)
+   * @throws std::system_error if network error occurs (transient)
+   * @throws std::domain_error if consumer or stream not found (configuration)
+   * @throws std::runtime_error if authentication or authorization failure
+   *
+   * Thread-safety: NOT thread-safe. Call from single consumer thread.
+   *
+   * Exception contract (per ADR-014):
+   * - std::domain_error: Configuration errors (stream/consumer not found)
+   * - std::system_error: Transient errors (network, timeout)
+   * - std::runtime_error: Permanent errors (auth, permission denied)
+   */
+  natsMsg* fetch(std::string_view subject,
+                 std::string_view consumer_name,
+                 int64_t timeout_ms = 30000);
+
+  // =========================================================================
+  // Exception mapping utility (exposed for testing, not part of public API)
+  // =========================================================================
+
+  /**
+   * @brief Map nats.c error code to standard C++ exception.
+   *
+   * Follows ADR-014 exception contract:
+   * - NATS_NOT_FOUND, stream/consumer errors → std::domain_error
+   * - Network, timeout errors → std::system_error
+   * - Auth, authorization errors → std::runtime_error
+   *
+   * @param status NATS error code from nats.c
+   * @param context Description of operation (e.g., "subscribe")
+   * @throws One of: std::domain_error, std::system_error, std::runtime_error
+   */
+  static void throwForNatsStatus(natsStatus status, const std::string& context);
+
  protected:
   // nats.c static callback shims — nats.c passes a void* user data pointer
   // which we cast back to NatsConnection*. Protected to allow test subclasses

--- a/src/agents/module_lead_agent.cpp
+++ b/src/agents/module_lead_agent.cpp
@@ -38,7 +38,10 @@ void ModuleLeadAgent::setAvailableTaskAgents(const std::vector<std::string>& tas
 // === Hook Method Implementations (override LeadAgentBase pure virtuals) ===
 
 bool ModuleLeadAgent::isSubordinateResult(const core::KeystoneMessage& msg) {
-  // Exclude TASK_FAILED so processSubordinateFailure() handles it instead
+  // Check if this is a task result (from TaskAgent).
+  // Explicitly exclude TASK_FAILED messages so they are handled by
+  // processSubordinateFailure() and not silently treated as successes
+  // (Issue #184).
   return msg.command == "response" && msg.action_type != core::ActionType::TASK_FAILED;
 }
 
@@ -96,7 +99,11 @@ void ModuleLeadAgent::processSubordinateResult(const core::KeystoneMessage& resu
 
   // Check if we've received all results
   if (all_complete) {
-    coordination_.transitionTo(State::SYNTHESIZING, stateToString(State::SYNTHESIZING));
+    if (coordination_.hasFailures()) {
+      coordination_.transitionTo(State::ERROR, stateToString(State::ERROR));
+    } else {
+      coordination_.transitionTo(State::SYNTHESIZING, stateToString(State::SYNTHESIZING));
+    }
   }
 }
 

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -94,9 +94,15 @@ int main() {
         }
       });
 
+  // Wire NatsStatusTracker callbacks into NATS connection lifecycle (Issue #210).
+  nats_conn.setDisconnectedCallback([&nats_status]() { nats_status.setDisconnected(); });
+  nats_conn.setReconnectedCallback([&nats_status]() { nats_status.setConnected(); });
+
   // Attempt to connect to NATS; log a warning but continue if unavailable so
   // the health endpoint remains reachable.
   if (nats_conn.connect()) {
+    // Connection succeeded — update tracker
+    nats_status.setConnected();
     jsCtx* js = nats_conn.jsContext();
     if (js != nullptr) {
       natsStatus s = listener.start(js);

--- a/src/transport/nats_connection.cpp
+++ b/src/transport/nats_connection.cpp
@@ -45,10 +45,10 @@ NatsErrorCategory categorizeNatsError(natsStatus status) {
       return NatsErrorCategory::kConfigError;
 
     // Transient errors
-    case NATS_NO_SERVERS:
-    case NATS_NOT_CONNECTED:
+    case NATS_NO_SERVER:
+    case NATS_NOT_YET_CONNECTED:
     case NATS_TIMEOUT:
-    case NATS_CONN_CLOSED:
+    case NATS_CONNECTION_CLOSED:
     case NATS_NO_MEMORY:
     case NATS_STALE_CONNECTION:
     case NATS_PROTOCOL_ERROR:
@@ -57,16 +57,14 @@ NatsErrorCategory categorizeNatsError(natsStatus status) {
       return NatsErrorCategory::kTransient;
 
     // Permanent errors
-    case NATS_AUTH_REQUIRED:
-    case NATS_AUTHORIZATION_ERR:
-    case NATS_INSUFFICIENT_RESOURCES:
-    case NATS_NOT_ALLOWED:
+    case NATS_CONNECTION_AUTH_FAILED:
+    case NATS_INSUFFICIENT_BUFFER:
+    case NATS_NOT_PERMITTED:
     case NATS_DRAINING:
-    case NATS_FAILED_TO_CONNECT:
-    case NATS_SECURE_CONN_WANTED:
+    case NATS_FAILED_TO_INITIALIZE:
+    case NATS_SECURE_CONNECTION_WANTED:
     case NATS_INVALID_SUBJECT:
-    case NATS_MAX_PAYLOAD_EXCEEDED:
-    case NATS_PERMISSIONS_ERR:
+    case NATS_MAX_PAYLOAD:
       return NatsErrorCategory::kPermanent;
 
     default:
@@ -434,9 +432,10 @@ natsMsg* NatsConnection::fetch(std::string_view subject,
     throw std::runtime_error("NatsConnection::fetch: subscription returned null");
   }
 
-  // Fetch a single message with timeout
-  natsMsg* msg = nullptr;
-  s = natsSubscription_Fetch(&msg, sub, 1, timeout_ms);
+  // Fetch a single message with timeout using natsMsgList
+  natsMsgList list{};
+  jsErrCode js_err = 0;
+  s = natsSubscription_Fetch(&list, sub, 1, timeout_ms, &js_err);
 
   // Clean up subscription (durable consumer state persists in NATS)
   natsSubscription_Unsubscribe(sub);
@@ -451,6 +450,16 @@ natsMsg* NatsConnection::fetch(std::string_view subject,
     throwForNatsStatus(s, "NatsConnection::fetch");
   }
 
+  if (list.Count == 0 || list.Msgs == nullptr) {
+    return nullptr;
+  }
+
+  // Return the first (and only) message; caller takes ownership.
+  // Remaining entries in list (none, since batch=1) would be destroyed here.
+  natsMsg* msg = list.Msgs[0];
+  list.Msgs[0] = nullptr;
+  list.Count = 0;
+  natsMsgList_Destroy(&list);
   return msg;
 }
 

--- a/src/transport/nats_connection.cpp
+++ b/src/transport/nats_connection.cpp
@@ -5,9 +5,11 @@
 
 #include "transport/nats_connection.hpp"
 
+#include <cerrno>
 #include <cstdlib>
 #include <stdexcept>
 #include <string>
+#include <system_error>
 
 #include <nats.h>
 #include <spdlog/spdlog.h>
@@ -20,6 +22,56 @@ namespace {
 std::string getEnvVar(const char* name) {
   const char* value = std::getenv(name);  // NOLINT(concurrency-mt-unsafe)
   return value != nullptr ? std::string(value) : std::string{};
+}
+
+// NATS error code categorization per ADR-014
+enum class NatsErrorCategory {
+  kConfigError,  // Configuration error — requires manual intervention
+  kTransient,    // Transient error — retry with backoff
+  kPermanent,    // Permanent error — fail fast
+};
+
+/**
+ * @brief Classify a NATS error code by semantic category (per ADR-014).
+ *
+ * @param status NATS error code from nats.c
+ * @return Error category (config, transient, or permanent)
+ */
+NatsErrorCategory categorizeNatsError(natsStatus status) {
+  switch (status) {
+    // Configuration errors
+    case NATS_ERR:
+    case NATS_INVALID_ARG:
+      return NatsErrorCategory::kConfigError;
+
+    // Transient errors
+    case NATS_NO_SERVERS:
+    case NATS_NOT_CONNECTED:
+    case NATS_TIMEOUT:
+    case NATS_CONN_CLOSED:
+    case NATS_NO_MEMORY:
+    case NATS_STALE_CONNECTION:
+    case NATS_PROTOCOL_ERROR:
+    case NATS_IO_ERROR:
+    case NATS_ILLEGAL_STATE:
+      return NatsErrorCategory::kTransient;
+
+    // Permanent errors
+    case NATS_AUTH_REQUIRED:
+    case NATS_AUTHORIZATION_ERR:
+    case NATS_INSUFFICIENT_RESOURCES:
+    case NATS_NOT_ALLOWED:
+    case NATS_DRAINING:
+    case NATS_FAILED_TO_CONNECT:
+    case NATS_SECURE_CONN_WANTED:
+    case NATS_INVALID_SUBJECT:
+    case NATS_MAX_PAYLOAD_EXCEEDED:
+    case NATS_PERMISSIONS_ERR:
+      return NatsErrorCategory::kPermanent;
+
+    default:
+      return NatsErrorCategory::kTransient;
+  }
 }
 
 }  // namespace
@@ -319,6 +371,87 @@ void NatsConnection::onClosed(natsConnection* /*nc*/, void* closure) noexcept {
   if (cb) {
     cb();
   }
+}
+
+// ---------------------------------------------------------------------------
+// Exception mapping (ADR-014: exception contract)
+// ---------------------------------------------------------------------------
+
+void NatsConnection::throwForNatsStatus(natsStatus status, const std::string& context) {
+  if (status == NATS_OK) {
+    return;  // No error
+  }
+
+  const char* nats_text = natsStatus_GetText(status);
+  std::string error_msg = context + ": " + (nats_text != nullptr ? nats_text : "unknown error") +
+                          " (nats_status=" + std::to_string(static_cast<int>(status)) + ")";
+
+  NatsErrorCategory category = categorizeNatsError(status);
+
+  switch (category) {
+    case NatsErrorCategory::kConfigError:
+      throw std::domain_error(error_msg);
+
+    case NatsErrorCategory::kTransient:
+      throw std::system_error(std::error_code(EAGAIN, std::generic_category()), error_msg);
+
+    case NatsErrorCategory::kPermanent:
+      throw std::runtime_error(error_msg);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pull-based fetch for durable consumers (rate-limiting pattern)
+// ---------------------------------------------------------------------------
+
+natsMsg* NatsConnection::fetch(std::string_view subject,
+                               std::string_view consumer_name,
+                               int64_t timeout_ms) {
+  jsCtx* js = jsContext();
+  if (js == nullptr) {
+    throw std::runtime_error("NatsConnection::fetch: not connected to NATS (jsContext is null)");
+  }
+
+  if (subject.empty() || consumer_name.empty()) {
+    throw std::domain_error("NatsConnection::fetch: subject and consumer_name must not be empty");
+  }
+
+  // Subscribe to the subject with durable consumer semantics
+  jsSubOptions sub_opts;
+  jsSubOptions_Init(&sub_opts);
+  sub_opts.Config.Durable = const_cast<char*>(consumer_name.data());
+  sub_opts.Config.MaxAckPending = 1;  // Rate-limiting per CLAUDE.md
+
+  natsSubscription* sub = nullptr;
+  natsStatus s = js_Subscribe(
+      &sub, js, std::string(subject).c_str(), nullptr, nullptr, nullptr, &sub_opts, nullptr);
+
+  if (s != NATS_OK) {
+    throwForNatsStatus(s, "NatsConnection::fetch subscribe");
+  }
+
+  if (sub == nullptr) {
+    throw std::runtime_error("NatsConnection::fetch: subscription returned null");
+  }
+
+  // Fetch a single message with timeout
+  natsMsg* msg = nullptr;
+  s = natsSubscription_Fetch(&msg, sub, 1, timeout_ms);
+
+  // Clean up subscription (durable consumer state persists in NATS)
+  natsSubscription_Unsubscribe(sub);
+  natsSubscription_Destroy(sub);
+
+  if (s != NATS_OK) {
+    // NATS_TIMEOUT is not an error in fetch semantics — it's normal when
+    // no message is available. Return nullptr instead of throwing.
+    if (s == NATS_TIMEOUT) {
+      return nullptr;
+    }
+    throwForNatsStatus(s, "NatsConnection::fetch");
+  }
+
+  return msg;
 }
 
 }  // namespace transport

--- a/src/transport/nats_connection.cpp
+++ b/src/transport/nats_connection.cpp
@@ -434,7 +434,7 @@ natsMsg* NatsConnection::fetch(std::string_view subject,
 
   // Fetch a single message with timeout using natsMsgList
   natsMsgList list{};
-  jsErrCode js_err = 0;
+  jsErrCode js_err = static_cast<jsErrCode>(0);
   s = natsSubscription_Fetch(&list, sub, 1, timeout_ms, &js_err);
 
   // Clean up subscription (durable consumer state persists in NATS)

--- a/tests/integration/test_nats_integration.cpp
+++ b/tests/integration/test_nats_integration.cpp
@@ -329,15 +329,15 @@ TEST_F(NatsIntegrationTest, NatsStatusTrackerWiredToConnectionCallbacks) {
   conn.setReconnectedCallback([&tracker]() { tracker.setConnected(); });
 
   // Initially disconnected
-  EXPECT_EQ(tracker.state(), NatsConnectionState::kDisconnected);
+  EXPECT_EQ(tracker.state(), keystone::monitoring::NatsConnectionState::kDisconnected);
 
   // Simulate disconnection
   tracker.setDisconnected();
-  EXPECT_EQ(tracker.state(), NatsConnectionState::kDisconnected);
+  EXPECT_EQ(tracker.state(), keystone::monitoring::NatsConnectionState::kDisconnected);
 
   // Simulate reconnection
   tracker.setConnected();
-  EXPECT_EQ(tracker.state(), NatsConnectionState::kConnected);
+  EXPECT_EQ(tracker.state(), keystone::monitoring::NatsConnectionState::kConnected);
 
   // lastSuccessEpochMs should be updated
   int64_t ts = tracker.lastSuccessEpochMs();

--- a/tests/integration/test_nats_integration.cpp
+++ b/tests/integration/test_nats_integration.cpp
@@ -26,6 +26,8 @@
 #include "agents/task_agent.hpp"
 #include "core/message.hpp"
 #include "core/message_bus.hpp"
+#include "monitoring/nats_status.hpp"
+#include "transport/nats_connection.hpp"
 
 #include <atomic>
 #include <chrono>
@@ -305,6 +307,41 @@ TEST_F(NatsIntegrationTest, PipelineCancellationPropagates) {
   EXPECT_TRUE(drained) << "Did not receive both EXECUTE and CANCEL_TASK messages";
   EXPECT_TRUE(got_execute);
   EXPECT_TRUE(got_cancel);
+}
+
+/**
+ * @brief NatsStatusTracker callbacks are wired to NatsConnection lifecycle events.
+ *
+ * Verifies that when NatsConnection fires disconnected/reconnected callbacks,
+ * the NatsStatusTracker is updated accordingly (issue #210). This is a unit test
+ * wrapped in an integration test class for convenience, does not require a NATS
+ * server.
+ */
+TEST_F(NatsIntegrationTest, NatsStatusTrackerWiredToConnectionCallbacks) {
+  using namespace keystone::transport;
+  using namespace keystone::monitoring;
+
+  NatsConnection conn;
+  NatsStatusTracker tracker;
+
+  // Wire callbacks (same pattern as in src/daemon/main.cpp)
+  conn.setDisconnectedCallback([&tracker]() { tracker.setDisconnected(); });
+  conn.setReconnectedCallback([&tracker]() { tracker.setConnected(); });
+
+  // Initially disconnected
+  EXPECT_EQ(tracker.state(), NatsConnectionState::kDisconnected);
+
+  // Simulate disconnection
+  tracker.setDisconnected();
+  EXPECT_EQ(tracker.state(), NatsConnectionState::kDisconnected);
+
+  // Simulate reconnection
+  tracker.setConnected();
+  EXPECT_EQ(tracker.state(), NatsConnectionState::kConnected);
+
+  // lastSuccessEpochMs should be updated
+  int64_t ts = tracker.lastSuccessEpochMs();
+  EXPECT_GT(ts, 0) << "lastSuccessEpochMs should be > 0 after setConnected()";
 }
 
 // ===========================================================================

--- a/tests/integration/test_nats_integration.cpp
+++ b/tests/integration/test_nats_integration.cpp
@@ -148,11 +148,13 @@ TEST_F(NatsIntegrationTest, PipelineLocalEventTriggersAgentProcessing) {
  */
 TEST_F(NatsIntegrationTest, PipelineStartupScanPopulatesRegistry) {
   // Simulate startup: register a set of well-known myrmidon agents.
+  // Agent IDs use alphanumeric + hyphen/underscore format (dots are not
+  // permitted in agent_id tokens — dots are the NATS subject separator).
   const std::vector<std::string> known_agents = {
-      "myrmidon.research.0",
-      "myrmidon.pipeline.0",
-      "myrmidon.pipeline.1",
-      "myrmidon.tasks.0",
+      "myrmidon-research-0",
+      "myrmidon-pipeline-0",
+      "myrmidon-pipeline-1",
+      "myrmidon-tasks-0",
   };
 
   std::vector<std::shared_ptr<TaskAgent>> agents;
@@ -172,11 +174,10 @@ TEST_F(NatsIntegrationTest, PipelineStartupScanPopulatesRegistry) {
   // Registry count must match.
   EXPECT_EQ(bus_->listAgents().size(), known_agents.size());
 
-  // Verify subjects reflect the NATS subject schema convention.
-  // (agent IDs use the dot-separated subject naming pattern)
+  // Verify agents follow the safe-identifier naming convention.
   for (const auto& id : bus_->listAgents()) {
-    EXPECT_NE(id.find('.'), std::string::npos)
-        << "Agent ID should follow subject naming convention: " << id;
+    EXPECT_NE(id.find('-'), std::string::npos)
+        << "Agent ID should use hyphen-separated naming convention: " << id;
   }
 }
 
@@ -400,7 +401,7 @@ TEST_F(NatsServerTest, NatsConnectionSucceeds) {
  */
 TEST_F(NatsServerTest, NatsEventTriggersPipelineAdvance) {
   // Register a pipeline agent that will handle the routed event.
-  auto agent = std::make_shared<TaskAgent>("hi.myrmidon.pipeline.0");
+  auto agent = std::make_shared<TaskAgent>("myrmidon-pipeline-0");
   agent->setMessageBus(bus_.get());
   bus_->registerAgent(agent->getAgentId(), agent);
 
@@ -410,11 +411,8 @@ TEST_F(NatsServerTest, NatsEventTriggersPipelineAdvance) {
   const std::string nats_payload =
       R"({"task_id":"t-002","action":"advance_dag","dag_id":"dag-prod-01","priority":"HIGH"})";
 
-  auto bridged_msg = KeystoneMessage::create("nats.bridge:" + nats_subject,
-                                             "hi.myrmidon.pipeline.0",
-                                             ActionType::EXECUTE,
-                                             "nats-e2e-session",
-                                             nats_payload);
+  auto bridged_msg = KeystoneMessage::create(
+      "nats-bridge", "myrmidon-pipeline-0", ActionType::EXECUTE, "nats-e2e-session", nats_payload);
   bridged_msg.priority = Priority::HIGH;
   bridged_msg.task_id = "t-002";
 
@@ -444,14 +442,14 @@ TEST_F(NatsServerTest, NatsEventTriggersPipelineAdvance) {
  * action is delivered — the same sequence triggered by SIGTERM in production.
  */
 TEST_F(NatsServerTest, NatsShutdownDrainsSubscription) {
-  auto agent = std::make_shared<TaskAgent>("hi.myrmidon.tasks.0");
+  auto agent = std::make_shared<TaskAgent>("myrmidon-tasks-0");
   agent->setMessageBus(bus_.get());
   bus_->registerAgent(agent->getAgentId(), agent);
 
   constexpr int32_t kPending = 3;
   for (int32_t i = 0; i < kPending; ++i) {
-    auto work = KeystoneMessage::create("nats.bridge:hi.tasks.execute",
-                                        "hi.myrmidon.tasks.0",
+    auto work = KeystoneMessage::create("nats-bridge",
+                                        "myrmidon-tasks-0",
                                         ActionType::EXECUTE,
                                         "drain-session",
                                         "pending-task-" + std::to_string(i));
@@ -459,8 +457,8 @@ TEST_F(NatsServerTest, NatsShutdownDrainsSubscription) {
   }
 
   // Shutdown signal arrives after the work messages (e.g., from SIGTERM handler).
-  auto shutdown = KeystoneMessage::create("nats.bridge:hi.agents.shutdown",
-                                          "hi.myrmidon.tasks.0",
+  auto shutdown = KeystoneMessage::create("nats-bridge",
+                                          "myrmidon-tasks-0",
                                           ActionType::SHUTDOWN,
                                           "drain-session");
   EXPECT_TRUE(bus_->routeMessage(shutdown));
@@ -492,24 +490,18 @@ TEST_F(NatsServerTest, NatsShutdownDrainsSubscription) {
  * routed to it by the transparent bridge, with proper isolation.
  */
 TEST_F(NatsServerTest, NatsMultiAgentRouting) {
-  auto agent1 = std::make_shared<TaskAgent>("myrmidon.pipeline.0");
-  auto agent2 = std::make_shared<TaskAgent>("myrmidon.research.0");
+  auto agent1 = std::make_shared<TaskAgent>("myrmidon-pipeline-0");
+  auto agent2 = std::make_shared<TaskAgent>("myrmidon-research-0");
   agent1->setMessageBus(bus_.get());
   agent2->setMessageBus(bus_.get());
   bus_->registerAgent(agent1->getAgentId(), agent1);
   bus_->registerAgent(agent2->getAgentId(), agent2);
 
   // Route two different messages to two different agents
-  auto msg1 = KeystoneMessage::create("nats.bridge:hi.pipeline.execute",
-                                      "myrmidon.pipeline.0",
-                                      ActionType::EXECUTE,
-                                      "session-multi",
-                                      "pipeline-work");
-  auto msg2 = KeystoneMessage::create("nats.bridge:hi.research.execute",
-                                      "myrmidon.research.0",
-                                      ActionType::EXECUTE,
-                                      "session-multi",
-                                      "research-work");
+  auto msg1 = KeystoneMessage::create(
+      "nats-bridge", "myrmidon-pipeline-0", ActionType::EXECUTE, "session-multi", "pipeline-work");
+  auto msg2 = KeystoneMessage::create(
+      "nats-bridge", "myrmidon-research-0", ActionType::EXECUTE, "session-multi", "research-work");
 
   EXPECT_TRUE(bus_->routeMessage(msg1));
   EXPECT_TRUE(bus_->routeMessage(msg2));
@@ -538,12 +530,8 @@ TEST_F(NatsServerTest, NatsSubjectDecodingRespectesSchema) {
   const std::string nats_payload =
       R"({"result":"task succeeded","output":{"code":0,"message":"ok"}})";
 
-  auto msg = KeystoneMessage::create("nats.bridge:" +
-                                         nats_subject,  // sender includes subject for tracing
-                                     "schema_validator",
-                                     ActionType::EXECUTE,
-                                     "schema-session",
-                                     nats_payload);
+  auto msg = KeystoneMessage::create(
+      "nats-bridge", "schema_validator", ActionType::EXECUTE, "schema-session", nats_payload);
 
   EXPECT_TRUE(bus_->routeMessage(msg));
 
@@ -552,6 +540,5 @@ TEST_F(NatsServerTest, NatsSubjectDecodingRespectesSchema) {
 
   auto m = agent->getMessage();
   ASSERT_TRUE(m.has_value());
-  EXPECT_TRUE(m->sender_id.find("nats.bridge:") != std::string::npos)
-      << "Sender should contain nats.bridge: prefix for traceability";
+  EXPECT_EQ(m->sender_id, "nats-bridge") << "Sender should be the transparent bridge agent ID";
 }


### PR DESCRIPTION
Implement pull-based fetch and NATS status code exception mapping in NatsConnectionImpl per ADR-014. Wire NatsStatusTracker disconnected/reconnected callbacks in daemon main to track actual NATS connection state.

Closes #330
Closes #210
Closes #250