### PR TITLE
docs(readme): link GLOSSARY.md from Documentation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,7 @@ See [Architecture Docs](docs/plan/FOUR_LAYER_ARCHITECTURE.md) for details.
 ## Documentation
 
 - [CLAUDE.md](CLAUDE.md) - Project overview for Claude Code
+- [Glossary](docs/GLOSSARY.md) - Terminology and definitions
 - [Four-Layer Architecture](docs/plan/FOUR_LAYER_ARCHITECTURE.md)
 - [TDD Roadmap](docs/plan/TDD_FOUR_LAYER_ROADMAP.md)
 - [Testing Strategy](docs/plan/testing-strategy.md)


### PR DESCRIPTION
## Summary
- Adds a link to `docs/GLOSSARY.md` in the Documentation section of `README.md`
- The glossary was present but undiscoverable — not referenced from README or CLAUDE.md
- Places the link immediately after the CLAUDE.md entry as a high-priority reference document

## Test plan
- [ ] Verify markdownlint passes (valid relative link to existing file)
- [ ] Confirm CI passes

Closes #533

🤖 Generated with [Claude Code](https://claude.com/claude-code)