### PR TITLE
refactor(transport): replace raw natsMsg* with NatsMsgPtr RAII in fetch() (#514)

### DIFF
--- a/include/transport/nats_connection.hpp
+++ b/include/transport/nats_connection.hpp
@@ -14,17 +14,39 @@
 
 #pragma once
 
-#include <nats.h>
-
 #include <atomic>
 #include <chrono>
 #include <cstdint>
 #include <functional>
+#include <memory>
 #include <mutex>
 #include <string>
 
+#include <nats.h>
+
 namespace keystone {
 namespace transport {
+
+/**
+ * @brief RAII owner for a nats.c message.
+ *
+ * Wraps a raw natsMsg* with a custom deleter so that ownership is explicit and
+ * compiler-enforced.  The deleter is natsMsg_Destroy, which nats.c requires the
+ * caller to invoke after processing a message.
+ *
+ * A null NatsMsgPtr (constructed with nullptr) is valid and represents the
+ * "no message" (timeout) case returned by NatsConnection::fetch().
+ *
+ * Example:
+ * @code
+ * NatsMsgPtr msg = conn.fetch("hi.tasks.>", "my-consumer", 5000);
+ * if (msg) {
+ *   natsMsg_Ack(msg.get(), nullptr);
+ *   // msg is destroyed automatically when it goes out of scope
+ * }
+ * @endcode
+ */
+using NatsMsgPtr = std::unique_ptr<natsMsg, decltype(&natsMsg_Destroy)>;
 
 /**
  * @brief NATS connection state observable by health checks
@@ -253,15 +275,19 @@ class NatsConnection {
    * - Provides backpressure: slow consumer simply stops fetching
    * - Timeout allows periodic wakeup for graceful shutdown checks
    *
+   * Ownership is transferred to the caller via NatsMsgPtr.  The caller does
+   * NOT need to call natsMsg_Destroy() — the unique_ptr destructor handles
+   * cleanup automatically.  A null NatsMsgPtr (i.e. !msg) indicates that the
+   * fetch timed out and no message is available; this is normal, not an error.
+   *
    * @param subject       Subject pattern to subscribe to (e.g., "hi.tasks.>")
    * @param consumer_name Durable consumer name (e.g., "my-myrmidon")
    * @param timeout_ms    Fetch timeout in milliseconds (default 30000)
-   * @return              Non-null natsMsg* on success; caller owns it and must
-   *                      call natsMsg_Destroy()
+   * @return              NatsMsgPtr owning the fetched message, or a null
+   *                      NatsMsgPtr on timeout.  Ownership is transferred via
+   *                      NatsMsgPtr; the caller must NOT call natsMsg_Destroy().
    *
-   * @throws std::system_error if fetch times out (timeout is normal, not an
-   * error)
-   * @throws std::system_error if network error occurs (transient)
+   * @throws std::system_error if a network error occurs (transient)
    * @throws std::domain_error if consumer or stream not found (configuration)
    * @throws std::runtime_error if authentication or authorization failure
    *
@@ -272,8 +298,9 @@ class NatsConnection {
    * - std::system_error: Transient errors (network, timeout)
    * - std::runtime_error: Permanent errors (auth, permission denied)
    */
-  natsMsg* fetch(std::string_view subject, std::string_view consumer_name,
-                 int64_t timeout_ms = 30000);
+  NatsMsgPtr fetch(std::string_view subject,
+                   std::string_view consumer_name,
+                   int64_t timeout_ms = 30000);
 
   // =========================================================================
   // Exception mapping utility (exposed for testing, not part of public API)
@@ -297,7 +324,9 @@ class NatsConnection {
   // nats.c static callback shims — nats.c passes a void* user data pointer
   // which we cast back to NatsConnection*. Protected to allow test subclasses
   // to invoke them directly without a live nats.c connection.
-  static void onError(natsConnection* nc, natsSubscription* sub, natsStatus err,
+  static void onError(natsConnection* nc,
+                      natsSubscription* sub,
+                      natsStatus err,
                       void* closure) noexcept;
   static void onDisconnected(natsConnection* nc, void* closure) noexcept;
   static void onReconnected(natsConnection* nc, void* closure) noexcept;

--- a/src/transport/nats_connection.cpp
+++ b/src/transport/nats_connection.cpp
@@ -5,14 +5,15 @@
 
 #include "transport/nats_connection.hpp"
 
-#include <nats.h>
-#include <spdlog/spdlog.h>
-
 #include <cerrno>
 #include <cstdlib>
+#include <memory>
 #include <stdexcept>
 #include <string>
 #include <system_error>
+
+#include <nats.h>
+#include <spdlog/spdlog.h>
 
 namespace keystone {
 namespace transport {
@@ -90,8 +91,7 @@ void NatsTlsConfig::validate() const {
   }
 
   // Both must be set or both must be empty
-  if ((!cert_path.empty() && key_path.empty()) ||
-      (cert_path.empty() && !key_path.empty())) {
+  if ((!cert_path.empty() && key_path.empty()) || (cert_path.empty() && !key_path.empty())) {
     throw std::invalid_argument(
         "NatsTlsConfig: client certificate and key must both be set or both "
         "be empty; cert_path='" +
@@ -103,10 +103,11 @@ void NatsTlsConfig::validate() const {
 // Construction / destruction
 // ---------------------------------------------------------------------------
 
-NatsConnection::NatsConnection(NatsConfig config)
-    : config_(std::move(config)) {}
+NatsConnection::NatsConnection(NatsConfig config) : config_(std::move(config)) {}
 
-NatsConnection::~NatsConnection() { disconnect(); }
+NatsConnection::~NatsConnection() {
+  disconnect();
+}
 
 // ---------------------------------------------------------------------------
 // Callback registration
@@ -161,10 +162,8 @@ bool NatsConnection::applyTlsOptions(natsOptions* opts) const {
     ca_path = tls.ca_cert_path;
   }
   if (!ca_path.empty()) {
-    if (natsOptions_LoadCATrustedCertificates(opts, ca_path.c_str()) !=
-        NATS_OK) {
-      spdlog::error("NatsConnection: failed to load CA certificate from {}",
-                    ca_path);
+    if (natsOptions_LoadCATrustedCertificates(opts, ca_path.c_str()) != NATS_OK) {
+      spdlog::error("NatsConnection: failed to load CA certificate from {}", ca_path);
       return false;
     }
   }
@@ -181,11 +180,10 @@ bool NatsConnection::applyTlsOptions(natsOptions* opts) const {
   }
 
   if (!cert_path.empty() && !key_path.empty()) {
-    if (natsOptions_LoadCertificatesChain(opts, cert_path.c_str(),
-                                          key_path.c_str()) != NATS_OK) {
-      spdlog::error(
-          "NatsConnection: failed to load client certificate from {} / {}",
-          cert_path, key_path);
+    if (natsOptions_LoadCertificatesChain(opts, cert_path.c_str(), key_path.c_str()) != NATS_OK) {
+      spdlog::error("NatsConnection: failed to load client certificate from {} / {}",
+                    cert_path,
+                    key_path);
       return false;
     }
   }
@@ -231,8 +229,7 @@ bool NatsConnection::connect() {
   }
 
   // Reconnection policy
-  if (natsOptions_SetMaxReconnect(opts, config_.max_reconnect_attempts) !=
-      NATS_OK) {
+  if (natsOptions_SetMaxReconnect(opts, config_.max_reconnect_attempts) != NATS_OK) {
     return false;
   }
 
@@ -256,20 +253,16 @@ bool NatsConnection::connect() {
   }
 
   // Lifecycle callbacks — pass `this` as closure so static shims can dispatch
-  if (natsOptions_SetErrorHandler(opts, NatsConnection::onError, this) !=
-      NATS_OK) {
+  if (natsOptions_SetErrorHandler(opts, NatsConnection::onError, this) != NATS_OK) {
     return false;
   }
-  if (natsOptions_SetDisconnectedCB(opts, NatsConnection::onDisconnected,
-                                    this) != NATS_OK) {
+  if (natsOptions_SetDisconnectedCB(opts, NatsConnection::onDisconnected, this) != NATS_OK) {
     return false;
   }
-  if (natsOptions_SetReconnectedCB(opts, NatsConnection::onReconnected, this) !=
-      NATS_OK) {
+  if (natsOptions_SetReconnectedCB(opts, NatsConnection::onReconnected, this) != NATS_OK) {
     return false;
   }
-  if (natsOptions_SetClosedCB(opts, NatsConnection::onClosed, this) !=
-      NATS_OK) {
+  if (natsOptions_SetClosedCB(opts, NatsConnection::onClosed, this) != NATS_OK) {
     return false;
   }
 
@@ -306,9 +299,8 @@ jsCtx* NatsConnection::jsContext() noexcept {
   }
   const natsStatus status = natsConnection_JetStream(&js_ctx_, conn_, nullptr);
   if (status != NATS_OK) {
-    spdlog::error(
-        "NatsConnection::jsContext: natsConnection_JetStream failed: {}",
-        natsStatus_GetText(status));
+    spdlog::error("NatsConnection::jsContext: natsConnection_JetStream failed: {}",
+                  natsStatus_GetText(status));
     js_ctx_ = nullptr;
     return nullptr;
   }
@@ -327,15 +319,19 @@ bool NatsConnection::isConnected() const noexcept {
   return getState() == NatsConnectionState::CONNECTED;
 }
 
-natsConnection* NatsConnection::handle() const noexcept { return conn_; }
+natsConnection* NatsConnection::handle() const noexcept {
+  return conn_;
+}
 
 // ---------------------------------------------------------------------------
 // Static callback shims
 // ---------------------------------------------------------------------------
 
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
-void NatsConnection::onError(natsConnection* /*nc*/, natsSubscription* /*sub*/,
-                             natsStatus err, void* closure) noexcept {
+void NatsConnection::onError(natsConnection* /*nc*/,
+                             natsSubscription* /*sub*/,
+                             natsStatus err,
+                             void* closure) noexcept {
   auto* self = static_cast<NatsConnection*>(closure);
   ErrorCallback cb;
   {
@@ -348,11 +344,9 @@ void NatsConnection::onError(natsConnection* /*nc*/, natsSubscription* /*sub*/,
   }
 }
 
-void NatsConnection::onDisconnected(natsConnection* /*nc*/,
-                                    void* closure) noexcept {
+void NatsConnection::onDisconnected(natsConnection* /*nc*/, void* closure) noexcept {
   auto* self = static_cast<NatsConnection*>(closure);
-  self->state_.store(NatsConnectionState::RECONNECTING,
-                     std::memory_order_release);
+  self->state_.store(NatsConnectionState::RECONNECTING, std::memory_order_release);
   DisconnectedCallback cb;
   {
     std::lock_guard<std::mutex> lock(self->callbacks_mutex_);
@@ -363,8 +357,7 @@ void NatsConnection::onDisconnected(natsConnection* /*nc*/,
   }
 }
 
-void NatsConnection::onReconnected(natsConnection* /*nc*/,
-                                   void* closure) noexcept {
+void NatsConnection::onReconnected(natsConnection* /*nc*/, void* closure) noexcept {
   auto* self = static_cast<NatsConnection*>(closure);
   self->state_.store(NatsConnectionState::CONNECTED, std::memory_order_release);
   ReconnectedCallback cb;
@@ -394,16 +387,14 @@ void NatsConnection::onClosed(natsConnection* /*nc*/, void* closure) noexcept {
 // Exception mapping (ADR-014: exception contract)
 // ---------------------------------------------------------------------------
 
-void NatsConnection::throwForNatsStatus(natsStatus status,
-                                        const std::string& context) {
+void NatsConnection::throwForNatsStatus(natsStatus status, const std::string& context) {
   if (status == NATS_OK) {
     return;  // No error
   }
 
   const char* nats_text = natsStatus_GetText(status);
-  std::string error_msg =
-      context + ": " + (nats_text != nullptr ? nats_text : "unknown error") +
-      " (nats_status=" + std::to_string(static_cast<int>(status)) + ")";
+  std::string error_msg = context + ": " + (nats_text != nullptr ? nats_text : "unknown error") +
+                          " (nats_status=" + std::to_string(static_cast<int>(status)) + ")";
 
   NatsErrorCategory category = categorizeNatsError(status);
 
@@ -412,8 +403,7 @@ void NatsConnection::throwForNatsStatus(natsStatus status,
       throw std::domain_error(error_msg);
 
     case NatsErrorCategory::kTransient:
-      throw std::system_error(std::error_code(EAGAIN, std::generic_category()),
-                              error_msg);
+      throw std::system_error(std::error_code(EAGAIN, std::generic_category()), error_msg);
 
     case NatsErrorCategory::kPermanent:
       throw std::runtime_error(error_msg);
@@ -424,18 +414,16 @@ void NatsConnection::throwForNatsStatus(natsStatus status,
 // Pull-based fetch for durable consumers (rate-limiting pattern)
 // ---------------------------------------------------------------------------
 
-natsMsg* NatsConnection::fetch(std::string_view subject,
-                               std::string_view consumer_name,
-                               int64_t timeout_ms) {
+NatsMsgPtr NatsConnection::fetch(std::string_view subject,
+                                 std::string_view consumer_name,
+                                 int64_t timeout_ms) {
   jsCtx* js = jsContext();
   if (js == nullptr) {
-    throw std::runtime_error(
-        "NatsConnection::fetch: not connected to NATS (jsContext is null)");
+    throw std::runtime_error("NatsConnection::fetch: not connected to NATS (jsContext is null)");
   }
 
   if (subject.empty() || consumer_name.empty()) {
-    throw std::domain_error(
-        "NatsConnection::fetch: subject and consumer_name must not be empty");
+    throw std::domain_error("NatsConnection::fetch: subject and consumer_name must not be empty");
   }
 
   // Subscribe to the subject with durable consumer semantics
@@ -445,16 +433,15 @@ natsMsg* NatsConnection::fetch(std::string_view subject,
   sub_opts.Config.MaxAckPending = 1;  // Rate-limiting per CLAUDE.md
 
   natsSubscription* sub = nullptr;
-  natsStatus s = js_Subscribe(&sub, js, std::string(subject).c_str(), nullptr,
-                              nullptr, nullptr, &sub_opts, nullptr);
+  natsStatus s = js_Subscribe(
+      &sub, js, std::string(subject).c_str(), nullptr, nullptr, nullptr, &sub_opts, nullptr);
 
   if (s != NATS_OK) {
     throwForNatsStatus(s, "NatsConnection::fetch subscribe");
   }
 
   if (sub == nullptr) {
-    throw std::runtime_error(
-        "NatsConnection::fetch: subscription returned null");
+    throw std::runtime_error("NatsConnection::fetch: subscription returned null");
   }
 
   // Fetch a single message with timeout using natsMsgList
@@ -468,20 +455,21 @@ natsMsg* NatsConnection::fetch(std::string_view subject,
 
   if (s != NATS_OK) {
     // NATS_TIMEOUT is not an error in fetch semantics — it's normal when
-    // no message is available. Return nullptr instead of throwing.
+    // no message is available. Return a null NatsMsgPtr instead of throwing.
     if (s == NATS_TIMEOUT) {
-      return nullptr;
+      return NatsMsgPtr{nullptr, &natsMsg_Destroy};
     }
     throwForNatsStatus(s, "NatsConnection::fetch");
   }
 
   if (list.Count == 0 || list.Msgs == nullptr) {
-    return nullptr;
+    return NatsMsgPtr{nullptr, &natsMsg_Destroy};
   }
 
-  // Return the first (and only) message; caller takes ownership.
+  // Transfer ownership to the caller via NatsMsgPtr.  The unique_ptr destructor
+  // will call natsMsg_Destroy() automatically; the caller must NOT call it.
   // Remaining entries in list (none, since batch=1) would be destroyed here.
-  natsMsg* msg = list.Msgs[0];
+  NatsMsgPtr msg{list.Msgs[0], &natsMsg_Destroy};
   list.Msgs[0] = nullptr;
   list.Count = 0;
   natsMsgList_Destroy(&list);

--- a/tests/unit/test_nats_connection.cpp
+++ b/tests/unit/test_nats_connection.cpp
@@ -16,18 +16,21 @@
  * - Callback replacement semantics
  * - jsContext() returns nullptr when not connected (issue #274)
  * - jsContext() caching semantics (issue #274)
+ * - NatsMsgPtr ownership contract for fetch() (issue #514)
  *
  * Tests do NOT exercise connect() against a live NATS server because the CI
  * environment has no NATS process. The callback dispatch path is exercised via
  * the NatsConnectionTestPeer helper below.
  */
 
-#include <gtest/gtest.h>
+#include "transport/nats_connection.hpp"
 
 #include <atomic>
+#include <memory>
 #include <string>
+#include <type_traits>
 
-#include "transport/nats_connection.hpp"
+#include <gtest/gtest.h>
 
 using namespace keystone::transport;
 
@@ -39,9 +42,7 @@ class NatsConnectionTestPeer : public NatsConnection {
  public:
   using NatsConnection::NatsConnection;
 
-  void fireError() {
-    NatsConnection::onError(nullptr, nullptr, static_cast<natsStatus>(0), this);
-  }
+  void fireError() { NatsConnection::onError(nullptr, nullptr, static_cast<natsStatus>(0), this); }
 
   void fireDisconnected() { NatsConnection::onDisconnected(nullptr, this); }
   void fireReconnected() { NatsConnection::onReconnected(nullptr, this); }
@@ -463,4 +464,66 @@ TEST_F(NatsJsContextTest, JsContextNullDoesNotAffectOtherMethods) {
   EXPECT_EQ(conn_.getState(), NatsConnectionState::DISCONNECTED);
   EXPECT_FALSE(conn_.isConnected());
   EXPECT_EQ(conn_.handle(), nullptr);
+}
+
+// ---------------------------------------------------------------------------
+// NatsFetchOwnershipTest — NatsMsgPtr type alias and ownership contract
+// (issue #514)
+//
+// These tests validate the fetch() return type contract without a live NATS
+// server.  They confirm:
+//   1. NatsMsgPtr is a unique_ptr<natsMsg, …> (type-trait / static_assert).
+//   2. A null NatsMsgPtr (the timeout / no-message path) is constructible,
+//      usable, and does not crash on destruction.
+//   3. Calling fetch() on an unconnected NatsConnection throws
+//      std::runtime_error.
+//   4. Calling fetch() with empty arguments throws std::runtime_error before
+//      reaching the domain-error guard (because "not connected" fires first).
+// ---------------------------------------------------------------------------
+
+class NatsFetchOwnershipTest : public ::testing::Test {
+ protected:
+  NatsConnectionTestPeer conn_;  // never connected — jsContext() returns nullptr
+};
+
+// --- Static type check -------------------------------------------------
+
+// NatsMsgPtr must be a specialisation of std::unique_ptr whose element type is
+// natsMsg and whose deleter is a function pointer (not a stateful object).
+static_assert(std::is_same_v<NatsMsgPtr, std::unique_ptr<natsMsg, decltype(&natsMsg_Destroy)>>,
+              "NatsMsgPtr must be unique_ptr<natsMsg, decltype(&natsMsg_Destroy)>");
+
+// --- Runtime tests ------------------------------------------------------
+
+TEST_F(NatsFetchOwnershipTest, NullNatsMsgPtrIsValidAndDestructsCleanly) {
+  // Simulates the timeout return path of fetch(): a null NatsMsgPtr must
+  // construct, evaluate to false, expose a null .get(), and destruct without
+  // crashing or invoking natsMsg_Destroy on a null pointer.
+  NatsMsgPtr p{nullptr, &natsMsg_Destroy};
+
+  EXPECT_EQ(p.get(), nullptr);
+  EXPECT_FALSE(static_cast<bool>(p));
+  // Destructor is called here — must not crash.
+}
+
+TEST_F(NatsFetchOwnershipTest, NullNatsMsgPtrResetIsNoOp) {
+  // Verify that explicitly resetting a null NatsMsgPtr is also safe (models
+  // early-exit patterns in message-loop code that calls msg.reset()).
+  NatsMsgPtr p{nullptr, &natsMsg_Destroy};
+  EXPECT_NO_THROW(p.reset());
+  EXPECT_EQ(p.get(), nullptr);
+}
+
+TEST_F(NatsFetchOwnershipTest, FetchThrowsRuntimeErrorWhenNotConnected) {
+  // fetch() must throw std::runtime_error when jsContext() returns nullptr
+  // (i.e., the connection was never established).  This confirms the guard
+  // at the top of the implementation is intact after the RAII refactor.
+  EXPECT_THROW(conn_.fetch("hi.tasks.>", "my-consumer", 5000), std::runtime_error);
+}
+
+TEST_F(NatsFetchOwnershipTest, FetchThrowsRuntimeErrorBeforeDomainCheck) {
+  // The "not connected" guard must fire before the "empty arguments" guard so
+  // that callers always get a runtime_error (not domain_error) on an
+  // unconnected instance, even when arguments are empty.
+  EXPECT_THROW(conn_.fetch("", "", 0), std::runtime_error);
 }


### PR DESCRIPTION
## Summary

- Add `NatsMsgPtr` type alias (`std::unique_ptr<natsMsg, decltype(&natsMsg_Destroy)>`) in `nats_connection.hpp` — one definition site for the deleter, reusable by all callsites
- Change `NatsConnection::fetch()` return type from `natsMsg*` to `NatsMsgPtr`; all three return paths (timeout, empty list, success) wrap the pointer in `NatsMsgPtr` — no manual `natsMsg_Destroy()` call is ever needed at callsites
- Update `fetch()` doc comment to describe the `NatsMsgPtr` ownership contract (removes the old "caller must call `natsMsg_Destroy()`" sentence)
- Add `NatsFetchOwnershipTest` fixture (4 tests) covering: null `NatsMsgPtr` construction/destruction safety, `reset()` safety, and the two exception-throw paths; a `static_assert` verifies the type alias at compile time

**Plan review divergence:** The original plan proposed also modifying `nats_listener.{hpp,cpp}`. Per the plan review (which correctly identified P2/YAGNI: those files call `natsSubscription_Fetch` directly and never use `NatsConnection::fetch()`), those changes are excluded from this PR.

## Test plan

- [ ] `cmake --build build/conan-deps --target unit_tests` compiles without errors
- [ ] `./build/conan-deps/bin/unit_tests --gtest_filter="NatsFetch*"` — 4 new tests pass
- [ ] `./build/conan-deps/bin/unit_tests --gtest_filter="NatsConnection*:NatsConfig*:NatsTls*:NatsCallback*:NatsState*:NatsJs*"` — 42 pre-existing tests pass (no regressions)
- [ ] `clang-format --dry-run --Werror` passes on the 3 changed files
- [ ] `grep -r "natsMsg_Destroy" src/transport/nats_connection.cpp` — appears only in `NatsMsgPtr{...}` constructor calls, never as a standalone call
- [ ] Sanitizer build (`cmake --preset asan && ctest --preset asan`) — requires dev container (network unavailable in this environment; CI will verify)

Closes #514

🤖 Generated with [Claude Code](https://claude.com/claude-code)