### PR TITLE
fix(container): ship keystone-server daemon in production stage (#513)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -573,6 +573,10 @@ target_include_directories(
   keystone_transport PUBLIC ${spdlog_INCLUDE_DIRS_RELEASE}
                             ${fmt_INCLUDE_DIRS_RELEASE})
 
+# Daemon — production service binary (issue #513)
+# Must come after keystone_core and keystone_transport are defined.
+add_subdirectory(src/daemon)
+
 # Unit Tests — NATS transport (issue #122)
 add_executable(transport_unit_tests tests/unit/test_nats_connection.cpp)
 

--- a/Containerfile
+++ b/Containerfile
@@ -80,8 +80,8 @@ RUN cmake -S . -B build/release -G Ninja \
         -DCMAKE_TOOLCHAIN_FILE=build/conan-deps/conan_toolchain.cmake \
     && cmake --build build/release
 
-# Stage 2: Runtime environment (smaller image)
-FROM ubuntu:24.04 AS runtime
+# Stage 2: Test runner (runs the built test suites)
+FROM ubuntu:24.04 AS test
 
 # Install only runtime dependencies
 RUN apt-get update && apt-get install -y \
@@ -100,13 +100,15 @@ WORKDIR /app
 CMD ["sh", "-c", "basic_delegation_tests && module_coordination_tests && component_coordination_tests"]
 
 # Stage 3: Production environment (Kubernetes deployment)
+# Ships the Keystone daemon service binary — NOT test executables.
+# See issue #513: the previous version incorrectly packaged test binaries here.
 FROM ubuntu:24.04 AS production
 
-# Install runtime dependencies + Python3 for health checks
+# Install runtime dependencies. wget is used for the healthcheck so that
+# Python3 (a dev tool) is not required in the production image.
 RUN apt-get update && apt-get install -y \
     libstdc++6 \
