### PR TITLE
chore: easy-issue sweep 2026-05-11

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,19 @@ invisible plumbing beneath every other component.
 
 ### Primary Language: C++20
 
-**This project is EXCLUSIVELY C++20. Do NOT use Python, Mojo, or other languages for implementation.**
+**The transport runtime in this project is EXCLUSIVELY C++20. Do NOT use
+Python, Mojo, or other languages for new transport, message-bus, or
+agent-runtime code.**
+
+**Exception — supporting Python tooling.** A small number of Python modules
+remain in `src/keystone/` as a thin orchestration / test harness layer
+(`config.py`, `daemon.py`, `dag_walker.py`, `models.py`, `nats_listener.py`,
+`task_claimer.py`, `validation.py`, `logging.py`). These predate the ADR-015
+extraction to ProjectAgamemnon and are still imported by the Python tests
+under `tests/`. They are maintained in-place but **must not** grow new
+production responsibilities — any new orchestration logic belongs in
+ProjectAgamemnon, and any new transport logic must be implemented in C++20
+under `src/transport/`, `src/network/`, or `include/`.
 
 ### Required Technologies
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -901,8 +901,10 @@ set(CPACK_PACKAGE_VENDOR "ProjectKeystone Development Team")
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY
     "Hierarchical Multi-Agent System (HMAS) in C++20")
 # Version already defined earlier for CMake package config
-set(CPACK_PACKAGE_CONTACT "projectkeystone@example.com")
-set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/projectkeystone/hmas")
+set(CPACK_PACKAGE_CONTACT
+    "ProjectKeystone Maintainers <noreply@homericintelligence.dev>")
+set(CPACK_PACKAGE_HOMEPAGE_URL
+    "https://github.com/HomericIntelligence/ProjectKeystone")
 
 # Resource files
 set(CPACK_RESOURCE_FILE_LICENSE "${PROJECT_SOURCE_DIR}/LICENSE")

--- a/README.md
+++ b/README.md
@@ -78,6 +78,15 @@ cd ProjectKeystone
 
 # Setup environment variables (required for Docker)
 ./scripts/setup-env.sh
+# Writes ./.env with:
+#   GIT_COMMIT  - short SHA of HEAD (or "latest" outside a git checkout),
+#                 baked into image tags so docker compose can pull/build
+#                 reproducible artifacts.
+#   BUILD_UID   - your host UID, mapped into the dev container so files
+#                 written from inside the container are owned by you.
+#   BUILD_GID   - your host GID, same reason.
+# Re-run this whenever you switch branches/commits or change UID/GID.
+# The script writes only ./.env (gitignored); no other system state changes.
 
 # Build and test
 make docker.build

--- a/helm/projectkeystone/values.yaml
+++ b/helm/projectkeystone/values.yaml
@@ -22,7 +22,11 @@ replicaCount: 2
 image:
   repository: projectkeystone
   pullPolicy: IfNotPresent
-  tag: "latest"
+  # Default to the chart's appVersion (Chart.yaml: appVersion: "1.0.0") so
+  # deployments are reproducible and rollbacks are deterministic. Override at
+  # install time with `--set image.tag=<sha-or-semver>` in CI/CD pipelines.
+  # Avoid `latest` here: it breaks rollbacks and cache invalidation.
+  tag: ""
 
 imagePullSecrets: []
 nameOverride: ""

--- a/helm/projectkeystone/values.yaml
+++ b/helm/projectkeystone/values.yaml
@@ -50,8 +50,13 @@ podSecurityContext:
   runAsUser: 1000
   fsGroup: 1000
 
-# Container security context
-securityContext: {}
+# Container security context (production hardening — issue #526)
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
 
 # Service configuration
 service:

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -38,6 +38,14 @@ spec:
           image: projectkeystone:latest
           imagePullPolicy: IfNotPresent
 
+          # Container security hardening (issue #526)
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+
           # Resource limits
           resources:
             requests:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-# Python dependencies for ProjectKeystone
-
-# Test dependencies
-pytest>=7.0
-pytest-asyncio>=0.21

--- a/src/keystone/nats_listener.py
+++ b/src/keystone/nats_listener.py
@@ -46,6 +46,26 @@ class NATSListener:
     def __init__(self, task_claimer: TaskClaimer) -> None:
         self._task_claimer = task_claimer
         self._shutting_down: bool = False
+        self._subscription: Any = None
+
+    async def _dispatch_message(self, msg: Any) -> None:
+        """JetStream subscription callback: parse subject, validate, dispatch.
+
+        Wired into ``js.subscribe(..., cb=self._dispatch_message)`` in
+        :meth:`start` so incoming NATS messages reach :meth:`_on_task_event`
+        instead of being silently dropped (issue #521).
+        """
+        try:
+            team_id, task_id = self._parse_subject(msg.subject)
+        except ValueError as exc:
+            logger.warning(
+                "nats_event_dropped_invalid_subject",
+                extra={"subject": msg.subject, "error": str(exc)},
+            )
+            return
+        await self._on_task_event(
+            msg.subject, team_id, task_id, raw_payload=msg.data
+        )
 
     @property
     def shutting_down(self) -> bool:
@@ -91,7 +111,9 @@ class NATSListener:
 
         for attempt in range(1, max_retries + 1):
             try:
-                await js.subscribe(subject)
+                self._subscription = await js.subscribe(
+                    subject, cb=self._dispatch_message
+                )
                 logger.info(
                     "nats_listener_subscribed",
                     extra={"subject": subject, "stream": stream},
@@ -237,5 +259,37 @@ class NATSListener:
         return parts[2], parts[3]  # team_id, task_id
 
     async def stop(self) -> None:
-        """Drain the NATS connection and release resources."""
+        """Drain in-flight messages and unsubscribe from JetStream (issue #527).
+
+        Must be preceded by :meth:`begin_shutdown` if the caller wants new
+        events that arrive during the drain to be dropped rather than
+        dispatched.
+        """
+        sub = self._subscription
+        self._subscription = None
+        if sub is None:
+            logger.info("nats_listener_stopped", extra={"subscription": "none"})
+            return
+
+        # Drain delivers any in-flight messages to the callback, then
+        # unsubscribes. Fall back to an explicit unsubscribe if drain is
+        # unsupported by the underlying client (older nats-py).
+        try:
+            drain = getattr(sub, "drain", None)
+            if drain is not None:
+                await drain()
+            else:
+                await sub.unsubscribe()
+        except Exception as exc:  # noqa: BLE001 — best-effort shutdown
+            logger.warning(
+                "nats_listener_stop_drain_failed",
+                extra={"error": str(exc)},
+            )
+            try:
+                await sub.unsubscribe()
+            except Exception as inner_exc:  # noqa: BLE001
+                logger.warning(
+                    "nats_listener_stop_unsubscribe_failed",
+                    extra={"error": str(inner_exc)},
+                )
         logger.info("nats_listener_stopped")

--- a/tests/test_nats_listener.py
+++ b/tests/test_nats_listener.py
@@ -167,7 +167,9 @@ class TestStartSubscribeSuccess:
         listener, _ = _make_listener()
         nc = _make_mock_nc()
         await listener.start(nc, "hi.tasks.team-1.>", stream="homeric-tasks")
-        nc.jetstream().subscribe.assert_awaited_once_with("hi.tasks.team-1.>")
+        nc.jetstream().subscribe.assert_awaited_once_with(
+            "hi.tasks.team-1.>", cb=listener._dispatch_message
+        )
 
 
 class TestStartStreamNotFound:


### PR DESCRIPTION
Bundled implementation of EASY audit-finding issues from the 2026-04-28 audit (#504), per the 2026-05-11 ecosystem-wide sweep.

## Closes — implemented

- Closes #530 — `helm/projectkeystone/values.yaml`: change `image.tag` default from `"latest"` to `""` so the existing `_helpers.tpl` `default .Chart.AppVersion` fallback wins; deployments are now reproducible by default.
- Closes #529 — `README.md`: document what `./scripts/setup-env.sh` writes (`GIT_COMMIT`, `BUILD_UID`, `BUILD_GID`) and that its only side effect is creating `./.env`.
- Closes #528 — `CMakeLists.txt:904`: replace placeholder `projectkeystone@example.com` with `ProjectKeystone Maintainers <noreply@homericintelligence.dev>` and update the homepage URL to the canonical `HomericIntelligence/ProjectKeystone` repo.
- Closes #527 — `src/keystone/nats_listener.py`: `stop()` now drains the JetStream subscription (or unsubscribes if drain is unsupported) instead of only logging.
- Closes #526 — `k8s/deployment.yaml` + `helm/projectkeystone/values.yaml`: container `securityContext` now sets `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`, and drops all capabilities.
- Closes #523 — delete `requirements.txt`; the same two test deps (`pytest`, `pytest-asyncio`) are already declared in `pyproject.toml`'s `dev` extras, so the file was redundant.
- Closes #521 — `src/keystone/nats_listener.py`: `start()` now passes `cb=self._dispatch_message` to `js.subscribe`, wiring the previously dead `_on_task_event` handler. Added `_dispatch_message` to parse the subject and invoke the existing validated handler.
- Closes #520 — `CLAUDE.md`: clarify the C++20-only mandate. The transport runtime stays C++20-only; the small Python orchestration layer in `src/keystone/` is documented as a maintained-but-frozen exception (no new responsibilities — those go to ProjectAgamemnon).

## Closes — verified ALREADY-DONE

- Closes #525 — `.github/workflows/extras.yml:69` is now `run: make benchmark.native` (no `|| true`). Removed in #549 (refactor `|| true` workarounds) and reinforced by the forbid-suppressions pre-commit + CI guard introduced in the same PR plus #550.

## Skipped — out of 50-LoC sweep scope

- #524 (Dependabot for FetchContent C++ deps): Dependabot has no native CMake `FetchContent` ecosystem; a real fix needs Renovate config or a custom CVE workflow. Defer to a dedicated PR.
- #522 (`getenv()` in `NatsConfig` constructor): the env-var reads in `NatsTlsConfig::validate()` are intentional today (validate cert/key parity using the *effective* path, env-overridden). Removing them moves env-aware validation from construction to apply-time and risks changing observable behavior for env-only deployments. Needs a small design discussion + cert/key parity tests at apply-time before flipping. Out of sweep scope.

## Notes

- Pre-commit was attempted but the local sandbox lacks `python3.12` (pre-commit env pinned in `.pre-commit-config.yaml`). Local YAML / Python AST sanity checks pass; relying on CI for full validation.
- All commits anchored on `origin/main` (`0c83068`); no unrelated diff.
- Per-issue commits, one logical change each, to make Closes-list verification trivial.