### PR TITLE
refactor(core): slim KeystoneMessage to pure transport fields (#515)

### DIFF
--- a/include/core/message.hpp
+++ b/include/core/message.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <chrono>
-#include <map>
 #include <optional>
 #include <string>
 
@@ -37,18 +36,14 @@ inline std::string priorityToString(Priority priority) {
 }
 
 /**
- * @brief Action types for agent communication in HMAS
+ * @brief Action types carried by a transport message
  *
- * Defines the different types of actions that can be requested or performed
- * in the hierarchical agent system.
+ * Defines the transport-level action semantics that a message may carry.
  */
 enum class ActionType {
-  DECOMPOSE,      ///< Decompose a goal into subtasks/subgoals
   EXECUTE,        ///< Execute a concrete task or command
   RETURN_RESULT,  ///< Return the result of a computation
-  SHUTDOWN,       ///< Graceful shutdown signal
-  CANCEL_TASK,    ///< Cancel a running task (Issue #52)
-  TASK_FAILED     ///< Report task failure to parent agent (Issue #87)
+  SHUTDOWN        ///< Graceful shutdown signal
 };
 
 /**
@@ -66,18 +61,12 @@ enum class ContentType {
  */
 inline std::string actionTypeToString(ActionType type) {
   switch (type) {
-    case ActionType::DECOMPOSE:
-      return "DECOMPOSE";
     case ActionType::EXECUTE:
       return "EXECUTE";
     case ActionType::RETURN_RESULT:
       return "RETURN_RESULT";
     case ActionType::SHUTDOWN:
       return "SHUTDOWN";
-    case ActionType::CANCEL_TASK:
-      return "CANCEL_TASK";
-    case ActionType::TASK_FAILED:
-      return "TASK_FAILED";
     default:
       return "UNKNOWN";
   }
@@ -100,17 +89,11 @@ inline std::string contentTypeToString(ContentType type) {
 /**
  * @brief Keystone Interchange Message (KIM) protocol
  *
- * Enhanced message structure for work-stealing concurrent agent communication.
- * Messages are passed between agents to delegate tasks and return results.
+ * Pure transport message structure for routing payloads between endpoints.
  *
- * Phase A additions:
+ * Fields:
  * - action_type: Semantic action classification
  * - content_type: Payload format specification
- * - session_id: Context isolation for concurrent operations
- * - metadata: Extensible key-value attributes
- *
- * Phase 1.2 (Issue #52) additions:
- * - task_id: Optional task identifier for cancellation tracking
  */
 struct KeystoneMessage {
   // Core identifiers
@@ -118,11 +101,9 @@ struct KeystoneMessage {
   std::string sender_id;    ///< ID of the sending agent
   std::string receiver_id;  ///< ID of the receiving agent
 
-  // Phase A: Enhanced fields
+  // Enhanced fields
   ActionType action_type;    ///< Type of action requested/performed
   ContentType content_type;  ///< Format of the payload
-  std::string session_id;    ///< Session/context identifier
-  std::map<std::string, std::string> metadata;  ///< Extensible metadata
 
   // Phase C: Priority field
   Priority priority;  ///< Message priority (HIGH/NORMAL/LOW)
@@ -130,10 +111,6 @@ struct KeystoneMessage {
   // Phase C: Deadline scheduling
   std::optional<std::chrono::system_clock::time_point>
       deadline;  ///< Optional processing deadline
-
-  // Phase 1.2 (Issue #52): Task cancellation
-  std::optional<std::string>
-      task_id;  ///< Optional task ID for tracking/cancellation
 
   // Issue #285: Cross-host tracing
   std::optional<std::string>
@@ -179,14 +156,12 @@ struct KeystoneMessage {
    * @param sender Sender agent ID
    * @param receiver Receiver agent ID
    * @param action Action type
-   * @param session Session identifier
    * @param data Optional payload data
    * @param content Content type (default: TEXT_PLAIN)
    * @return KeystoneMessage New message with auto-generated ID
    */
   static KeystoneMessage create(
       const std::string& sender, const std::string& receiver, ActionType action,
-      const std::string& session,
       const std::optional<std::string>& data = std::nullopt,
       ContentType content = ContentType::TEXT_PLAIN);
 
@@ -210,23 +185,6 @@ struct KeystoneMessage {
    * @return milliseconds until deadline, nullopt if no deadline set
    */
   std::optional<std::chrono::milliseconds> getTimeUntilDeadline() const;
-
-  /**
-   * @brief Create a task cancellation message
-   *
-   * Phase 1.2 (Issue #52): Factory method for creating CANCEL_TASK messages.
-   * Cancellation is cooperative - agents check for cancellation and respond
-   * gracefully.
-   *
-   * @param sender Sender agent ID (parent requesting cancellation)
-   * @param receiver Receiver agent ID (child executing the task)
-   * @param task_id Task identifier to cancel
-   * @param session Session identifier (default: "default")
-   * @return KeystoneMessage Cancellation message with CANCEL_TASK action
-   */
-  static KeystoneMessage createCancellation(
-      const std::string& sender, const std::string& receiver,
-      const std::string& task_id, const std::string& session = "default");
 };
 
 /**

--- a/include/core/message_serializer.hpp
+++ b/include/core/message_serializer.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cista/containers.h>
-#include <cista/containers/hash_map.h>
 #include <cista/serialization.h>
 
 #include <cstdint>
@@ -25,9 +24,6 @@ struct SerializableMessage {
 
   uint32_t action_type;   // Serialized as uint32_t
   uint32_t content_type;  // Serialized as uint32_t
-  cista::offset::string session_id;
-  cista::offset::hash_map<cista::offset::string, cista::offset::string>
-      metadata;
 
   cista::offset::string command;
   cista::offset::string payload;

--- a/src/core/message.cpp
+++ b/src/core/message.cpp
@@ -62,11 +62,9 @@ KeystoneMessage KeystoneMessage::create(
   msg.payload = data;
   msg.timestamp = std::chrono::system_clock::now();
 
-  // Phase A: Initialize new fields with defaults for backward compatibility
+  // Initialize new fields with defaults for backward compatibility
   msg.action_type = ActionType::EXECUTE;
   msg.content_type = ContentType::TEXT_PLAIN;
-  msg.session_id = "default";
-  // metadata is empty by default
 
   // Phase C: Initialize priority to NORMAL by default
   msg.priority = Priority::NORMAL;
@@ -77,7 +75,6 @@ KeystoneMessage KeystoneMessage::create(
 KeystoneMessage KeystoneMessage::create(const std::string& sender,
                                         const std::string& receiver,
                                         ActionType action,
-                                        const std::string& session,
                                         const std::optional<std::string>& data,
                                         ContentType content) {
   KeystoneMessage msg;
@@ -86,7 +83,6 @@ KeystoneMessage KeystoneMessage::create(const std::string& sender,
   msg.receiver_id = receiver;
   msg.action_type = action;
   msg.content_type = content;
-  msg.session_id = session;
   msg.payload = data;
   msg.timestamp = std::chrono::system_clock::now();
 
@@ -127,26 +123,6 @@ std::optional<std::chrono::milliseconds> KeystoneMessage::getTimeUntilDeadline()
   }
 
   return std::chrono::duration_cast<std::chrono::milliseconds>(*deadline - now);
-}
-
-KeystoneMessage KeystoneMessage::createCancellation(
-    const std::string& sender, const std::string& receiver,
-    const std::string& task_id, const std::string& session) {
-  KeystoneMessage msg;
-  msg.msg_id = generate_uuid();
-  msg.sender_id = sender;
-  msg.receiver_id = receiver;
-  msg.action_type = ActionType::CANCEL_TASK;
-  msg.content_type = ContentType::TEXT_PLAIN;
-  msg.session_id = session;
-  msg.task_id = task_id;          // Set the task to cancel
-  msg.priority = Priority::HIGH;  // Cancellations are high priority
-  _Pragma("GCC diagnostic push")
-  _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
-  msg.command = "CANCEL_TASK";
-  _Pragma("GCC diagnostic pop")
-  msg.timestamp = std::chrono::system_clock::now();
-  return msg;
 }
 
 Response Response::createSuccess(const KeystoneMessage& original_msg,

--- a/src/core/message_serializer.cpp
+++ b/src/core/message_serializer.cpp
@@ -20,13 +20,6 @@ SerializableMessage SerializableMessage::fromKeystoneMessage(
 
   smsg.action_type = static_cast<uint32_t>(msg.action_type);
   smsg.content_type = static_cast<uint32_t>(msg.content_type);
-  smsg.session_id = cista::offset::string{msg.session_id.c_str()};
-
-  // Convert metadata map
-  for (const auto& [key, value] : msg.metadata) {
-    smsg.metadata[cista::offset::string{key.c_str()}] =
-        cista::offset::string{value.c_str()};
-  }
 
   _Pragma("GCC diagnostic push")
   _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
@@ -68,13 +61,6 @@ KeystoneMessage SerializableMessage::toKeystoneMessage() const {
 
   msg.action_type = static_cast<ActionType>(action_type);
   msg.content_type = static_cast<ContentType>(content_type);
-  msg.session_id = std::string{session_id.data(), session_id.size()};
-
-  // Convert metadata map
-  for (const auto& [key, value] : metadata) {
-    msg.metadata[std::string{key.data(), key.size()}] =
-        std::string{value.data(), value.size()};
-  }
 
   _Pragma("GCC diagnostic push")
   _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")

--- a/tests/unit/test_deadline_scheduling.cpp
+++ b/tests/unit/test_deadline_scheduling.cpp
@@ -148,12 +148,11 @@ TEST(DeadlineSchedulingTest, MultipleMessagesWithDeadlines) {
  */
 TEST(DeadlineSchedulingTest, DeadlineWithEnhancedMessage) {
   auto msg = KeystoneMessage::create("sender", "receiver", ActionType::EXECUTE,
-                                     "session123", "payload data");
+                                     "payload data");
 
   msg.setDeadlineFromNow(100ms);
 
   EXPECT_EQ(msg.action_type, ActionType::EXECUTE);
-  EXPECT_EQ(msg.session_id, "session123");
   EXPECT_TRUE(msg.deadline.has_value());
   EXPECT_FALSE(msg.hasDeadlinePassed());
 }

--- a/tests/unit/test_message_serializer.cpp
+++ b/tests/unit/test_message_serializer.cpp
@@ -19,7 +19,7 @@ using namespace keystone::core;
 TEST(MessageSerializerTest, BasicSerializeDeserialize) {
   // Create a message
   auto msg = KeystoneMessage::create("agent1", "agent2", ActionType::EXECUTE,
-                                     "session123", "test payload");
+                                     "test payload");
 
   // Serialize
   auto buffer = MessageSerializer::serialize(msg);
@@ -34,34 +34,13 @@ TEST(MessageSerializerTest, BasicSerializeDeserialize) {
   EXPECT_EQ(deserialized.receiver_id, msg.receiver_id);
   EXPECT_EQ(deserialized.action_type, msg.action_type);
   EXPECT_EQ(deserialized.content_type, msg.content_type);
-  EXPECT_EQ(deserialized.session_id, msg.session_id);
   EXPECT_EQ(deserialized.payload, msg.payload);
-}
-
-// Test: Serialize message with metadata
-TEST(MessageSerializerTest, SerializeWithMetadata) {
-  auto msg = KeystoneMessage::create("agent1", "agent2", ActionType::DECOMPOSE,
-                                     "session456");
-
-  msg.metadata["key1"] = "value1";
-  msg.metadata["key2"] = "value2";
-  msg.metadata["priority"] = "high";
-
-  // Serialize and deserialize
-  auto buffer = MessageSerializer::serialize(msg);
-  auto deserialized = MessageSerializer::deserialize(buffer);
-
-  // Verify metadata
-  EXPECT_EQ(deserialized.metadata.size(), 3u);
-  EXPECT_EQ(deserialized.metadata["key1"], "value1");
-  EXPECT_EQ(deserialized.metadata["key2"], "value2");
-  EXPECT_EQ(deserialized.metadata["priority"], "high");
 }
 
 // Test: Serialize message without payload
 TEST(MessageSerializerTest, SerializeWithoutPayload) {
   auto msg = KeystoneMessage::create("agent1", "agent2", ActionType::SHUTDOWN,
-                                     "session789", std::nullopt);
+                                     std::nullopt);
 
   // Serialize and deserialize
   auto buffer = MessageSerializer::serialize(msg);
@@ -74,11 +53,11 @@ TEST(MessageSerializerTest, SerializeWithoutPayload) {
 
 // Test: Serialize different action types
 TEST(MessageSerializerTest, DifferentActionTypes) {
-  ActionType types[] = {ActionType::DECOMPOSE, ActionType::EXECUTE,
-                        ActionType::RETURN_RESULT, ActionType::SHUTDOWN};
+  ActionType types[] = {ActionType::EXECUTE, ActionType::RETURN_RESULT,
+                        ActionType::SHUTDOWN};
 
   for (auto type : types) {
-    auto msg = KeystoneMessage::create("agent1", "agent2", type, "session");
+    auto msg = KeystoneMessage::create("agent1", "agent2", type);
 
     auto buffer = MessageSerializer::serialize(msg);
     auto deserialized = MessageSerializer::deserialize(buffer);
@@ -91,11 +70,10 @@ TEST(MessageSerializerTest, DifferentActionTypes) {
 TEST(MessageSerializerTest, DifferentContentTypes) {
   auto msg1 =
       KeystoneMessage::create("agent1", "agent2", ActionType::EXECUTE,
-                              "session", "text data", ContentType::TEXT_PLAIN);
+                              "text data", ContentType::TEXT_PLAIN);
 
   auto msg2 = KeystoneMessage::create("agent1", "agent2", ActionType::EXECUTE,
-                                      "session", "binary data",
-                                      ContentType::BINARY_CISTA);
+                                      "binary data", ContentType::BINARY_CISTA);
 
   auto buffer1 = MessageSerializer::serialize(msg1);
   auto buffer2 = MessageSerializer::serialize(msg2);
@@ -112,7 +90,7 @@ TEST(MessageSerializerTest, LargePayload) {
   std::string large_payload(10000, 'x');  // 10KB payload
 
   auto msg = KeystoneMessage::create(
-      "agent1", "agent2", ActionType::RETURN_RESULT, "session", large_payload);
+      "agent1", "agent2", ActionType::RETURN_RESULT, large_payload);
 
   auto buffer = MessageSerializer::serialize(msg);
   auto deserialized = MessageSerializer::deserialize(buffer);
@@ -123,7 +101,7 @@ TEST(MessageSerializerTest, LargePayload) {
 // Test: Zero-copy deserialization
 TEST(MessageSerializerTest, ZeroCopyDeserialize) {
   auto msg = KeystoneMessage::create("agent1", "agent2", ActionType::EXECUTE,
-                                     "session", "payload");
+                                     "payload");
 
   auto buffer = MessageSerializer::serialize(msg);
 
@@ -141,8 +119,7 @@ TEST(MessageSerializerTest, ZeroCopyDeserialize) {
 
 // Test: Timestamp preservation
 TEST(MessageSerializerTest, TimestampPreservation) {
-  auto msg = KeystoneMessage::create("agent1", "agent2", ActionType::EXECUTE,
-                                     "session");
+  auto msg = KeystoneMessage::create("agent1", "agent2", ActionType::EXECUTE);
 
   auto original_timestamp = msg.timestamp;
 
@@ -154,37 +131,18 @@ TEST(MessageSerializerTest, TimestampPreservation) {
   EXPECT_LT(diff, std::chrono::microseconds(1));
 }
 
-// Test: Empty metadata
-TEST(MessageSerializerTest, EmptyMetadata) {
-  auto msg = KeystoneMessage::create("agent1", "agent2", ActionType::EXECUTE,
-                                     "session");
-
-  // Don't add any metadata
-  EXPECT_TRUE(msg.metadata.empty());
-
-  auto buffer = MessageSerializer::serialize(msg);
-  auto deserialized = MessageSerializer::deserialize(buffer);
-
-  EXPECT_TRUE(deserialized.metadata.empty());
-}
-
 // Test: Special characters in strings
 TEST(MessageSerializerTest, SpecialCharacters) {
   auto msg = KeystoneMessage::create(
       "agent-1.test", "agent@2#special", ActionType::EXECUTE,
-      "session/with/slashes", "payload with\nnewlines\tand\ttabs");
-
-  msg.metadata["key-special!@#"] = "value with 中文 characters";
+      "payload with\nnewlines\tand\ttabs");
 
   auto buffer = MessageSerializer::serialize(msg);
   auto deserialized = MessageSerializer::deserialize(buffer);
 
   EXPECT_EQ(deserialized.sender_id, msg.sender_id);
   EXPECT_EQ(deserialized.receiver_id, msg.receiver_id);
-  EXPECT_EQ(deserialized.session_id, msg.session_id);
   EXPECT_EQ(deserialized.payload, msg.payload);
-  EXPECT_EQ(deserialized.metadata["key-special!@#"],
-            "value with 中文 characters");
 }
 
 // Test: Backward compatibility with legacy create()
@@ -196,7 +154,6 @@ TEST(MessageSerializerTest, LegacyCreateCompatibility) {
   // Should have default values for new fields
   EXPECT_EQ(msg.action_type, ActionType::EXECUTE);
   EXPECT_EQ(msg.content_type, ContentType::TEXT_PLAIN);
-  EXPECT_EQ(msg.session_id, "default");
 
   // Should serialize and deserialize correctly
   auto buffer = MessageSerializer::serialize(msg);

--- a/tests/unit/test_transparent_bridge.cpp
+++ b/tests/unit/test_transparent_bridge.cpp
@@ -96,7 +96,7 @@ TEST(MessageBusOutbound, OutboundPayloadRoundTrips) {
   });
 
   auto msg = KeystoneMessage::create(
-      "alice", "remote-bob", ActionType::EXECUTE, "session-42", std::string("hello remote"));
+      "alice", "remote-bob", ActionType::EXECUTE, std::string("hello remote"));
   bus.routeMessage(msg);
 
   ASSERT_FALSE(captured_payload.empty());
@@ -106,7 +106,6 @@ TEST(MessageBusOutbound, OutboundPayloadRoundTrips) {
 
   EXPECT_EQ(decoded.sender_id, "alice");
   EXPECT_EQ(decoded.receiver_id, "remote-bob");
-  EXPECT_EQ(decoded.session_id, "session-42");
   EXPECT_TRUE(decoded.payload.has_value());
   EXPECT_EQ(*decoded.payload, "hello remote");
 }


### PR DESCRIPTION
## Summary

Removes the now-orphaned **orchestration** fields and actions from the `KeystoneMessage` transport struct, per #515's single-responsibility intent. This is the final cleanup for Keystone's "pure C++20 transport library" goal.

This is safe now that the **only** consumers were removed:
- the agent layer (#578)
- the HMAS gRPC network layer (#579)

The `AgentEnvelope` orchestration wrapper that #515 also proposed already lives in **ProjectAgamemnon** (#419), so no functionality is lost — the orchestration concerns simply live where they belong.

## What was removed

- `KeystoneMessage::createCancellation()` — 0 consumers outside core.
- `ActionType::DECOMPOSE`, `ActionType::CANCEL_TASK`, `ActionType::TASK_FAILED` (+ their `actionTypeToString` cases). Kept the genuine transport actions `EXECUTE` / `RETURN_RESULT` / `SHUTDOWN`.
- `KeystoneMessage` fields: `session_id`, `task_id`, `metadata`.
- `SerializableMessage` cista fields `session_id` + `metadata` and their (de)serialization in `fromKeystoneMessage` / `toKeystoneMessage`; dropped the now-unused `<map>` and `<cista/containers/hash_map.h>` includes.
- The dead `session` parameter from the enhanced `create()` overload (no production caller; only tests passed it to set `session_id`).
- Updated the serializer / deadline / transparent-bridge unit tests to the slimmed struct.

## Not touched (verified safe)

- **Logger's `LogContext.session_id`** is a thread-local log-prefix string, completely separate from `KeystoneMessage.session_id`; it never reads the message field. Untouched.
- **nats_listener** parses `task_id` from NATS **subject tokens** (`parts[3]` on its own `ClassifiedSubject` struct), not from `KeystoneMessage.task_id`. Untouched.
- No agent / network / Python code re-introduced.

## Verification

- `grep -rn "createCancellation|ActionType::DECOMPOSE|ActionType::CANCEL_TASK|ActionType::TASK_FAILED" src include tests` → 0.
- `keystone_core` + `keystone_transport` build clean; serializer round-trips the slimmed struct.
- Full reduced unit suite green (223 passed, 5 profiling tests skipped by build option, 0 failed); bridge + transport unit tests pass.

Closes #515.

🤖 Generated with [Claude Code](https://claude.com/claude-code)