### PR TITLE
chore(ci): remove duplicate clang-format check from lint job

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -51,9 +51,6 @@ jobs:
       - name: Install Python linters
         run: pip install "ruff>=0.1,<1" "mypy>=1.8.0,<2" "conan>=2.0.0"
 
-      - name: Clang-format check (C++)
-        run: just format-check
-
       - name: Ruff lint (Python)
         run: ruff check src/ tests/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Starting from v0.2.0, this file is maintained automatically by
 
 ### Changed
 
+- Remove duplicate clang-format step from lint job; pre-commit hook (mirrors-clang-format v18.1.0) is the single source of truth for C++ formatting checks
 - License replaced from MIT placeholder to BSD 3-Clause
 - Unsized integers converted to sized types (`int32_t`, `uint32_t`, `size_t`)
 - `CONTRIBUTING.md` rewritten to match current C++20/Conan/just workflow


### PR DESCRIPTION
## Summary

- Removes the redundant `Clang-format check (C++)` step (`just format-check`) from the `lint` job in `.github/workflows/_required.yml`
- The `Run pre-commit hooks` step already runs `mirrors-clang-format v18.1.0` (pinned SHA) on all C++ files via `pre-commit/action`
- The separate `just format-check` step invokes system clang-format, which can be a different version from the pinned v18.1.0 in pre-commit, causing false conflicts where one check passes and the other fails
- Pre-commit hook is the single, deterministic source of truth for C++ formatting in CI

Closes #260

## Test plan

- [ ] Confirm lint job still runs `Run pre-commit hooks` (which includes mirrors-clang-format v18.1.0)
- [ ] Confirm `Clang-format check (C++)` step is no longer present in the lint job
- [ ] Confirm all other lint steps remain unchanged (Ruff, cppcheck, CMake cycle check, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)