### PR TITLE
fix(logger): thread-safe Logger::init() — stop concurrent spdlog double-registration abort

### DIFF
--- a/include/concurrency/logger.hpp
+++ b/include/concurrency/logger.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <spdlog/fmt/fmt.h>
-#include <spdlog/sinks/stdout_color_sinks.h>
-#include <spdlog/spdlog.h>
-
 #include <memory>
 #include <string>
 #include <thread>
+
+#include <spdlog/fmt/fmt.h>
+#include <spdlog/sinks/stdout_color_sinks.h>
+#include <spdlog/spdlog.h>
 
 namespace keystone {
 namespace concurrency {
@@ -44,8 +44,7 @@ class LogContext {
    * @param worker_id Worker thread index
    * @param session_id Session identifier
    */
-  static void set(const std::string& agent_id, int32_t worker_id,
-                  const std::string& session_id);
+  static void set(const std::string& agent_id, int32_t worker_id, const std::string& session_id);
 
   /**
    * @brief Clear the thread-local logging context (including correlation ID)
@@ -237,8 +236,10 @@ class Logger {
   static std::shared_ptr<spdlog::logger> logger_;
 
   template <typename... Args>
-  static void log(spdlog::level::level_enum level, const std::string& fmt,
-                  Args&&... args) {
+  static void log(spdlog::level::level_enum level, const std::string& fmt, Args&&... args) {
+    // init() is idempotent and thread-safe (guarded by an internal mutex), so a
+    // racing first-log from multiple threads creates the "keystone" logger
+    // exactly once instead of throwing spdlog_ex on the loser of the race.
     if (!logger_) {
       init();
     }
@@ -248,8 +249,7 @@ class Logger {
     std::string full_fmt = context + " " + fmt;
 
     // Use runtime format to avoid compile-time format string requirement
-    logger_->log(spdlog::source_loc{}, level, fmt::runtime(full_fmt),
-                 std::forward<Args>(args)...);
+    logger_->log(spdlog::source_loc{}, level, fmt::runtime(full_fmt), std::forward<Args>(args)...);
   }
 };
 

--- a/src/concurrency/logger.cpp
+++ b/src/concurrency/logger.cpp
@@ -5,10 +5,11 @@
 
 #include "concurrency/logger.hpp"
 
-#include <spdlog/sinks/stdout_color_sinks.h>
-
+#include <mutex>
 #include <random>
 #include <sstream>
+
+#include <spdlog/sinks/stdout_color_sinks.h>
 
 namespace keystone {
 namespace concurrency {
@@ -31,8 +32,14 @@ std::string generateCorrelationId() {
   c = (c & 0x3FFFFFFFu) | 0x80000000u;  // variant 10xx
 
   char buf[37];
-  std::snprintf(buf, sizeof(buf), "%08x-%04x-%04x-%04x-%04x%08x", a,
-                (b >> 16) & 0xFFFF, b & 0xFFFF, (c >> 16) & 0xFFFF, c & 0xFFFF,
+  std::snprintf(buf,
+                sizeof(buf),
+                "%08x-%04x-%04x-%04x-%04x%08x",
+                a,
+                (b >> 16) & 0xFFFF,
+                b & 0xFFFF,
+                (c >> 16) & 0xFFFF,
+                c & 0xFFFF,
                 d);
   return std::string(buf);
 }
@@ -40,7 +47,8 @@ std::string generateCorrelationId() {
 // LogContext thread-local storage
 thread_local LogContext::Context LogContext::context_;
 
-void LogContext::set(const std::string& agent_id, int32_t worker_id,
+void LogContext::set(const std::string& agent_id,
+                     int32_t worker_id,
                      const std::string& session_id) {
   context_.agent_id = agent_id;
   context_.worker_id = worker_id;
@@ -54,19 +62,29 @@ void LogContext::clear() {
   context_.correlation_id.clear();
 }
 
-std::string LogContext::getAgentId() { return context_.agent_id; }
+std::string LogContext::getAgentId() {
+  return context_.agent_id;
+}
 
-int32_t LogContext::getWorkerId() { return context_.worker_id; }
+int32_t LogContext::getWorkerId() {
+  return context_.worker_id;
+}
 
-std::string LogContext::getSessionId() { return context_.session_id; }
+std::string LogContext::getSessionId() {
+  return context_.session_id;
+}
 
 void LogContext::setCorrelationId(const std::string& correlation_id) {
   context_.correlation_id = correlation_id;
 }
 
-void LogContext::clearCorrelationId() { context_.correlation_id.clear(); }
+void LogContext::clearCorrelationId() {
+  context_.correlation_id.clear();
+}
 
-std::string LogContext::getCorrelationId() { return context_.correlation_id; }
+std::string LogContext::getCorrelationId() {
+  return context_.correlation_id;
+}
 
 std::string LogContext::getContextString() {
   if (context_.agent_id.empty()) {
@@ -74,8 +92,7 @@ std::string LogContext::getContextString() {
   }
 
   std::ostringstream oss;
-  oss << "[" << context_.agent_id << ":" << context_.worker_id << ":"
-      << context_.session_id;
+  oss << "[" << context_.agent_id << ":" << context_.worker_id << ":" << context_.session_id;
   if (!context_.correlation_id.empty()) {
     oss << ":corr=" << context_.correlation_id;
   }
@@ -85,12 +102,10 @@ std::string LogContext::getContextString() {
 
 // CorrelationScope
 
-CorrelationScope::CorrelationScope()
-    : CorrelationScope(generateCorrelationId()) {}
+CorrelationScope::CorrelationScope() : CorrelationScope(generateCorrelationId()) {}
 
 CorrelationScope::CorrelationScope(std::string correlation_id)
-    : previous_id_(LogContext::getCorrelationId()),
-      current_id_(std::move(correlation_id)) {
+    : previous_id_(LogContext::getCorrelationId()), current_id_(std::move(correlation_id)) {
   LogContext::setCorrelationId(current_id_);
 }
 
@@ -101,15 +116,38 @@ CorrelationScope::~CorrelationScope() {
 // Logger static members
 std::shared_ptr<spdlog::logger> Logger::logger_;
 
+namespace {
+// Guards the check-then-act in init()/log(). Without it, two threads can both
+// observe a null logger_, both call spdlog::stdout_color_mt("keystone"), and the
+// second throws spdlog::spdlog_ex("logger with name 'keystone' already exists").
+// That exception is thrown from worker threads (e.g. the backpressure warning
+// path in AgentCore::receiveMessage), is never caught there, and terminates the
+// process. The -O0 --coverage build widens the race window enough to reproduce
+// it deterministically (see AgentCoreTest.BackpressureConcurrentTrigger).
+std::mutex& loggerInitMutex() {
+  static std::mutex m;
+  return m;
+}
+}  // namespace
+
 void Logger::init(spdlog::level::level_enum level) {
+  std::lock_guard<std::mutex> lock(loggerInitMutex());
+  if (logger_) {
+    return;
+  }
+  // Reuse an already-registered "keystone" logger if one exists (e.g. a prior
+  // init()/shutdown() cycle left it in the registry) instead of re-creating it,
+  // which would throw. spdlog::get() returns nullptr when absent.
+  logger_ = spdlog::get("keystone");
   if (!logger_) {
     logger_ = spdlog::stdout_color_mt("keystone");
-    logger_->set_level(level);
-    logger_->set_pattern("[%Y-%m-%d %H:%M:%S.%e] [%^%l%$] %v");
   }
+  logger_->set_level(level);
+  logger_->set_pattern("[%Y-%m-%d %H:%M:%S.%e] [%^%l%$] %v");
 }
 
 void Logger::shutdown() {
+  std::lock_guard<std::mutex> lock(loggerInitMutex());
   if (logger_) {
     spdlog::drop("keystone");
     logger_.reset();


### PR DESCRIPTION
## Problem

`AgentCoreTest.BackpressureConcurrentTrigger` aborts under the `-O0 --coverage` CI build:

```
terminate called after throwing an instance of 'spdlog::spdlog_ex'
  what():  logger with name 'keystone' already exists
167/685 Test #76: AgentCoreTest.BackpressureConcurrentTrigger ... Subprocess aborted
```

This is **not a flaky test** — it is a real check-then-act data race in `Logger`.

## Root cause

`Logger::log()` (header) does `if (!logger_) init();` and `Logger::init()` did
`if (!logger_) logger_ = spdlog::stdout_color_mt("keystone");` with no synchronization.
When concurrent producer threads first hit the backpressure warning path in
`AgentCore::receiveMessage()`, two threads both observe a null `logger_`, both call
`spdlog::stdout_color_mt("keystone")`, and the second throws `spdlog_ex`. The throw
escapes a worker thread uncaught → `std::terminate()` → aborted subprocess. The coverage
build's wider race window makes it deterministic. PR #559 only relaxed the test's tolerance
bound; it never addressed the abort.

## Fix

- Guard `init()` / `shutdown()` with a function-local `std::mutex` so the `keystone`
  logger is created exactly once.
- Defensively reuse an already-registered logger via `spdlog::get("keystone")` before
  creating one, so an `init()/shutdown()/init()` cycle can never throw.

No behavior change for single-threaded `init()` callers; the concurrent first-log path
is now safe.

## Verification

- `clang-format` clean.
- The fix directly removes the only path that can throw `spdlog_ex` in `init()`, which
  is the documented abort cause. CI (coverage + TSan) validates end-to-end.

This unblocks PR #571 (#512 TransparentBridge), whose only failing check was this abort.