### PR TITLE
fix(ci): Profiling Tests (Weekly) workflow failing on main

### DIFF
--- a/.github/workflows/profiling-weekly.yml
+++ b/.github/workflows/profiling-weekly.yml
@@ -25,6 +25,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6.0.2
 
+      - name: Install build dependencies
+        uses: ./.github/actions/install-build-deps
+
+      - name: Cache Conan packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.conan2
+          key: conan-${{ runner.os }}-${{ hashFiles('conanfile.py') }}
+          restore-keys: |
+            conan-${{ runner.os }}-
+
       - name: Cache FetchContent downloads
         uses: actions/cache@v5
         with:
@@ -39,27 +50,20 @@ jobs:
       - name: Configure sccache
         run: echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
 
-      - name: Install dependencies
+      - name: Install Conan dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            build-essential \
-            cmake \
-            ninja-build \
-            clang-18 \
-            clang++-18 \
-            libc++-18-dev \
-            libc++abi-18-dev
-          sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-18 100
-          sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-18 100
-          sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang-18 100
-          sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-18 100
+          conan install . \
+            --output-folder=build/conan-deps \
+            --build=missing \
+            -s build_type=Release \
+            -s compiler.cppstd=20
 
       - name: Build with profiling enabled
         run: |
           mkdir -p build/profiling
           cd build/profiling
           cmake -S ../.. -DCMAKE_BUILD_TYPE=Release -DENABLE_PROFILING=ON -G Ninja \
+            -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/build/conan-deps/conan_toolchain.cmake \
             -DCMAKE_C_COMPILER_LAUNCHER=sccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
           ninja profiling_tests


### PR DESCRIPTION
Repairs **Profiling Tests (Weekly)** (run [25620831958](https://github.com/HomericIntelligence/ProjectKeystone/actions/runs/25620831958), persistent across at least the last two weekly runs).

## RC
Tooling/environment. CMake configure failed with:

```
CMake Error at /usr/local/share/cmake-3.31/Modules/FindPackageHandleStandardArgs.cmake:233 (message):
  Could NOT find GTest (missing: GTEST_LIBRARY GTEST_INCLUDE_DIR
  GTEST_MAIN_LIBRARY)
```

`profiling-weekly.yml` installed clang/cmake/ninja but never ran `conan install`. GTest is supplied via Conan (`gtest/1.14.0` in `conanfile.py`) and required by `find_package(GTest REQUIRED)` in `CMakeLists.txt:115`.

## Fix
Adopt the same pattern `_required.yml` uses for every other C++ build job:

- Replace ad-hoc `apt-get install` block with the canonical `./.github/actions/install-build-deps` composite action (installs clang-18, cmake, ninja, AND conan with a detected profile).
- Cache `~/.conan2` keyed on `hashFiles('conanfile.py')`.
- Add a `conan install` step (Release, cppstd=20) before the CMake configure.
- Pass `-DCMAKE_TOOLCHAIN_FILE=build/conan-deps/conan_toolchain.cmake` so `find_package(GTest REQUIRED)` resolves.

Net change: +18 / -14 lines, scoped to `.github/workflows/profiling-weekly.yml` only.

## Test plan
- [ ] Trigger via `workflow_dispatch` after merge and confirm green