### PR TITLE
fix(arch): enforce ADR-015/016 extraction via regression guard

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -297,6 +297,9 @@ jobs:
       - name: Run mypy (Python typecheck)
         run: mypy conanfile.py
 
+      - name: Verify agent + Python extraction (ADR-015 / ADR-016)
+        run: ./scripts/check-extraction.sh
+
   markdownlint:
     name: markdownlint
     runs-on: ubuntu-24.04

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,12 @@ orchestration logic belongs in ProjectAgamemnon; any new transport logic must
 be implemented in C++20 under `src/transport/`, `src/network/`, `src/core/`,
 or `include/`.
 
+`scripts/check-extraction.sh` (invoked via `just check-extraction` in the
+`lint` job of `.github/workflows/_required.yml`) fails the build if any
+artifact extracted under ADR-015 (agent classes `ChiefArchitectAgent`,
+`ComponentLeadAgent`, `ModuleLeadAgent`, `TaskAgent`) or ADR-016 (Python
+orchestration modules under `src/keystone/`) reappears in the tree.
+
 ### Required Technologies
 
 | Technology | Version | Purpose |

--- a/include/core/message_bus.hpp
+++ b/include/core/message_bus.hpp
@@ -114,7 +114,8 @@ class MessageBus : public IAgentRegistry,
    *
    * Example:
    * @code
-   * auto agent = std::make_shared<ChiefArchitectAgent>("chief");
+   * // MyAgent satisfies the AgentLike concept (getAgentId() + IMessageSink).
+   * auto agent = std::make_shared<MyAgent>("worker-1");
    * bus.registerAgent(agent);  // Compile error if interface incomplete
    * @endcode
    *

--- a/justfile
+++ b/justfile
@@ -39,6 +39,11 @@ test-tsan: build-tsan
 lint:
   make lint
 
+# Enforces ADR-015 (agent layer) + ADR-016 (Python orchestration) extraction.
+# Fails if any extracted artifact reappears in the tree.
+check-extraction:
+  ./scripts/check-extraction.sh
+
 format:
   make format
 

--- a/scripts/check-extraction.sh
+++ b/scripts/check-extraction.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Enforces ADR-015 (C++ agent hierarchy extraction) and ADR-016 (Python
+# orchestration extraction). Fails CI if any extracted artifact reappears.
+#
+# Layer 1 — directory + file structural checks (cheap, catches re-extraction).
+# Layer 2 — usage-form symbol check: ANY occurrence of the four extracted
+#           class names in src/, include/, tests/. The four classes all live
+#           in ProjectAgamemnon now; any mention in this repo (including
+#           `std::make_shared<X>`, `#include <agents/X.hpp>`, Doxygen @code
+#           examples, or comments) is a regression.
+set -euo pipefail
+
+fail=0
+report() { printf 'FAIL: %s\n' "$*" >&2; fail=1; }
+
+# --- ADR-015: agent layer directories must not exist ---------------------
+[[ -d src/agents ]]     && report "src/agents/ exists (ADR-015: extracted to ProjectAgamemnon)"
+[[ -d include/agents ]] && report "include/agents/ exists (ADR-015: extracted to ProjectAgamemnon)"
+
+# --- ADR-015 layer 1: strict class-definition check ----------------------
+defs=$(git grep -nE \
+  'class[[:space:]]+(ChiefArchitectAgent|ComponentLeadAgent|ModuleLeadAgent|TaskAgent)\b' \
+  -- src include tests || true)
+if [[ -n "$defs" ]]; then
+  report "agent class definitions present in tree (ADR-015):"
+  printf '%s\n' "$defs" >&2
+fi
+
+# --- ADR-015 layer 2: broad usage-form check -----------------------------
+# Matches ANY occurrence: std::make_shared<X>, includes, types, comments,
+# Doxygen examples. This catches the exact form the prior plan would have
+# missed (message_bus.hpp:117). Intentional aggressive match — all four
+# classes live in ProjectAgamemnon and have no legitimate use in this repo.
+uses=$(git grep -nE \
+  '\b(ChiefArchitectAgent|ComponentLeadAgent|ModuleLeadAgent|TaskAgent)\b' \
+  -- src include tests || true)
+if [[ -n "$uses" ]]; then
+  report "agent class names referenced in tree (ADR-015 — extracted to ProjectAgamemnon):"
+  printf '%s\n' "$uses" >&2
+fi
+
+# --- ADR-016: Python orchestration package must not exist ----------------
+[[ -f pyproject.toml ]] && report "top-level pyproject.toml exists (ADR-016: Keystone ships no Python)"
+for f in daemon.py dag_walker.py task_claimer.py nats_listener.py \
+         models.py config.py logging.py validation.py maestro_client.py \
+         __init__.py __main__.py; do
+  [[ -f "src/keystone/$f" ]] && report "src/keystone/$f exists (ADR-016)"
+done
+
+# --- ADR-016: tests/*.py orchestration tests must not exist --------------
+shopt -s nullglob
+py_tests=( tests/test_*.py )
+shopt -u nullglob
+if (( ${#py_tests[@]} > 0 )); then
+  report "tests/*.py orchestration tests present (ADR-016):"
+  printf '  %s\n' "${py_tests[@]}" >&2
+fi
+
+exit "$fail"

--- a/tests/e2e/distributed_hierarchy_test.cpp
+++ b/tests/e2e/distributed_hierarchy_test.cpp
@@ -130,7 +130,7 @@ TEST_F(DistributedHierarchyTest, MultipleCommandsDistributed) {
       // ComponentLead receives and delegates to ModuleLead
       size_t module_node = 2;
       cluster.getNetwork()->send(1, module_node, [&]() {
-        // ModuleLead delegates to TaskAgent
+        // Worker agent receives and executes
         cluster.getNetwork()->send(2, 3, [&]() { total_task_executions++; });
       });
     });


### PR DESCRIPTION
## Summary

Adds automated regression guard to fail CI if any component of the ADR-015 (C++ agent hierarchy) or ADR-016 (Python orchestration) extraction reappears in the codebase. Implements a two-layer check that catches both class definitions and usage-form references (Doxygen examples, `std::make_shared<>`, includes, comments).

Also scrubs the public header example and removes residual agent class name references from test comments.

## Changes

- `scripts/check-extraction.sh` — guard script enforcing ADR-015 + ADR-016 invariants
- `justfile` — adds `check-extraction` target
- `.github/workflows/_required.yml` — wires guard into CI `lint` job
- `include/core/message_bus.hpp` — replaces Doxygen example that used `ChiefArchitectAgent`
- `tests/e2e/distributed_hierarchy_test.cpp` — removes agent class name from comment
- `CLAUDE.md` — documents the automated guard

Closes #505

## Verification

All acceptance criteria from the issue:
- ✓ No `src/agents/` or `include/agents/` directories
- ✓ No references to extracted agent class names anywhere in code/tests/includes
- ✓ No Python files under `src/keystone/`
- ✓ CMakeLists.txt clean of extracted agent references
- ✓ Public headers no longer instantiate extracted classes
- ✓ Guard script installed and CI-integrated