### PR TITLE
fix(ci): pin actions/checkout@v6.0.2 to SHA in _required.yml

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install build dependencies (just + linters)
         uses: ./.github/actions/install-build-deps
@@ -287,7 +287,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install build dependencies
         uses: ./.github/actions/install-build-deps
@@ -375,7 +375,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install build dependencies
         uses: ./.github/actions/install-build-deps
@@ -437,7 +437,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install build dependencies
         uses: ./.github/actions/install-build-deps
@@ -487,7 +487,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -517,7 +517,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -585,7 +585,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -719,7 +719,7 @@ jobs:
 
     steps:
       - name: Checkout code (full history)
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
@@ -843,7 +843,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install build dependencies
         uses: ./.github/actions/install-build-deps


### PR DESCRIPTION
## Summary
- Replaces all 9 unpinned `actions/checkout@v6.0.2` tag references in `.github/workflows/_required.yml` with the full commit SHA `de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2`
- Makes all 13 checkout steps consistently use the pinned SHA format, matching the 4 already-pinned steps
- Eliminates supply-chain risk from mutable tag references in CI

## Test plan
- [ ] Verify CI passes with pinned SHA references
- [ ] Confirm no workflow syntax errors

Closes #532

🤖 Generated with [Claude Code](https://claude.com/claude-code)