### PR TITLE
refactor(build): remove keystone_agents phantom target from CMake package config

### DIFF
--- a/cmake/KeystoneConfig.cmake.in
+++ b/cmake/KeystoneConfig.cmake.in
@@ -10,12 +10,6 @@ include(CMakeFindDependencyMacro)
 # Find required dependencies
 find_dependency(Threads REQUIRED)
 
-# Optional: Find gRPC dependencies if ENABLE_GRPC was ON during build
-if(@ENABLE_GRPC@)
-    find_dependency(Protobuf REQUIRED)
-    find_dependency(gRPC REQUIRED)
-endif()
-
 # Define library locations
 set(_Keystone_LIBDIR "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_LIBDIR@")
 set(_Keystone_INCLUDEDIR "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_INCLUDEDIR@/keystone")
@@ -47,15 +41,6 @@ if(NOT TARGET Keystone::keystone_concurrency)
     )
 endif()
 
-if(NOT TARGET Keystone::keystone_agents)
-    add_library(Keystone::keystone_agents STATIC IMPORTED)
-    set_target_properties(Keystone::keystone_agents PROPERTIES
-        IMPORTED_LOCATION "${_Keystone_LIBDIR}/${_Keystone_LIBPREFIX}keystone_agents${_Keystone_LIBSUFFIX}"
-        INTERFACE_INCLUDE_DIRECTORIES "${_Keystone_INCLUDEDIR}"
-        INTERFACE_LINK_LIBRARIES "Keystone::keystone_core;Keystone::keystone_concurrency"
-    )
-endif()
-
 if(NOT TARGET Keystone::keystone_simulation)
     add_library(Keystone::keystone_simulation STATIC IMPORTED)
     set_target_properties(Keystone::keystone_simulation PROPERTIES
@@ -65,22 +50,8 @@ if(NOT TARGET Keystone::keystone_simulation)
     )
 endif()
 
-if(@ENABLE_GRPC@)
-    if(NOT TARGET Keystone::keystone_network)
-        add_library(Keystone::keystone_network STATIC IMPORTED)
-        set_target_properties(Keystone::keystone_network PROPERTIES
-            IMPORTED_LOCATION "${_Keystone_LIBDIR}/${_Keystone_LIBPREFIX}keystone_network${_Keystone_LIBSUFFIX}"
-            INTERFACE_INCLUDE_DIRECTORIES "${_Keystone_INCLUDEDIR}"
-            INTERFACE_LINK_LIBRARIES "Keystone::keystone_core"
-        )
-    endif()
-endif()
-
-# Define available components
-set(Keystone_COMPONENTS core concurrency agents simulation)
-if(@ENABLE_GRPC@)
-    list(APPEND Keystone_COMPONENTS network)
-endif()
+# Define available components (post ADR-015/016: pure transport)
+set(Keystone_COMPONENTS core concurrency simulation)
 
 # Check requested components
 foreach(component ${Keystone_FIND_COMPONENTS})
@@ -100,13 +71,8 @@ set(Keystone_VERSION @CPACK_PACKAGE_VERSION@)
 set(Keystone_LIBRARIES
     Keystone::keystone_core
     Keystone::keystone_concurrency
-    Keystone::keystone_agents
     Keystone::keystone_simulation
 )
-
-if(@ENABLE_GRPC@)
-    list(APPEND Keystone_LIBRARIES Keystone::keystone_network)
-endif()
 
 # Include directories are handled by target properties
 get_target_property(Keystone_INCLUDE_DIRS Keystone::keystone_core INTERFACE_INCLUDE_DIRECTORIES)

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -56,13 +56,12 @@ ProjectKeystone is distributed as five separate packages to support different us
 
 ```cmake
 # In your CMakeLists.txt
-find_package(Keystone REQUIRED COMPONENTS core concurrency agents)
+find_package(Keystone REQUIRED COMPONENTS core concurrency)
 
 add_executable(my_app main.cpp)
 target_link_libraries(my_app
     Keystone::keystone_core
     Keystone::keystone_concurrency
-    Keystone::keystone_agents
 )
 ```
 
