### PR TITLE
fix/chore: handle TASK_FAILED in async gRPC path and reconcile justfile/pixi deps

### DIFF
--- a/src/agents/component_lead_agent.cpp
+++ b/src/agents/component_lead_agent.cpp
@@ -245,6 +245,25 @@ void ComponentLeadAgent::processYamlComponent(const std::string& yaml_spec) {
 
       coordination_.trackPendingSubordinate(child_spec.metadata.task_id,
                                             available_module_leads_[agent_index]);
+
+      // Poll for task result in background (gRPC async result handling for Issue #186)
+      // If the task fails, record it to prevent DAG deadlock
+      std::thread([this, coordinator_client, task_id = response.task_id(), deadline_ms]() {
+        try {
+          auto result = coordinator_client->getTaskResult(task_id, deadline_ms);
+          if (!result.success()) {
+            coordination_.recordFailure(result.error());
+            // Transition to ERROR if all results are now in
+            State current_state = coordination_.getCurrentState();
+            if (coordination_.isComplete() && current_state == State::WAITING_FOR_MODULES) {
+              coordination_.transitionTo(State::ERROR, stateToString(State::ERROR));
+            }
+          }
+        } catch (const std::exception& e) {
+          concurrency::Logger::error("Failed to get result for module task {}: {}", task_id,
+                                     e.what());
+        }
+      }).detach();
     } catch (const std::exception& e) {
       concurrency::Logger::error("Failed to submit module: {}", e.what());
     }

--- a/src/agents/component_lead_agent.cpp
+++ b/src/agents/component_lead_agent.cpp
@@ -260,7 +260,8 @@ void ComponentLeadAgent::processYamlComponent(const std::string& yaml_spec) {
             }
           }
         } catch (const std::exception& e) {
-          concurrency::Logger::error("Failed to get result for module task {}: {}", task_id,
+          concurrency::Logger::error("Failed to get result for module task {}: {}",
+                                     task_id,
                                      e.what());
         }
       }).detach();

--- a/src/agents/module_lead_agent.cpp
+++ b/src/agents/module_lead_agent.cpp
@@ -260,8 +260,7 @@ void ModuleLeadAgent::processYamlModule(const std::string& yaml_spec) {
             }
           }
         } catch (const std::exception& e) {
-          concurrency::Logger::error("Failed to get result for task {}: {}", task_id,
-                                     e.what());
+          concurrency::Logger::error("Failed to get result for task {}: {}", task_id, e.what());
         }
       }).detach();
     } catch (const std::exception& e) {

--- a/src/agents/module_lead_agent.cpp
+++ b/src/agents/module_lead_agent.cpp
@@ -245,13 +245,29 @@ void ModuleLeadAgent::processYamlModule(const std::string& yaml_spec) {
 
       coordination_.trackPendingSubordinate(child_spec.metadata.task_id,
                                             available_task_agents_[agent_index]);
+
+      // Poll for task result in background (gRPC async result handling for Issue #186)
+      // If the task fails, record it to prevent DAG deadlock
+      std::thread([this, coordinator_client, task_id = response.task_id(), deadline_ms]() {
+        try {
+          auto result = coordinator_client->getTaskResult(task_id, deadline_ms);
+          if (!result.success()) {
+            coordination_.recordFailure(result.error());
+            // Transition to ERROR if all results are now in
+            State current_state = coordination_.getCurrentState();
+            if (coordination_.isComplete() && current_state == State::WAITING_FOR_TASKS) {
+              coordination_.transitionTo(State::ERROR, stateToString(State::ERROR));
+            }
+          }
+        } catch (const std::exception& e) {
+          concurrency::Logger::error("Failed to get result for task {}: {}", task_id,
+                                     e.what());
+        }
+      }).detach();
     } catch (const std::exception& e) {
       concurrency::Logger::error("Failed to submit task: {}", e.what());
     }
   }
-
-  // Wait for results (in a real implementation, this would be async)
-  // For now, we'll rely on processTaskResult being called externally
 }
 
 void ModuleLeadAgent::startHeartbeat() {

--- a/src/agents/module_lead_agent.cpp
+++ b/src/agents/module_lead_agent.cpp
@@ -38,8 +38,8 @@ void ModuleLeadAgent::setAvailableTaskAgents(const std::vector<std::string>& tas
 // === Hook Method Implementations (override LeadAgentBase pure virtuals) ===
 
 bool ModuleLeadAgent::isSubordinateResult(const core::KeystoneMessage& msg) {
-  // Check if this is a task result (from TaskAgent)
-  return msg.command == "response";
+  // Exclude TASK_FAILED so processSubordinateFailure() handles it instead
+  return msg.command == "response" && msg.action_type != core::ActionType::TASK_FAILED;
 }
 
 std::vector<std::string> ModuleLeadAgent::decomposeGoal(const std::string& goal) {


### PR DESCRIPTION
Handle TASK_FAILED in async (gRPC) result callback of processYamlModule for ComponentLeadAgent and ModuleLeadAgent. The async path previously had no failure check, relying on external processTaskResult calls, which could cause DAG deadlock when tasks failed.

Also adds Conan dependency installation as a pixi task to match the justfile deps recipe, ensuring developers using pixi have a clear path to install C++ dependencies.

Closes #186
Closes #243