### PR TITLE
test(concurrency): re-enable WorkStealingQueue unit tests (#510)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -355,8 +355,7 @@ add_executable(
   concurrency_unit_tests
   tests/unit/test_task.cpp
   tests/unit/test_thread_pool.cpp
-  # DISABLED: Compilation error - private constructor access
-  # tests/unit/test_work_stealing_queue.cpp
+  tests/unit/test_work_stealing_queue.cpp
   tests/unit/test_logger.cpp
   tests/unit/test_pull_or_steal.cpp
   tests/unit/test_work_stealing_scheduler.cpp

--- a/tests/unit/test_work_stealing_queue.cpp
+++ b/tests/unit/test_work_stealing_queue.cpp
@@ -3,14 +3,15 @@
  * @brief Unit tests for WorkStealingQueue
  */
 
-#include <gtest/gtest.h>
+#include "concurrency/logger.hpp"
+#include "concurrency/task.hpp"
+#include "concurrency/work_stealing_queue.hpp"
 
 #include <atomic>
 #include <thread>
 #include <vector>
 
-#include "concurrency/task.hpp"
-#include "concurrency/work_stealing_queue.hpp"
+#include <gtest/gtest.h>
 
 using namespace keystone::concurrency;
 
@@ -194,8 +195,7 @@ TEST(WorkStealingQueueTest, LIFOPopSemantics) {
 
   // Push items in order 1, 2, 3, 4, 5
   for (int i = 1; i <= 5; ++i) {
-    auto item =
-        WorkItem::makeFunction([i, &push_order]() { push_order.push_back(i); });
+    auto item = WorkItem::makeFunction([i, &push_order]() { push_order.push_back(i); });
     queue.push(std::move(item));
   }
 
@@ -203,7 +203,6 @@ TEST(WorkStealingQueueTest, LIFOPopSemantics) {
   std::vector<int> pop_order;
   while (auto item = queue.pop()) {
     if (item->valid()) {
-      int item_value = 0;
       // Extract value from captured lambda (hacky but for test purposes)
       // We'll verify order by comparing with push_order in reverse
       pop_order.push_back(0);  // Placeholder

--- a/tests/unit/test_work_stealing_queue.cpp
+++ b/tests/unit/test_work_stealing_queue.cpp
@@ -223,7 +223,7 @@ TEST(WorkStealingQueueTest, FIFOStealSemantics) {
 
   // Owner pushes items in order 1, 2, 3, 4, 5
   for (int i = 1; i <= 5; ++i) {
-    auto item = WorkItem::makeFunction([i]() {
+    auto item = WorkItem::makeFunction([]() {
       // No-op
     });
     queue.push(std::move(item));


### PR DESCRIPTION
## Summary

- Add missing `#include "concurrency/logger.hpp"` to `tests/unit/test_work_stealing_queue.cpp` — this was the actual root cause of the compilation failure (not \"private constructor access\" as the CMake comment said; `LogContext::setCorrelationId`/`clearCorrelationId` were unresolved symbols)
- Uncomment `tests/unit/test_work_stealing_queue.cpp` in `CMakeLists.txt` (removes the `# DISABLED:` comment block and re-adds the source to `concurrency_unit_tests`)
- Remove dead `item_value` variable in `LIFOPopSemantics` test (was causing `-Werror=unused-variable`)
- Apply `clang-format` to the test file

## Divergence from Plan

Plan stated CMakeLists.txt lines 531–532; actual location was lines 534–535 (off by 3, as the plan review noted). String-match diff was used as instructed. Include ordering after `clang-format` differs from the plan's diff snippet (system headers moved below project headers per `.clang-format` rules) but compiles and passes cleanly.

## Verification

All 16 `WorkStealingQueueTest.*` cases pass in the debug build:
- `CorrelationIDPropagation` ✓
- `CorrelationIDPropagationOnSteal` ✓
- All concurrent / work-stealing tests ✓

Pre-existing failures (`_NOT_BUILT` targets, `BackoffPhaseProgression`) are unrelated to this change.

Closes #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)