### PR TITLE
test(integration): wire TaskClaimer against in-process Agamemnon stub (#297)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ dev = [
     "pytest-asyncio>=0.23",
     "pytest-cov>=5.0,<7",
     "pytest-timeout>=2.3,<3",
+    "fastapi>=0.100.0",
+    "httpx[asgi]>=0.27.0",
 ]
 
 [tool.pytest.ini_options]
@@ -28,6 +30,7 @@ pythonpath = ["src"]
 asyncio_mode = "auto"
 markers = [
     "timeout: timeout marker for pytest (requires pytest-timeout)",
+    "integration: marks tests as integration tests requiring HTTP stub (no real external services)",
 ]
 
 [tool.coverage.run]

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,1 @@
+# Python package marker for the integration test subdirectory.

--- a/tests/integration/stub_agamemnon.py
+++ b/tests/integration/stub_agamemnon.py
@@ -1,0 +1,89 @@
+"""In-process FastAPI stub simulating the ProjectAgamemnon REST API.
+
+Used exclusively by the integration tests in this package.  No real port
+binding occurs — tests wire an httpx.AsyncClient with ASGITransport so the
+stub runs entirely in-process.
+
+State:
+    The stub tracks which tasks have been claimed via an asyncio.Lock-protected
+    set.  The ``/reset`` endpoint clears all state between test cases.
+
+Endpoints:
+    GET  /teams/{team_id}/tasks
+        Returns the list configured by configure_tasks().
+    POST /teams/{team_id}/tasks/{task_id}/claim
+        First call for (team_id, task_id) → 200 {"claimed": true}
+        Subsequent calls for the same pair  → 409 {"detail": "Task already claimed"}
+    POST /reset
+        Clears claimed-task state and the configured task list.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from fastapi import FastAPI, HTTPException
+
+app: FastAPI = FastAPI()
+
+# ---------------------------------------------------------------------------
+# Mutable in-process state (reset between tests via POST /reset)
+# ---------------------------------------------------------------------------
+
+_claim_lock: asyncio.Lock = asyncio.Lock()
+_claimed_tasks: set[str] = set()
+_configured_tasks: list[dict[str, Any]] = []
+
+
+def configure_tasks(tasks: list[dict[str, Any]]) -> None:
+    """Seed the task list returned by GET /teams/{team_id}/tasks.
+
+    Call this from a test fixture *before* the first HTTP request.
+
+    Args:
+        tasks: List of task dicts (must each have an "id" key).
+    """
+    global _configured_tasks
+    _configured_tasks = list(tasks)
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@app.get("/teams/{team_id}/tasks")
+async def get_tasks(team_id: str) -> list[dict[str, Any]]:
+    """Return all configured tasks for the given team.
+
+    The stub does not filter by team_id — all tasks are returned regardless.
+    Tests that need per-team isolation should configure distinct stubs or reset
+    between calls.
+    """
+    return list(_configured_tasks)
+
+
+@app.post("/teams/{team_id}/tasks/{task_id}/claim")
+async def claim_task(team_id: str, task_id: str) -> dict[str, Any]:
+    """Claim a task.
+
+    The first call for a given (team_id, task_id) pair succeeds (200).
+    Subsequent calls for the same pair return 409 Conflict.
+    """
+    key = f"{team_id}:{task_id}"
+    async with _claim_lock:
+        if key in _claimed_tasks:
+            raise HTTPException(status_code=409, detail="Task already claimed")
+        _claimed_tasks.add(key)
+    return {"claimed": True}
+
+
+@app.post("/reset")
+async def reset() -> dict[str, str]:
+    """Reset all stub state.  Call between test cases to ensure isolation."""
+    global _configured_tasks
+    async with _claim_lock:
+        _claimed_tasks.clear()
+    _configured_tasks = []
+    return {"status": "reset"}

--- a/tests/integration/test_task_claimer_integration.py
+++ b/tests/integration/test_task_claimer_integration.py
@@ -1,0 +1,333 @@
+"""Integration tests: TaskClaimer wired against an in-process ProjectAgamemnon stub.
+
+These tests verify behaviour at the HTTP boundary — not at the unit/mock level:
+
+1. A 409 Conflict from the stub propagates correctly when two independent
+   TaskClaimer instances both attempt to claim the same task.
+2. After a 409, the _advancing set in TaskClaimer is cleaned up (not leaked),
+   so subsequent calls can proceed without deadlock.
+3. The full get_tasks → claim_task → advance_dag lifecycle works end-to-end.
+4. Happy-path single-claimer claim succeeds and returns the claimed task IDs.
+
+Design notes
+------------
+* The coalesce guard in TaskClaimer (``if team_id in self._advancing``) fires
+  *before* any HTTP call is made, so a single TaskClaimer instance will never
+  produce two concurrent HTTP requests for the same team.  To exercise the
+  HTTP-level 409, we create **two independent TaskClaimer instances** that
+  share the same stub — each bypasses the other's guard while still hitting the
+  same claim endpoint.
+* ``AgamemnonAPIError`` is defined here (test layer only) per the architectural
+  constraint in CLAUDE.md that ``src/keystone/`` must not grow new production
+  responsibilities.
+* The ``integration`` marker is registered in ``pyproject.toml``; run with::
+
+    pixi run python -m pytest tests/integration/ -v --override-ini="addopts="
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from keystone.task_claimer import TaskClaimer
+from tests.integration.stub_agamemnon import app as stub_app
+from tests.integration.stub_agamemnon import configure_tasks
+
+pytestmark = pytest.mark.integration
+
+# ---------------------------------------------------------------------------
+# Test-local error hierarchy (intentionally NOT in src/keystone/)
+# ---------------------------------------------------------------------------
+
+
+class AgamemnonError(Exception):
+    """Base class for Agamemnon REST errors."""
+
+
+class AgamemnonAPIError(AgamemnonError):
+    """Raised when the Agamemnon stub returns a non-2xx response.
+
+    Attributes:
+        status_code: HTTP status code returned by the stub.
+        response_body: Raw response text.
+    """
+
+    def __init__(self, status_code: int, response_body: str) -> None:
+        super().__init__(f"Agamemnon API error {status_code}: {response_body}")
+        self.status_code = status_code
+        self.response_body = response_body
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.fixture
+async def async_client() -> httpx.AsyncClient:  # type: ignore[misc]
+    """Yield an httpx.AsyncClient backed by the in-process FastAPI stub.
+
+    Uses ASGITransport — no real TCP port is bound.
+    """
+    transport = httpx.ASGITransport(app=stub_app)  # type: ignore[arg-type]
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://test"
+    ) as client:
+        # Reset stub state before every test
+        await client.post("/reset")
+        yield client
+
+
+def _make_real_get_tasks(
+    client: httpx.AsyncClient,
+    team_id: str,
+) -> Any:
+    """Return an async callable that fetches tasks from the stub for team_id."""
+
+    async def get_tasks(tid: str) -> list[dict[str, Any]]:
+        response = await client.get(f"/teams/{tid}/tasks")
+        response.raise_for_status()
+        return response.json()  # type: ignore[no-any-return]
+
+    return get_tasks
+
+
+def _make_real_claim_task(client: httpx.AsyncClient) -> Any:
+    """Return an async callable that claims a task via the stub.
+
+    Raises:
+        AgamemnonAPIError: If the stub returns a non-2xx status (e.g. 409).
+    """
+
+    async def claim_task(team_id: str, task_id: str) -> bool:
+        response = await client.post(f"/teams/{team_id}/tasks/{task_id}/claim")
+        if response.status_code == 200:
+            return True
+        raise AgamemnonAPIError(response.status_code, response.text)
+
+    return claim_task
+
+
+@pytest.fixture
+async def claimer(async_client: httpx.AsyncClient) -> TaskClaimer:
+    """TaskClaimer wired to the in-process stub — single instance."""
+    return TaskClaimer(
+        get_tasks=_make_real_get_tasks(async_client, "team-1"),
+        claim_task=_make_real_claim_task(async_client),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_get_tasks_returns_real_data(
+    async_client: httpx.AsyncClient,
+) -> None:
+    """GET /teams/{team_id}/tasks returns the stub's configured task list."""
+    configure_tasks([{"id": "t1"}, {"id": "t2"}])
+
+    response = await async_client.get("/teams/team-1/tasks")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, list)
+    assert len(data) == 2
+    ids = {item["id"] for item in data}
+    assert ids == {"t1", "t2"}
+
+
+async def test_single_successful_claim(
+    async_client: httpx.AsyncClient,
+) -> None:
+    """Happy path: a single TaskClaimer claims all available tasks successfully."""
+    configure_tasks([{"id": "t1"}, {"id": "t2"}])
+
+    local_claimer = TaskClaimer(
+        get_tasks=_make_real_get_tasks(async_client, "team-1"),
+        claim_task=_make_real_claim_task(async_client),
+    )
+
+    result = await local_claimer.advance_dag("team-1")
+
+    assert sorted(result) == ["t1", "t2"]
+    # _advancing is cleaned up after the call
+    assert "team-1" not in local_claimer._advancing
+
+
+async def test_concurrent_claim_rejected_at_api_layer(
+    async_client: httpx.AsyncClient,
+) -> None:
+    """409 Conflict propagates from stub when two independent claimers race.
+
+    Two *independent* TaskClaimer instances share the same stub.  Each
+    instance has its own _advancing set, so neither coalesces the other at
+    the Python level.  The stub's claim-deduplication fires instead, and the
+    second claimer receives a 409 → AgamemnonAPIError.
+
+    This verifies criterion 1 from issue #297: the 409 is rejected at the
+    HTTP / API layer, not merely at the Python guard level.
+    """
+    configure_tasks([{"id": "t-race"}])
+
+    # Gate to ensure both claimers start get_tasks roughly simultaneously
+    both_started = asyncio.Event()
+    first_count = 0
+
+    original_get_tasks = _make_real_get_tasks(async_client, "team-1")
+
+    async def gated_get_tasks(team_id: str) -> list[dict[str, Any]]:
+        nonlocal first_count
+        first_count += 1
+        if first_count == 1:
+            # First claimer signals it's inside get_tasks, then waits briefly
+            both_started.set()
+            await asyncio.sleep(0)  # yield to let second claimer start
+        return await original_get_tasks(team_id)
+
+    claimer_a = TaskClaimer(
+        get_tasks=gated_get_tasks,
+        claim_task=_make_real_claim_task(async_client),
+    )
+    claimer_b = TaskClaimer(
+        get_tasks=_make_real_get_tasks(async_client, "team-1"),
+        claim_task=_make_real_claim_task(async_client),
+    )
+
+    results: list[Any] = []
+
+    async def run_a() -> None:
+        try:
+            r = await claimer_a.advance_dag("team-1")
+            results.append(("ok", r))
+        except AgamemnonAPIError as exc:
+            results.append(("err", exc.status_code))
+
+    async def run_b() -> None:
+        # Wait until claimer_a has entered get_tasks, then fire
+        await both_started.wait()
+        try:
+            r = await claimer_b.advance_dag("team-1")
+            results.append(("ok", r))
+        except AgamemnonAPIError as exc:
+            results.append(("err", exc.status_code))
+
+    await asyncio.gather(run_a(), run_b())
+
+    statuses = {r[0] for r in results}
+    assert "ok" in statuses, "At least one claimer should succeed"
+    assert "err" in statuses, "At least one claimer should receive a 409"
+
+    error_codes = [r[1] for r in results if r[0] == "err"]
+    assert all(code == 409 for code in error_codes), (
+        f"Expected 409, got: {error_codes}"
+    )
+
+
+async def test_advance_dag_cleanup_not_discarded_on_409(
+    async_client: httpx.AsyncClient,
+) -> None:
+    """_advancing is cleaned up after a 409 AgamemnonAPIError — no lock leak.
+
+    This verifies criterion 2 from issue #297: error handling in advance_dag
+    does not discard the _advancing cleanup when claim_task raises.
+
+    After the error, a subsequent sequential call for the same team must
+    complete without deadlock.
+    """
+    configure_tasks([{"id": "t-fail"}])
+
+    # Claim the task directly first so the claimer's call produces a 409
+    pre_claim = await async_client.post("/teams/team-1/tasks/t-fail/claim")
+    assert pre_claim.status_code == 200
+
+    local_claimer = TaskClaimer(
+        get_tasks=_make_real_get_tasks(async_client, "team-1"),
+        claim_task=_make_real_claim_task(async_client),
+    )
+
+    with pytest.raises(AgamemnonAPIError) as exc_info:
+        await local_claimer.advance_dag("team-1")
+
+    assert exc_info.value.status_code == 409
+
+    # _advancing must be cleaned up — team-1 must NOT be in the set
+    assert "team-1" not in local_claimer._advancing, (
+        "_advancing was not cleaned up after 409; potential lock leak"
+    )
+
+    # Now free the stub claim state and verify a subsequent call can proceed
+    await async_client.post("/reset")
+    configure_tasks([{"id": "t-retry"}])
+
+    result = await local_claimer.advance_dag("team-1")
+    assert result == ["t-retry"], (
+        "Subsequent advance_dag call deadlocked or failed after 409 cleanup"
+    )
+
+
+async def test_full_lifecycle_get_tasks_claim_advance(
+    async_client: httpx.AsyncClient,
+) -> None:
+    """Full get_tasks → claim_task → advance_dag lifecycle via real HTTP.
+
+    Verifies criterion 3 from issue #297: the end-to-end flow works against
+    a real HTTP transport, not just AsyncMock.
+    """
+    configure_tasks([{"id": "task-a"}, {"id": "task-b"}, {"id": "task-c"}])
+
+    local_claimer = TaskClaimer(
+        get_tasks=_make_real_get_tasks(async_client, "team-x"),
+        claim_task=_make_real_claim_task(async_client),
+    )
+
+    claimed = await local_claimer.advance_dag("team-x")
+
+    assert sorted(claimed) == ["task-a", "task-b", "task-c"]
+
+    # Verify stub state: all three tasks are now claimed
+    for task_id in ["task-a", "task-b", "task-c"]:
+        response = await async_client.post(f"/teams/team-x/tasks/{task_id}/claim")
+        assert response.status_code == 409, (
+            f"Expected task {task_id} to already be claimed in stub"
+        )
+
+
+async def test_advance_dag_tracked_cleanup_after_409(
+    async_client: httpx.AsyncClient,
+) -> None:
+    """advance_dag_tracked in_flight count returns to 0 after a 409 error.
+
+    Ensures the done-callback on the Task cleans up _in_flight even when the
+    task raises.
+    """
+    configure_tasks([{"id": "t-tracked"}])
+
+    # Pre-claim so the claimer gets a 409
+    await async_client.post("/teams/team-1/tasks/t-tracked/claim")
+
+    local_claimer = TaskClaimer(
+        get_tasks=_make_real_get_tasks(async_client, "team-1"),
+        claim_task=_make_real_claim_task(async_client),
+    )
+
+    task = local_claimer.advance_dag_tracked("team-1")
+    assert local_claimer.in_flight_count == 1
+
+    with pytest.raises(AgamemnonAPIError):
+        await task
+
+    assert local_claimer.in_flight_count == 0, (
+        "_in_flight count was not decremented after the tracked task raised"
+    )


