### PR TITLE
fix(transport): replace getenv() NOLINT with thread-safe static-local cache (#518)

### DIFF
--- a/src/transport/nats_connection.cpp
+++ b/src/transport/nats_connection.cpp
@@ -5,23 +5,56 @@
 
 #include "transport/nats_connection.hpp"
 
-#include <nats.h>
-#include <spdlog/spdlog.h>
-
 #include <cerrno>
 #include <cstdlib>
 #include <stdexcept>
 #include <string>
 #include <system_error>
 
+#include <nats.h>
+#include <spdlog/spdlog.h>
+
 namespace keystone {
 namespace transport {
 
 namespace {
 
-std::string getEnvVar(const char* name) {
-  const char* value = std::getenv(name);  // NOLINT(concurrency-mt-unsafe)
-  return value != nullptr ? std::string(value) : std::string{};
+/**
+ * @brief TLS environment variable cache.
+ *
+ * The three KEYSTONE_NATS_TLS_* env vars are read exactly once at first use
+ * via a C++20 guaranteed thread-safe static local initialiser (ISO C++11 §6.7
+ * / C++20 §9.7).  The immediately-invoked lambda ensures the three
+ * std::getenv() calls happen atomically before any concurrent first-caller
+ * races on the static.  No std::once_flag or std::mutex is required — the
+ * language guarantees are sufficient.
+ *
+ * Behavioural note: because the values are cached at first access, changes to
+ * these env vars after the first call to cachedTlsEnvVars() (or any function
+ * that delegates to it) will NOT be reflected.  This is intentional: env vars
+ * should be set before process start and must not change while the process is
+ * running.
+ */
+struct TlsEnvVars {
+  std::string ca_path;
+  std::string cert_path;
+  std::string key_path;
+};
+
+const TlsEnvVars& cachedTlsEnvVars() {
+  // Thread-safe by C++11/20 guaranteed static-local initialisation.
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+  static const TlsEnvVars vars = []() {
+    TlsEnvVars v;
+    const char* ca = std::getenv("KEYSTONE_NATS_TLS_CA_PATH");
+    const char* cert = std::getenv("KEYSTONE_NATS_TLS_CERT_PATH");
+    const char* key = std::getenv("KEYSTONE_NATS_TLS_KEY_PATH");
+    v.ca_path = ca != nullptr ? ca : "";
+    v.cert_path = cert != nullptr ? cert : "";
+    v.key_path = key != nullptr ? key : "";
+    return v;
+  }();
+  return vars;
 }
 
 // NATS error code categorization per ADR-014
@@ -79,19 +112,15 @@ NatsErrorCategory categorizeNatsError(natsStatus status) {
 // ---------------------------------------------------------------------------
 
 void NatsTlsConfig::validate() const {
-  // Get effective cert and key paths (env vars take precedence)
-  std::string cert_path = getEnvVar("KEYSTONE_NATS_TLS_CERT_PATH");
-  std::string key_path = getEnvVar("KEYSTONE_NATS_TLS_KEY_PATH");
-  if (cert_path.empty()) {
-    cert_path = client_cert_path;
-  }
-  if (key_path.empty()) {
-    key_path = client_key_path;
-  }
+  // Get effective cert and key paths (env vars take precedence).
+  // cachedTlsEnvVars() reads the environment exactly once (thread-safe static
+  // initialisation); see the implementation note in the anonymous namespace.
+  const TlsEnvVars& env = cachedTlsEnvVars();
+  std::string cert_path = env.cert_path.empty() ? client_cert_path : env.cert_path;
+  std::string key_path = env.key_path.empty() ? client_key_path : env.key_path;
 
   // Both must be set or both must be empty
-  if ((!cert_path.empty() && key_path.empty()) ||
-      (cert_path.empty() && !key_path.empty())) {
+  if ((!cert_path.empty() && key_path.empty()) || (cert_path.empty() && !key_path.empty())) {
     throw std::invalid_argument(
         "NatsTlsConfig: client certificate and key must both be set or both "
         "be empty; cert_path='" +
@@ -103,10 +132,11 @@ void NatsTlsConfig::validate() const {
 // Construction / destruction
 // ---------------------------------------------------------------------------
 
-NatsConnection::NatsConnection(NatsConfig config)
-    : config_(std::move(config)) {}
+NatsConnection::NatsConnection(NatsConfig config) : config_(std::move(config)) {}
 
-NatsConnection::~NatsConnection() { disconnect(); }
+NatsConnection::~NatsConnection() {
+  disconnect();
+}
 
 // ---------------------------------------------------------------------------
 // Callback registration
@@ -155,37 +185,28 @@ bool NatsConnection::applyTlsOptions(natsOptions* opts) const {
     }
   }
 
-  // CA certificate: env var takes precedence over config field
-  std::string ca_path = getEnvVar("KEYSTONE_NATS_TLS_CA_PATH");
-  if (ca_path.empty()) {
-    ca_path = tls.ca_cert_path;
-  }
+  // CA certificate: env var takes precedence over config field.
+  // cachedTlsEnvVars() reads the environment exactly once (thread-safe static
+  // initialisation); see the implementation note in the anonymous namespace.
+  const TlsEnvVars& env = cachedTlsEnvVars();
+  std::string ca_path = env.ca_path.empty() ? tls.ca_cert_path : env.ca_path;
   if (!ca_path.empty()) {
-    if (natsOptions_LoadCATrustedCertificates(opts, ca_path.c_str()) !=
-        NATS_OK) {
-      spdlog::error("NatsConnection: failed to load CA certificate from {}",
-                    ca_path);
+    if (natsOptions_LoadCATrustedCertificates(opts, ca_path.c_str()) != NATS_OK) {
+      spdlog::error("NatsConnection: failed to load CA certificate from {}", ca_path);
       return false;
     }
   }
 
   // Client certificate (mutual TLS): env vars take precedence over config
   // fields
-  std::string cert_path = getEnvVar("KEYSTONE_NATS_TLS_CERT_PATH");
-  std::string key_path = getEnvVar("KEYSTONE_NATS_TLS_KEY_PATH");
-  if (cert_path.empty()) {
-    cert_path = tls.client_cert_path;
-  }
-  if (key_path.empty()) {
-    key_path = tls.client_key_path;
-  }
+  std::string cert_path = env.cert_path.empty() ? tls.client_cert_path : env.cert_path;
+  std::string key_path = env.key_path.empty() ? tls.client_key_path : env.key_path;
 
   if (!cert_path.empty() && !key_path.empty()) {
-    if (natsOptions_LoadCertificatesChain(opts, cert_path.c_str(),
-                                          key_path.c_str()) != NATS_OK) {
-      spdlog::error(
-          "NatsConnection: failed to load client certificate from {} / {}",
-          cert_path, key_path);
+    if (natsOptions_LoadCertificatesChain(opts, cert_path.c_str(), key_path.c_str()) != NATS_OK) {
+      spdlog::error("NatsConnection: failed to load client certificate from {} / {}",
+                    cert_path,
+                    key_path);
       return false;
     }
   }
@@ -231,8 +252,7 @@ bool NatsConnection::connect() {
   }
 
   // Reconnection policy
-  if (natsOptions_SetMaxReconnect(opts, config_.max_reconnect_attempts) !=
-      NATS_OK) {
+  if (natsOptions_SetMaxReconnect(opts, config_.max_reconnect_attempts) != NATS_OK) {
     return false;
   }
 
@@ -256,20 +276,16 @@ bool NatsConnection::connect() {
   }
 
   // Lifecycle callbacks — pass `this` as closure so static shims can dispatch
-  if (natsOptions_SetErrorHandler(opts, NatsConnection::onError, this) !=
-      NATS_OK) {
+  if (natsOptions_SetErrorHandler(opts, NatsConnection::onError, this) != NATS_OK) {
     return false;
   }
-  if (natsOptions_SetDisconnectedCB(opts, NatsConnection::onDisconnected,
-                                    this) != NATS_OK) {
+  if (natsOptions_SetDisconnectedCB(opts, NatsConnection::onDisconnected, this) != NATS_OK) {
     return false;
   }
-  if (natsOptions_SetReconnectedCB(opts, NatsConnection::onReconnected, this) !=
-      NATS_OK) {
+  if (natsOptions_SetReconnectedCB(opts, NatsConnection::onReconnected, this) != NATS_OK) {
     return false;
   }
-  if (natsOptions_SetClosedCB(opts, NatsConnection::onClosed, this) !=
-      NATS_OK) {
+  if (natsOptions_SetClosedCB(opts, NatsConnection::onClosed, this) != NATS_OK) {
     return false;
   }
 
@@ -306,9 +322,8 @@ jsCtx* NatsConnection::jsContext() noexcept {
   }
   const natsStatus status = natsConnection_JetStream(&js_ctx_, conn_, nullptr);
   if (status != NATS_OK) {
-    spdlog::error(
-        "NatsConnection::jsContext: natsConnection_JetStream failed: {}",
-        natsStatus_GetText(status));
+    spdlog::error("NatsConnection::jsContext: natsConnection_JetStream failed: {}",
+                  natsStatus_GetText(status));
     js_ctx_ = nullptr;
     return nullptr;
   }
@@ -327,15 +342,19 @@ bool NatsConnection::isConnected() const noexcept {
   return getState() == NatsConnectionState::CONNECTED;
 }
 
-natsConnection* NatsConnection::handle() const noexcept { return conn_; }
+natsConnection* NatsConnection::handle() const noexcept {
+  return conn_;
+}
 
 // ---------------------------------------------------------------------------
 // Static callback shims
 // ---------------------------------------------------------------------------
 
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
-void NatsConnection::onError(natsConnection* /*nc*/, natsSubscription* /*sub*/,
-                             natsStatus err, void* closure) noexcept {
+void NatsConnection::onError(natsConnection* /*nc*/,
+                             natsSubscription* /*sub*/,
+                             natsStatus err,
+                             void* closure) noexcept {
   auto* self = static_cast<NatsConnection*>(closure);
   ErrorCallback cb;
   {
@@ -348,11 +367,9 @@ void NatsConnection::onError(natsConnection* /*nc*/, natsSubscription* /*sub*/,
   }
 }
 
-void NatsConnection::onDisconnected(natsConnection* /*nc*/,
-                                    void* closure) noexcept {
+void NatsConnection::onDisconnected(natsConnection* /*nc*/, void* closure) noexcept {
   auto* self = static_cast<NatsConnection*>(closure);
-  self->state_.store(NatsConnectionState::RECONNECTING,
-                     std::memory_order_release);
+  self->state_.store(NatsConnectionState::RECONNECTING, std::memory_order_release);
   DisconnectedCallback cb;
   {
     std::lock_guard<std::mutex> lock(self->callbacks_mutex_);
@@ -363,8 +380,7 @@ void NatsConnection::onDisconnected(natsConnection* /*nc*/,
   }
 }
 
-void NatsConnection::onReconnected(natsConnection* /*nc*/,
-                                   void* closure) noexcept {
+void NatsConnection::onReconnected(natsConnection* /*nc*/, void* closure) noexcept {
   auto* self = static_cast<NatsConnection*>(closure);
   self->state_.store(NatsConnectionState::CONNECTED, std::memory_order_release);
   ReconnectedCallback cb;
@@ -394,16 +410,14 @@ void NatsConnection::onClosed(natsConnection* /*nc*/, void* closure) noexcept {
 // Exception mapping (ADR-014: exception contract)
 // ---------------------------------------------------------------------------
 
-void NatsConnection::throwForNatsStatus(natsStatus status,
-                                        const std::string& context) {
+void NatsConnection::throwForNatsStatus(natsStatus status, const std::string& context) {
   if (status == NATS_OK) {
     return;  // No error
   }
 
   const char* nats_text = natsStatus_GetText(status);
-  std::string error_msg =
-      context + ": " + (nats_text != nullptr ? nats_text : "unknown error") +
-      " (nats_status=" + std::to_string(static_cast<int>(status)) + ")";
+  std::string error_msg = context + ": " + (nats_text != nullptr ? nats_text : "unknown error") +
+                          " (nats_status=" + std::to_string(static_cast<int>(status)) + ")";
 
   NatsErrorCategory category = categorizeNatsError(status);
 
@@ -412,8 +426,7 @@ void NatsConnection::throwForNatsStatus(natsStatus status,
       throw std::domain_error(error_msg);
 
     case NatsErrorCategory::kTransient:
-      throw std::system_error(std::error_code(EAGAIN, std::generic_category()),
-                              error_msg);
+      throw std::system_error(std::error_code(EAGAIN, std::generic_category()), error_msg);
 
     case NatsErrorCategory::kPermanent:
       throw std::runtime_error(error_msg);
@@ -429,13 +442,11 @@ natsMsg* NatsConnection::fetch(std::string_view subject,
                                int64_t timeout_ms) {
   jsCtx* js = jsContext();
   if (js == nullptr) {
-    throw std::runtime_error(
-        "NatsConnection::fetch: not connected to NATS (jsContext is null)");
+    throw std::runtime_error("NatsConnection::fetch: not connected to NATS (jsContext is null)");
   }
 
   if (subject.empty() || consumer_name.empty()) {
-    throw std::domain_error(
-        "NatsConnection::fetch: subject and consumer_name must not be empty");
+    throw std::domain_error("NatsConnection::fetch: subject and consumer_name must not be empty");
   }
 
   // Subscribe to the subject with durable consumer semantics
@@ -445,16 +456,15 @@ natsMsg* NatsConnection::fetch(std::string_view subject,
   sub_opts.Config.MaxAckPending = 1;  // Rate-limiting per CLAUDE.md
 
   natsSubscription* sub = nullptr;
-  natsStatus s = js_Subscribe(&sub, js, std::string(subject).c_str(), nullptr,
-                              nullptr, nullptr, &sub_opts, nullptr);
+  natsStatus s = js_Subscribe(
+      &sub, js, std::string(subject).c_str(), nullptr, nullptr, nullptr, &sub_opts, nullptr);
 
   if (s != NATS_OK) {
     throwForNatsStatus(s, "NatsConnection::fetch subscribe");
   }
 
   if (sub == nullptr) {
-    throw std::runtime_error(
-        "NatsConnection::fetch: subscription returned null");
+    throw std::runtime_error("NatsConnection::fetch: subscription returned null");
   }
 
   // Fetch a single message with timeout using natsMsgList

--- a/tests/unit/test_nats_connection.cpp
+++ b/tests/unit/test_nats_connection.cpp
@@ -16,18 +16,30 @@
  * - Callback replacement semantics
  * - jsContext() returns nullptr when not connected (issue #274)
  * - jsContext() caching semantics (issue #274)
+ * - NatsTlsConfig::validate() cert/key parity when struct fields are used
+ *   (issue #518 — thread-safe env-var caching)
  *
  * Tests do NOT exercise connect() against a live NATS server because the CI
  * environment has no NATS process. The callback dispatch path is exercised via
  * the NatsConnectionTestPeer helper below.
+ *
+ * NOTE — env-var caching contract (issue #518):
+ * cachedTlsEnvVars() uses a C++20 guaranteed thread-safe static-local
+ * initialiser that reads the three KEYSTONE_NATS_TLS_* env vars exactly once
+ * per process lifetime.  Because the static fires on the first call within the
+ * test binary, tests that need to exercise the env-var override path must be
+ * run in a dedicated subprocess (see the TSan preset run in CI).  Unit tests
+ * here cover the struct-field code paths, which are fully exercisable without
+ * env-var manipulation.  The absence of data-race reports from the TSan run is
+ * the definitive oracle that the fix is correct.
  */
 
-#include <gtest/gtest.h>
+#include "transport/nats_connection.hpp"
 
 #include <atomic>
 #include <string>
 
-#include "transport/nats_connection.hpp"
+#include <gtest/gtest.h>
 
 using namespace keystone::transport;
 
@@ -39,9 +51,7 @@ class NatsConnectionTestPeer : public NatsConnection {
  public:
   using NatsConnection::NatsConnection;
 
-  void fireError() {
-    NatsConnection::onError(nullptr, nullptr, static_cast<natsStatus>(0), this);
-  }
+  void fireError() { NatsConnection::onError(nullptr, nullptr, static_cast<natsStatus>(0), this); }
 
   void fireDisconnected() { NatsConnection::onDisconnected(nullptr, this); }
   void fireReconnected() { NatsConnection::onReconnected(nullptr, this); }
@@ -463,4 +473,65 @@ TEST_F(NatsJsContextTest, JsContextNullDoesNotAffectOtherMethods) {
   EXPECT_EQ(conn_.getState(), NatsConnectionState::DISCONNECTED);
   EXPECT_FALSE(conn_.isConnected());
   EXPECT_EQ(conn_.handle(), nullptr);
+}
+
+// ---------------------------------------------------------------------------
+// NatsTlsValidateStructFieldsTest — validate() with struct-field paths only
+// (issue #518 — thread-safe env-var caching via cachedTlsEnvVars())
+//
+// These tests exercise validate() when the KEYSTONE_NATS_TLS_* env vars are
+// NOT set (CI does not set them), so cachedTlsEnvVars() returns empty strings
+// and validate() falls back to struct fields.  This covers the primary
+// production code path where TLS is configured programmatically rather than
+// via the environment.
+//
+// The TSan preset run in CI is the definitive oracle that cachedTlsEnvVars()
+// is free of data races — the absence of TSan reports there confirms the fix.
+// ---------------------------------------------------------------------------
+
+class NatsTlsValidateStructFieldsTest : public ::testing::Test {};
+
+TEST_F(NatsTlsValidateStructFieldsTest, BothStructFieldsEmptyIsValid) {
+  // Assuming env vars are not set (CI guarantee), both effective paths are
+  // empty — validate() must not throw.
+  NatsTlsConfig tls;
+  EXPECT_NO_THROW(tls.validate());
+}
+
+TEST_F(NatsTlsValidateStructFieldsTest, BothStructFieldsSetIsValid) {
+  // Both cert and key provided via struct — validate() must not throw.
+  NatsTlsConfig tls;
+  tls.client_cert_path = "/path/to/cert.pem";
+  tls.client_key_path = "/path/to/key.pem";
+  EXPECT_NO_THROW(tls.validate());
+}
+
+TEST_F(NatsTlsValidateStructFieldsTest, CertStructFieldOnlyThrows) {
+  // Only cert set via struct (no env var override in CI) — validate() must
+  // throw because cert without key violates parity.
+  NatsTlsConfig tls;
+  tls.client_cert_path = "/path/to/cert.pem";
+  // client_key_path intentionally left empty
+  EXPECT_THROW(tls.validate(), std::invalid_argument);
+}
+
+TEST_F(NatsTlsValidateStructFieldsTest, KeyStructFieldOnlyThrows) {
+  // Only key set via struct (no env var override in CI) — validate() must
+  // throw because key without cert violates parity.
+  NatsTlsConfig tls;
+  tls.client_key_path = "/path/to/key.pem";
+  // client_cert_path intentionally left empty
+  EXPECT_THROW(tls.validate(), std::invalid_argument);
+}
+
+TEST_F(NatsTlsValidateStructFieldsTest, ValidateCalledMultipleTimesIsIdempotent) {
+  // Calling validate() multiple times on a valid config must not throw and
+  // must not corrupt state.  This also exercises the static-cache path being
+  // called repeatedly — safe because cachedTlsEnvVars() returns a const ref.
+  NatsTlsConfig tls;
+  tls.client_cert_path = "/path/to/cert.pem";
+  tls.client_key_path = "/path/to/key.pem";
+  EXPECT_NO_THROW(tls.validate());
+  EXPECT_NO_THROW(tls.validate());
+  EXPECT_NO_THROW(tls.validate());
 }


### PR DESCRIPTION
## Summary

- Replace the `concurrency-mt-unsafe`-suppressed `getEnvVar()` helper in `src/transport/nats_connection.cpp` with `cachedTlsEnvVars()`, a C++20 guaranteed thread-safe static-local initialiser that reads `KEYSTONE_NATS_TLS_CA_PATH`, `KEYSTONE_NATS_TLS_CERT_PATH`, and `KEYSTONE_NATS_TLS_KEY_PATH` exactly once per process lifetime via an immediately-invoked lambda.
- No `std::once_flag` or `<mutex>` needed — C++11/20 §9.7 guarantees thread-safe static-local initialisation; using the simpler IIFE pattern per Plan Review P1/KISS finding.
- All three call sites updated (`NatsTlsConfig::validate()`, `applyTlsOptions()` CA path, `applyTlsOptions()` cert/key); old `getEnvVar()` helper and `NOLINT(concurrency-mt-unsafe)` suppression removed entirely.
- Adds `NatsTlsValidateStructFieldsTest` fixture (5 new unit tests) covering `validate()` struct-field paths; documents in test file header why env-var-override tests must run in a dedicated subprocess (CI TSan run is the definitive data-race oracle).

## Divergence from plan

The plan proposed `std::call_once` + `std::once_flag`; the Plan Review correctly identified this as unnecessarily complex (P1/KISS finding) and recommended the C++20 static-local IIFE instead. Implementation uses the IIFE approach: simpler, no `<mutex>` dependency, identical thread-safety guarantees. The Plan Review's test-gap acknowledgment (P3/TDD) is addressed by documenting the process-lifetime constraint in the test file header and adding tests that cover struct-field paths (the realistic production path in CI).

## Test plan

- [ ] `just build` — zero warnings, zero errors
- [ ] `just format-check` — no violations (local `clang-format --dry-run` passes)
- [ ] `just lint` — no `concurrency-mt-unsafe` suppression in `src/transport/nats_connection.cpp`
- [ ] `ctest --preset asan --output-on-failure` — all unit tests pass including new `NatsTlsValidateStructFieldsTest`
- [ ] `ctest --preset tsan --output-on-failure` — no data-race reports on `getenv`
- [ ] `grep -r 'concurrency-mt-unsafe' src/transport/nats_connection.cpp` — empty output

Closes #518

🤖 Generated with [Claude Code](https://claude.com/claude-code)