-    python3 \
-    python3-minimal \
+    wget \
     && rm -rf /var/lib/apt/lists/*
 
 # Create non-root user for security
@@ -115,16 +117,10 @@ RUN groupadd -g 1001 hmas || true && \
     mkdir -p /app && \
     chown -R hmas:hmas /app
 
-# Copy built test executables from builder
-COPY --from=builder /workspace/build/release/bin/basic_delegation_tests /usr/local/bin/
-COPY --from=builder /workspace/build/release/bin/module_coordination_tests /usr/local/bin/
-COPY --from=builder /workspace/build/release/bin/component_coordination_tests /usr/local/bin/
-COPY --from=builder /workspace/build/release/bin/async_delegation_tests /usr/local/bin/
-COPY --from=builder /workspace/build/release/bin/distributed_hierarchy_tests /usr/local/bin/
-
-# Copy server wrapper script
-COPY scripts/hmas-server.sh /usr/local/bin/hmas-server.sh
-RUN chmod +x /usr/local/bin/hmas-server.sh
+# Copy only the production service binary from the builder stage.
+# The keystone_server target sets OUTPUT_NAME "keystone-server" so CMake
+# places it at build/release/bin/keystone-server.
+COPY --from=builder /workspace/build/release/bin/keystone-server /usr/local/bin/keystone-server
 
 # Set working directory
 WORKDIR /app
@@ -135,12 +131,14 @@ USER hmas
 # Expose ports
 EXPOSE 8080 9090 50051
 
-# Health check
+# Health check against the daemon's /v1/health endpoint (port 8080).
+# Uses wget (available in the base image after the apt layer above) so that
+# Python3 is not required in this image.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD python3 -c "import urllib.request; urllib.request.urlopen('http://localhost:8080/v1/health')" || exit 1
+    CMD wget -qO- http://localhost:8080/v1/health || exit 1
 
-# Default command: run HMAS server
-CMD ["/usr/local/bin/hmas-server.sh"]
+# Default command: run the Keystone daemon
+CMD ["/usr/local/bin/keystone-server"]
 
 # Stage 4: Development environment (for iterative development)
 FROM builder AS development

--- a/docker-compose-distributed.yaml
+++ b/docker-compose-distributed.yaml
@@ -9,7 +9,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-      target: runtime
+      target: test
     image: projectkeystone:latest
     container_name: keystone-chief
     command: /app/build/chief_node_main
@@ -37,7 +37,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-      target: runtime
+      target: test
     image: projectkeystone:latest
     container_name: keystone-component-1
     command: /app/build/component_node_main
@@ -71,7 +71,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-      target: runtime
+      target: test
     image: projectkeystone:latest
     container_name: keystone-module-1
     command: /app/build/module_node_main
@@ -107,7 +107,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-      target: runtime
+      target: test
     image: projectkeystone:latest
     container_name: keystone-module-2
     command: /app/build/module_node_main
@@ -143,7 +143,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-      target: runtime
+      target: test
     image: projectkeystone:latest
     container_name: keystone-task-1
     command: /app/build/task_node_main
@@ -180,7 +180,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-      target: runtime
+      target: test
     image: projectkeystone:latest
     container_name: keystone-task-2
     command: /app/build/task_node_main
@@ -217,7 +217,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-      target: runtime
+      target: test
     image: projectkeystone:latest
     container_name: keystone-task-3
     command: /app/build/task_node_main

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   test:
     build:
       context: .
-      target: runtime
+      target: test
     image: projectkeystone:${GIT_COMMIT}-test
     container_name: projectkeystone-test-${GIT_COMMIT}
     environment:

--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -1,0 +1,27 @@
+# Keystone daemon — the production service binary.
+#
+# This target packages the Keystone transport daemon as a deployable binary.
+# It depends on keystone_core (MessageBus, health check), keystone_transport
+# (NatsConnection, NATSListener), and the nats.c library transitively.
+#
+# The daemon is installed to ${CMAKE_INSTALL_BINDIR}/keystone-server as part of
+# the `keystone` component so that `cmake --install` (and the production
+# Containerfile stage) can copy exactly this binary — and nothing else — into
+# the production image.  See issue #513.
+
+add_executable(keystone_server main.cpp)
+
+target_include_directories(
+  keystone_server
+  PRIVATE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)
+
+target_link_libraries(
+  keystone_server
+  PRIVATE keystone_core keystone_transport)
+
+set_target_properties(keystone_server PROPERTIES OUTPUT_NAME "keystone-server")
+
+install(
+  TARGETS keystone_server
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  COMPONENT keystone)

--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -17,7 +17,10 @@ target_include_directories(
 
 target_link_libraries(
   keystone_server
-  PRIVATE keystone_core keystone_transport)
+  # keystone_agents is required: keystone_core's message_bus.cpp references the
+  # typeinfo for keystone::agents::AgentCore (the bus stores AgentCore handles in
+  # its registry), so the daemon binary must resolve those symbols at link time.
+  PRIVATE keystone_core keystone_transport keystone_agents)
 
 set_target_properties(keystone_server PROPERTIES OUTPUT_NAME "keystone-server")
 


### PR DESCRIPTION
## Summary

- The `production` stage (Stage 3) was packaging test executables (`basic_delegation_tests`, etc.) and running a Python-based `hmas-server.sh` wrapper — making the container non-functional as a service and violating POLA
- Added `src/daemon/CMakeLists.txt` with a `keystone_server` target (links `keystone_core` + `keystone_transport`, `OUTPUT_NAME "keystone-server"`, `install()` to `${CMAKE_INSTALL_BINDIR}` in the `keystone` component)
- Wired into build via `add_subdirectory(src/daemon)` in root `CMakeLists.txt` (after `keystone_transport` is defined)
- Stage 3 now copies only `/workspace/build/release/bin/keystone-server`, uses `wget`-based healthcheck against `/v1/health`, and runs `CMD ["/usr/local/bin/keystone-server"]`
- Stage 2 renamed `AS runtime` → `AS test` (accurate name for the test-runner stage)
- Updated `docker-compose.yml` and `docker-compose-distributed.yaml`: `target: runtime` → `target: test`

## Divergence from plan

The Plan Review correctly identified that `src/daemon/main.cpp` had no CMake target. This PR adds the missing `src/daemon/CMakeLists.txt` as the critical prerequisite, then applies the Containerfile and compose-file fixes. The `docker-compose-distributed.yaml` references non-existent executables in its `command:` fields — those are pre-existing and out of scope.

## Verification

Build confirmed locally: produces `build/x86/bin/keystone-server` (11.8 MB ELF64 PIE executable). Test binaries remain present in the test stage; the production stage no longer references them.

Closes #513

🤖 Generated with [Claude Code](https://claude.com/claude-code)