### PR DESCRIPTION
## Summary

- Add `tests/integration/stub_agamemnon.py` — in-process FastAPI stub simulating the ProjectAgamemnon REST API (claim-deduplication via asyncio.Lock-protected set, `/reset` endpoint for test isolation)
- Add `tests/integration/test_task_claimer_integration.py` — 6 integration tests covering the full `get_tasks → claim_task → advance_dag` lifecycle against real HTTP (no `AsyncMock` on transport callables)
- Add `fastapi>=0.100.0` and `httpx[asgi]>=0.27.0` to `[project.optional-dependencies].dev`
- Register `integration` pytest marker in `pyproject.toml [tool.pytest.ini_options].markers`

## Plan review divergences applied

- `AgamemnonAPIError` defined in test file only (not `src/keystone/`) — CLAUDE.md prohibits new production responsibilities in `src/keystone/`
- Marker registered in `pyproject.toml`, not `conftest.py` (plan review: conftest marker registration does nothing for pytest)
- Concurrent 409 test uses **two independent TaskClaimer instances** — plan review identified that a single claimer's Python-level coalesce guard fires before HTTP; two instances bypass each other's guard and let the stub's claim-deduplication fire, correctly exercising the API-layer rejection path
- `_advancing` referred to as `set[str]` consistently (plan had wrongly called it a dict)

## Test plan

- [ ] `pixi run python -m pytest tests/integration/ -v --override-ini="addopts="` → 6 passed
- [ ] `pixi run python -m pytest tests/ --ignore=tests/integration/ -v` → existing suite unaffected
- [ ] No `PytestUnknownMarkWarning` for `integration` marker
- [ ] `test_concurrent_claim_rejected_at_api_layer`: one claimer gets `("ok", [...])`, one gets `("err", 409)`
- [ ] `test_advance_dag_cleanup_not_discarded_on_409`: `team-1 not in local_claimer._advancing` after 409, subsequent call succeeds

Closes #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)