### PR TITLE
chore(ci): lower coverage threshold to 75% and make it required

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -775,3 +775,78 @@ jobs:
             exit 1
           fi
           echo "Secret scan passed"
+
+  coverage:
+    name: coverage
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install build dependencies
+        uses: ./.github/actions/install-build-deps
+        with:
+          include-coverage: "true"
+
+      - name: Cache Conan packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.conan2
+          key: conan-${{ runner.os }}-${{ hashFiles('conanfile.py') }}
+          restore-keys: |
+            conan-${{ runner.os }}-
+
+      - name: Cache FetchContent downloads
+        uses: actions/cache@v5
+        with:
+          path: build/x86.debug.coverage/_deps
+          key: fetchcontent-coverage-${{ runner.os }}-${{ hashFiles('CMakeLists.txt') }}
+          restore-keys: |
+            fetchcontent-coverage-${{ runner.os }}-
+
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+
+      - name: Configure sccache
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+          echo "CMAKE_C_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+          echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+
+      - name: Install Conan dependencies
+        run: make deps.native
+
+      - name: Build with coverage
+        run: make compile.debug.coverage.native
+
+      - name: Show sccache stats
+        if: always()
+        run: sccache --show-stats
+
+      - name: Run tests for coverage
+        run: make test.debug.coverage.native
+
+      - name: Generate coverage report
+        run: |
+          chmod +x scripts/generate_coverage.sh
+          BUILD_DIR=build/x86.coverage.debug ./scripts/generate_coverage.sh
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-report
+          path: build/coverage/html/
+          retention-days: 30
+          if-no-files-found: ignore
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: build/coverage/coverage_filtered.info
+          flags: unittests
+          name: codecov-umbrella
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/extras.yml
+++ b/.github/workflows/extras.yml
@@ -1,7 +1,7 @@
 name: Extras (non-blocking)
 
-# Benchmarks and coverage — informational only, not required for merge.
-# These jobs produce build artifacts and Codecov reports but do not block PRs.
+# Benchmarks and NATS integration — informational only, not required for merge.
+# Coverage has moved to _required.yml and is now a blocking check.
 
 on:
   push:
@@ -75,81 +75,6 @@ jobs:
           path: build/reports/benchmarks/
           retention-days: 30
           if-no-files-found: ignore
-
-  coverage:
-    name: coverage
-    runs-on: ubuntu-24.04
-    timeout-minutes: 25
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Install build dependencies
-        uses: ./.github/actions/install-build-deps
-        with:
-          include-coverage: "true"
-
-      - name: Cache Conan packages
-        uses: actions/cache@v5
-        with:
-          path: ~/.conan2
-          key: conan-${{ runner.os }}-${{ hashFiles('conanfile.py') }}
-          restore-keys: |
-            conan-${{ runner.os }}-
-
-      - name: Cache FetchContent downloads
-        uses: actions/cache@v5
-        with:
-          path: build/x86.debug.coverage/_deps
-          key: fetchcontent-coverage-${{ runner.os }}-${{ hashFiles('CMakeLists.txt') }}
-          restore-keys: |
-            fetchcontent-coverage-${{ runner.os }}-
-
-      - name: Set up sccache
-        uses: mozilla-actions/sccache-action@v0.0.10
-
-      - name: Configure sccache
-        run: |
-          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
-          echo "CMAKE_C_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
-          echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
-
-      - name: Install Conan dependencies
-        run: make deps.native
-
-      - name: Build with coverage
-        run: make compile.debug.coverage.native
-
-      - name: Show sccache stats
-        if: always()
-        run: sccache --show-stats
-
-      - name: Run tests for coverage
-        run: make test.debug.coverage.native
-
-      - name: Generate coverage report
-        run: |
-          chmod +x scripts/generate_coverage.sh
-          BUILD_DIR=build/x86.coverage.debug ./scripts/generate_coverage.sh
-
-      - name: Upload coverage report
-        uses: actions/upload-artifact@v7
-        with:
-          name: coverage-report
-          path: build/coverage/html/
-          retention-days: 30
-          if-no-files-found: ignore
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
-        with:
-          files: build/coverage/coverage_filtered.info
-          flags: unittests
-          name: codecov-umbrella
-          fail_ci_if_error: false
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   nats-integration:
     name: NATS integration tests

--- a/scripts/generate_coverage.sh
+++ b/scripts/generate_coverage.sh
@@ -193,13 +193,13 @@ fi
 # Clean up temporary gcov wrapper
 [[ -n "$LLVM_GCOV_WRAPPER" ]] && rm -f "$LLVM_GCOV_WRAPPER"
 
-# Check if coverage meets threshold (80%)
-THRESHOLD=80.0
+# Check if coverage meets threshold (75%)
+THRESHOLD=75.0
 if (( $(echo "$COVERAGE_PERCENT >= $THRESHOLD" | bc -l) )); then
-    echo -e "${GREEN}✓ Coverage meets threshold (≥ 80%)${NC}"
+    echo -e "${GREEN}✓ Coverage meets threshold (≥ 75%)${NC}"
     exit 0
 else
-    echo -e "${YELLOW}⚠ Coverage below threshold (< 80%): $COVERAGE_PERCENT%${NC}"
+    echo -e "${YELLOW}⚠ Coverage below threshold (< 75%): $COVERAGE_PERCENT%${NC}"
     echo -e "${YELLOW}  Target: $THRESHOLD%${NC}"
     exit 1
 fi


### PR DESCRIPTION
## Summary

- **`scripts/generate_coverage.sh`**: threshold 80.0 → 75.0 (current repo-wide coverage is 77.7%, which passes 75% but fails 80%)
- **`.github/workflows/_required.yml`**: add `coverage` job (moved verbatim from `extras.yml`)
- **`.github/workflows/extras.yml`**: remove `coverage` job, update header comment

## Why

Coverage was running in the advisory `Extras (non-blocking)` workflow and silently failing on every PR (including `main`) because the repo is at 77.7% vs the 80% gate. This made the failure invisible and blocked no merges.

Lowering to 75% restores a meaningful but achievable gate. Moving `coverage` into the required workflow means PRs that drop coverage below 75% are blocked.

## After this merges

The branch ruleset needs `coverage` added to `required_status_checks`. Run:
```bash
gh api repos/HomericIntelligence/ProjectKeystone/rulesets/15556488
# then PUT with coverage added to required_status_checks array
```

## Test plan

- [ ] CI passes on this PR (coverage job runs and reports ≥ 75%)
- [ ] `extras.yml` no longer contains a `coverage:` job
- [ ] `_required.yml` `coverage` job matches the former `extras.yml` version exactly
- [ ] Add `coverage` to the branch ruleset after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)