### PR TITLE
refactor(core): decouple MessageBus from agents via IMessageSink

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -437,6 +437,7 @@ endif()
 add_executable(
   unit_tests
   tests/unit/test_message_bus.cpp
+  tests/unit/test_message_sink.cpp # Part A: transport decoupled from agents
   tests/unit/test_message_serializer.cpp
   # DISABLED: Async API not yet implemented
   # tests/unit/test_message_bus_async.cpp

--- a/include/agents/agent_core.hpp
+++ b/include/agents/agent_core.hpp
@@ -10,6 +10,7 @@
 #include "concurrentqueue.h"
 #include "core/config.hpp"  // FIX m3: Centralized configuration
 #include "core/message.hpp"
+#include "core/message_sink.hpp"  // Transport-facing sink interface
 
 namespace keystone {
 
@@ -41,7 +42,7 @@ namespace agents {
  * Phase C Enhancement: Uses lock-free concurrent queue for inbox
  * to eliminate contention under high message load.
  */
-class AgentCore {
+class AgentCore : public core::IMessageSink {
  public:
   /**
    * @brief Construct a new Agent Core
@@ -67,7 +68,7 @@ class AgentCore {
    *
    * @param msg Message to receive
    */
-  virtual void receiveMessage(const core::KeystoneMessage& msg);
+  void receiveMessage(const core::KeystoneMessage& msg) override;
 
   /**
    * @brief Get the next message from inbox

--- a/include/core/i_agent_registry.hpp
+++ b/include/core/i_agent_registry.hpp
@@ -1,17 +1,11 @@
 #pragma once
 
+#include <concepts>
 #include <memory>
 #include <string>
 #include <vector>
 
-// Forward declarations
-namespace keystone {
-namespace agents {
-class AgentCore;
-}
-}  // namespace keystone
-
-#include "agents/concepts.hpp"
+#include "core/message_sink.hpp"
 
 namespace keystone {
 namespace core {
@@ -46,7 +40,7 @@ class IAgentRegistry {
    * @throws std::runtime_error if agent_id already registered
    */
   virtual void registerAgent(const std::string& agent_id,
-                             std::shared_ptr<agents::AgentCore> agent) = 0;
+                             std::shared_ptr<IMessageSink> agent) = 0;
 
   /**
    * @brief Register an agent with compile-time interface verification
@@ -54,11 +48,16 @@ class IAgentRegistry {
    * Template method using C++20 concepts to verify at compile time
    * that the agent implements the required Agent interface.
    *
-   * @tparam A Agent type satisfying the Agent concept
+   * @tparam A Agent type exposing getAgentId() and convertible to IMessageSink
    * @param agent Shared pointer to the agent
    * @throws std::runtime_error if agent_id already registered
    */
-  template <agents::Agent A>
+  template <typename A>
+    requires requires(const A& a) {
+      { a.getAgentId() } -> std::convertible_to<std::string>;
+      requires std::convertible_to<std::shared_ptr<A>,
+                                   std::shared_ptr<IMessageSink>>;
+    }
   void registerAgent(std::shared_ptr<A> agent) {
     if (!agent) {
       throw std::runtime_error(
@@ -66,8 +65,8 @@ class IAgentRegistry {
     }
 
     std::string agent_id = agent->getAgentId();
-    std::shared_ptr<agents::AgentCore> base_agent = agent;
-    registerAgent(agent_id, base_agent);
+    std::shared_ptr<IMessageSink> sink = agent;
+    registerAgent(agent_id, sink);
   }
 
   /**

--- a/include/core/message_bus.hpp
+++ b/include/core/message_bus.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <atomic>
+#include <concepts>
 #include <cstddef>
 #include <functional>
 #include <memory>
@@ -15,21 +16,14 @@
 #include "i_message_router.hpp"
 #include "i_scheduler_integration.hpp"
 #include "message.hpp"
+#include "message_sink.hpp"
 
 // Forward declarations (must be outside namespace keystone to avoid nesting)
-namespace keystone {
-namespace agents {
-class AgentCore;
-}
-}  // namespace keystone
 namespace keystone {
 namespace concurrency {
 class WorkStealingScheduler;
 }
 }  // namespace keystone
-
-// Include concepts for compile-time agent interface verification
-#include "agents/concepts.hpp"
 
 namespace keystone {
 namespace core {
@@ -99,7 +93,7 @@ class MessageBus : public IAgentRegistry,
    * @throws std::runtime_error if agent_id already registered
    */
   void registerAgent(const std::string& agent_id,
-                     std::shared_ptr<agents::AgentCore> agent) override;
+                     std::shared_ptr<IMessageSink> agent) override;
 
   /**
    * @brief Register an agent with compile-time interface verification (Issue
@@ -124,11 +118,16 @@ class MessageBus : public IAgentRegistry,
    * bus.registerAgent(agent);  // Compile error if interface incomplete
    * @endcode
    *
-   * @tparam A Agent type satisfying the Agent concept
+   * @tparam A Agent type exposing getAgentId() and convertible to IMessageSink
    * @param agent Shared pointer to the agent
    * @throws std::runtime_error if agent_id already registered
    */
-  template <agents::Agent A>
+  template <typename A>
+    requires requires(const A& a) {
+      { a.getAgentId() } -> std::convertible_to<std::string>;
+      requires std::convertible_to<std::shared_ptr<A>,
+                                   std::shared_ptr<IMessageSink>>;
+    }
   void registerAgent(std::shared_ptr<A> agent) {
     if (!agent) {
       throw std::runtime_error("MessageBus::registerAgent: null agent pointer");
@@ -137,11 +136,11 @@ class MessageBus : public IAgentRegistry,
     // Use the agent's ID
     std::string agent_id = agent->getAgentId();
 
-    // Convert to AgentCore pointer for storage
-    std::shared_ptr<agents::AgentCore> base_agent = agent;
+    // Upcast to the transport-facing sink interface for storage.
+    std::shared_ptr<IMessageSink> sink = agent;
 
     // Delegate to the existing implementation
-    registerAgent(agent_id, base_agent);
+    registerAgent(agent_id, sink);
   }
 
   /**
@@ -220,7 +219,7 @@ class MessageBus : public IAgentRegistry,
 
   // FIX C2: Use shared_ptr for safe lifetime management in async scenarios
   // Phase A2: Registry now uses integer IDs (interned from string IDs)
-  std::unordered_map<uint32_t, std::shared_ptr<agents::AgentCore>> agents_;
+  std::unordered_map<uint32_t, std::shared_ptr<IMessageSink>> agents_;
 
   // FIX C5: Atomic scheduler pointer for thread-safe access without
   // registry_mutex

--- a/include/core/message_sink.hpp
+++ b/include/core/message_sink.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "core/message.hpp"
+
+namespace keystone {
+namespace core {
+
+/**
+ * @brief Minimal transport-facing interface for any entity that can receive a
+ *        message.
+ *
+ * This is the single point of contact the transport core (MessageBus,
+ * IAgentRegistry) requires from a delivery target. By depending on this
+ * one-method abstraction instead of the concrete agents::AgentCore, the
+ * transport core no longer depends on the agents layer at all.
+ *
+ * AgentCore implements this interface, so existing agents register and receive
+ * messages exactly as before. Any non-agent sink (test stubs, bridges, future
+ * non-agent consumers) can also be registered on a MessageBus without the
+ * transport core depending on the concrete agent type.
+ *
+ * Prerequisite root-fix for the ADR-015/016 agent + Python removal: deletion
+ * PRs were stalling because the core still referenced the agent layer.
+ */
+class IMessageSink {
+ public:
+  virtual ~IMessageSink() = default;
+
+  /**
+   * @brief Receive a message destined for this sink.
+   *
+   * Signature must match agents::AgentCore::receiveMessage exactly so AgentCore
+   * can override it.
+   *
+   * @param msg Message to deliver to this sink.
+   */
+  virtual void receiveMessage(const KeystoneMessage& msg) = 0;
+};
+
+}  // namespace core
+}  // namespace keystone

--- a/src/core/message_bus.cpp
+++ b/src/core/message_bus.cpp
@@ -1,6 +1,5 @@
 #include "core/message_bus.hpp"
 
-#include "agents/agent_core.hpp"
 #include "concurrency/work_stealing_scheduler.hpp"
 #include "core/message_serializer.hpp"
 #include "core/metrics.hpp"
@@ -22,7 +21,7 @@ concurrency::WorkStealingScheduler* MessageBus::getScheduler() const {
 }
 
 void MessageBus::registerAgent(const std::string& agent_id,
-                               std::shared_ptr<agents::AgentCore> agent) {
+                               std::shared_ptr<IMessageSink> agent) {
   // FIX C2: Use shared_ptr for safe lifetime management
   if (!agent) {
     throw std::invalid_argument("Cannot register null agent");
@@ -71,7 +70,7 @@ bool MessageBus::routeMessage(const KeystoneMessage& msg) {
   // Issue #512: nats_publisher_ captured under its own mutex for off-host
   // forwarding.
   // Phase A2: Use integer ID for O(1) lookup
-  std::shared_ptr<agents::AgentCore> agent;
+  std::shared_ptr<IMessageSink> agent;
 
   {
     std::lock_guard<std::mutex> lock(registry_mutex_);

--- a/tests/mocks/mock_interfaces.hpp
+++ b/tests/mocks/mock_interfaces.hpp
@@ -13,9 +13,6 @@
 
 // Forward declarations
 namespace keystone {
-namespace agents {
-class AgentCore;
-}
 namespace concurrency {
 class WorkStealingScheduler;
 }
@@ -36,7 +33,7 @@ class MockAgentRegistry : public core::IAgentRegistry {
 
   MOCK_METHOD(void, registerAgent,
               (const std::string& agent_id,
-               std::shared_ptr<agents::AgentCore> agent),
+               std::shared_ptr<core::IMessageSink> agent),
               (override));
 
   MOCK_METHOD(void, unregisterAgent, (const std::string& agent_id), (override));
@@ -95,7 +92,7 @@ class MockMessageBus : public core::IAgentRegistry,
   // IAgentRegistry interface
   MOCK_METHOD(void, registerAgent,
               (const std::string& agent_id,
-               std::shared_ptr<agents::AgentCore> agent),
+               std::shared_ptr<core::IMessageSink> agent),
               (override));
 
   MOCK_METHOD(void, unregisterAgent, (const std::string& agent_id), (override));

--- a/tests/mocks/mock_message_bus.hpp
+++ b/tests/mocks/mock_message_bus.hpp
@@ -16,7 +16,8 @@ namespace keystone::test {
 class MockAgentRegistry : public core::IAgentRegistry {
  public:
   MOCK_METHOD(void, registerAgent,
-              (const std::string& id, std::shared_ptr<agents::AgentCore> agent),
+              (const std::string& id,
+               std::shared_ptr<core::IMessageSink> agent),
               (override));
   MOCK_METHOD(void, unregisterAgent, (const std::string& id), (override));
   MOCK_METHOD(bool, hasAgent, (const std::string& id), (const, override));

--- a/tests/unit/test_message_sink.cpp
+++ b/tests/unit/test_message_sink.cpp
@@ -1,0 +1,87 @@
+/**
+ * @file test_message_sink.cpp
+ * @brief Decoupling test: MessageBus routes to a NON-agent IMessageSink.
+ *
+ * Part A of the "Keystone pure transport" effort: the transport core
+ * (MessageBus / IAgentRegistry) no longer depends on agents::AgentCore. It only
+ * depends on core::IMessageSink (a single receiveMessage method).
+ *
+ * This test deliberately uses NO agent types. It defines a minimal StubSink
+ * that implements core::IMessageSink, registers it on a MessageBus, routes a
+ * message, and asserts delivery. This proves transport works with an arbitrary
+ * non-agent sink and exercises the decoupled path end-to-end.
+ */
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "core/message.hpp"
+#include "core/message_bus.hpp"
+#include "core/message_sink.hpp"
+
+using namespace keystone::core;
+
+namespace {
+
+/**
+ * @brief Minimal non-agent message sink for transport decoupling tests.
+ *
+ * Implements only the IMessageSink contract. It is intentionally NOT an agent:
+ * no inbox, no lifecycle, no scheduler, no children. If this compiles and
+ * routes, the transport core is fully decoupled from the agent layer.
+ */
+struct StubSink : public IMessageSink {
+  std::vector<KeystoneMessage> got;
+  void receiveMessage(const KeystoneMessage& msg) override {
+    got.push_back(msg);
+  }
+};
+
+}  // namespace
+
+/**
+ * @brief Route a message to a registered non-agent IMessageSink (sync path).
+ */
+TEST(MessageSink, RoutesToNonAgentSink) {
+  MessageBus bus;
+  auto sink = std::make_shared<StubSink>();
+
+  // Register the bare sink via the IAgentRegistry interface (no agent type).
+  EXPECT_NO_THROW(bus.registerAgent("stub_sink", sink));
+  EXPECT_TRUE(bus.hasAgent("stub_sink"));
+
+  auto msg = KeystoneMessage::create("sender", "stub_sink", "ping");
+  EXPECT_TRUE(bus.routeMessage(msg));
+
+  ASSERT_EQ(sink->got.size(), 1u);
+  EXPECT_EQ(sink->got[0].sender_id, "sender");
+  EXPECT_EQ(sink->got[0].receiver_id, "stub_sink");
+}
+
+/**
+ * @brief Routing to an unregistered receiver returns false (no sink involved).
+ */
+TEST(MessageSink, RouteToUnregisteredReturnsFalse) {
+  MessageBus bus;
+  auto msg = KeystoneMessage::create("sender", "absent", "ping");
+  EXPECT_FALSE(bus.routeMessage(msg));
+}
+
+/**
+ * @brief Unregistering a non-agent sink stops delivery.
+ */
+TEST(MessageSink, UnregisterStopsDelivery) {
+  MessageBus bus;
+  auto sink = std::make_shared<StubSink>();
+
+  bus.registerAgent("stub_sink", sink);
+  bus.unregisterAgent("stub_sink");
+  EXPECT_FALSE(bus.hasAgent("stub_sink"));
+
+  auto msg = KeystoneMessage::create("sender", "stub_sink", "ping");
+  EXPECT_FALSE(bus.routeMessage(msg));
+  EXPECT_TRUE(sink->got.empty());
+}


### PR DESCRIPTION
## Part A — decouple the transport core from the concrete agent type

The transport core (`MessageBus`, `IAgentRegistry`) depended on `agents::AgentCore`, but used exactly **one** method of it: `receiveMessage(const KeystoneMessage&)`. That single dependency forced `include/core` + `src/core` to `#include "agents/..."` headers and was the **root cause stalling the ADR-015/016 agent + Python removal** — deletion PRs kept failing because the core still referenced `agents/`.

### Changes
- **New `core::IMessageSink`** (`include/core/message_sink.hpp`): a header-only, one-method interface — `virtual void receiveMessage(const KeystoneMessage&) = 0;` — matching `AgentCore::receiveMessage` exactly. This is the only contract the transport core needs from a delivery target.
- **`MessageBus` + `IAgentRegistry`** now register and store `std::shared_ptr<core::IMessageSink>` instead of `std::shared_ptr<agents::AgentCore>`. The templated `registerAgent(agent)` convenience overload is now constrained on `getAgentId()` + convertibility to `IMessageSink` (inline `requires`), so the headers no longer include `agents/concepts.hpp`.
- **`src/core/message_bus.cpp`** no longer includes `agents/agent_core.hpp`; the `agent->receiveMessage(msg)` async + sync delivery paths compile unchanged against `IMessageSink`.
- **`agents::AgentCore`** now publicly inherits `core::IMessageSink` (its existing `receiveMessage` becomes an `override`). **Agent behavior is unchanged**; all agents remain registrable exactly as before.
- **Test mocks** (`tests/mocks/mock_message_bus.hpp`, `tests/mocks/mock_interfaces.hpp`) updated to the new `IMessageSink` `registerAgent` signature.

### Result
- `grep -rn 'agents/' include/core src/core` → **zero real references** (only a pre-existing, unrelated example file-path in an `error_sanitizer` doc comment remains).
- `keystone_core` still links only `keystone_concurrency` — never `keystone_agents`.

### Tests
- Adds **`tests/unit/test_message_sink.cpp`**: a non-agent `StubSink : core::IMessageSink` is registered on a `MessageBus`, a message is routed, and delivery is asserted — proving transport works with a **non-agent** sink and exercising the decoupled path directly.
- Existing `MessageBus.*`, `AgentConcepts.*`, agent, bridge, and registry-integration tests all still pass (333 passed / 0 failed / 5 profiling skips in `unit_tests`; 70 agent; 9 bridge; 19 registry-integration).

This is the **prerequisite root-fix** for the ADR-015/016 agent + Python removal (#505).

🤖 Generated with [Claude Code](https://claude.com/claude-code)