@@ -200,12 +199,10 @@ This generates:
 
 ```bash
 mkdir -p build && cd build
-cmake -G Ninja -DENABLE_GRPC=ON ..
+cmake -G Ninja ..
 ninja
 cpack
 ```
-
-This includes the `keystone_network` library and gRPC tests.
 
 ### Build Specific Package Format
 
@@ -365,9 +362,7 @@ sudo apt install libkeystone0 libkeystone-dev keystone-doc keystone-test keyston
 /usr/lib/
 ├── libkeystone_core.so
 ├── libkeystone_concurrency.so
-├── libkeystone_agents.so
-├── libkeystone_simulation.so
-└── libkeystone_network.so (if ENABLE_GRPC=ON)
+└── libkeystone_simulation.so
 
 /usr/share/doc/ProjectKeystone/
 ├── README.md
@@ -383,34 +378,22 @@ sudo apt install libkeystone0 libkeystone-dev keystone-doc keystone-test keyston
 │   ├── message.hpp
 │   ├── message_bus.hpp
 │   └── ...
-├── agents/
-│   ├── base_agent.hpp
-│   ├── chief_architect_agent.hpp
-│   └── ...
 ├── concurrency/
 │   ├── task.hpp
 │   ├── thread_pool.hpp
 │   └── ...
-├── simulation/
-│   └── ...
-└── network/ (if ENABLE_GRPC=ON)
+└── simulation/
     └── ...
 
 /usr/lib/
 ├── libkeystone_core.a
 ├── libkeystone_concurrency.a
-├── libkeystone_agents.a
 └── libkeystone_simulation.a
 
 /usr/lib/cmake/Keystone/
 ├── KeystoneConfig.cmake
 ├── KeystoneConfigVersion.cmake
 └── KeystoneTargets.cmake
-
-/usr/share/keystone/proto/ (if ENABLE_GRPC=ON)
-├── hmas_coordinator.proto
-├── service_registry.proto
-└── common.proto
 
 /usr/share/doc/ProjectKeystone/build/
 ├── Dockerfile
@@ -441,7 +424,6 @@ sudo apt install libkeystone0 libkeystone-dev keystone-doc keystone-test keyston
 ├── component_coordination_tests
 ├── async_delegation_tests
 ├── distributed_hierarchy_tests
-├── distributed_grpc_tests (if ENABLE_GRPC=ON)
 ├── unit_tests
 ├── concurrency_unit_tests
 └── simulation_unit_tests


### PR DESCRIPTION
## Summary

Per ADR-015, the agent layer (ChiefArchitectAgent, ComponentLeadAgent, ModuleLeadAgent, TaskAgent) was extracted to ProjectAgamemnon. While the CMake build target was removed in a prior commit, the installed package config and packaging docs still referenced these removed components.

This change completes the ADR-015 extraction by removing all stale references from:
- `cmake/KeystoneConfig.cmake.in` — removed phantom `Keystone::keystone_agents` and `Keystone::keystone_network` imported targets
- `docs/PACKAGING.md` — updated usage examples and package structure trees

The installed CMake package config and documentation now accurately reflect Keystone as a pure-transport library with no agent or gRPC surface.

## Changes

- Remove phantom `keystone_agents` imported target from CMake config
- Remove phantom `keystone_network` imported target and ENABLE_GRPC guards
- Remove gRPC dependency blocks from config template
- Update components list to: core, concurrency, simulation only
- Update Keystone_LIBRARIES to exclude agents/network
- Update PACKAGING.md usage example and tree diagrams

## Test plan

- Verify no stale references remain in cmake/KeystoneConfig.cmake.in or docs/PACKAGING.md
- Verify CMake syntax is valid

Closes #507