### PR TITLE
chore(tests): close out residual DISABLED items per #511

### DIFF
--- a/scripts/run_benchmarks.sh
+++ b/scripts/run_benchmarks.sh
@@ -91,8 +91,6 @@ BENCHMARKS=(
     "hierarchy_benchmarks"
     "message_pool_benchmarks"
     "distributed_benchmarks"
-    # "message_bus_benchmarks"  # Disabled - compilation errors (see CMakeLists.txt:424)
-    # "resilience_benchmarks"    # Disabled - compilation errors (see CMakeLists.txt:434)
 )
 
 # Check that benchmarks exist

--- a/tests/unit/test_thread_pool.cpp
+++ b/tests/unit/test_thread_pool.cpp
@@ -25,6 +25,7 @@ using namespace keystone::concurrency;
 // DISABLED under sanitizers: TSan instruments thread-startup so heavily
 // that ThreadPool(4) + ~ThreadPool() takes >600s on CI runners.
 // Pool construction/destruction is validated indirectly by all other tests.
+// Tracked for re-enablement under non-sanitizer CI in issue #586.
 TEST(ThreadPoolTest, DISABLED_CreateAndDestroy) {
   ThreadPool pool(4);
   EXPECT_EQ(pool.size(), 4u);
@@ -159,6 +160,7 @@ TEST(ThreadPoolTest, NoWorkAfterShutdown) {
 // DISABLED under sanitizers: ASan/LSan/TSan instrument thread-startup so
 // heavily that ThreadPool() + ~ThreadPool() hangs on CI runners (>120s
 // CTest timeout). Construction is validated indirectly by all other tests.
+// Tracked for re-enablement under non-sanitizer CI in issue #586.
 TEST(ThreadPoolTest, DISABLED_HardwareConcurrency) {
   ThreadPool pool;  // Uses std::thread::hardware_concurrency()
 


### PR DESCRIPTION
## Summary

This PR addresses issue #511 by tracking and resolving residual disabled test items:

1. **Created tracking issue #586** for two ThreadPool DISABLED_ tests in `tests/unit/test_thread_pool.cpp` (lines 28, 162). These are disabled due to ASan/TSan instrumentation of thread-startup operations that exceed CI timeout thresholds—not missing features.

2. **Updated test comments** to cite issue #586 for future re-enablement work.

3. **Removed stale benchmark stubs** from `scripts/run_benchmarks.sh` (lines 94–95) that referenced non-existent targets `message_bus_benchmarks` and `resilience_benchmarks` with stale `CMakeLists.txt` line references.

## Verification

- ✅ All DISABLED markers accounted for (both `DISABLED_` prefix and `DISABLED:` comment forms)
- ✅ Both remaining `DISABLED_` tests now cite tracking issue #586
- ✅ No stale `CMakeLists.txt:` references remain in `scripts/`
- ✅ Chaos primitives retain unit tests (failure_injector, retry_policy, heartbeat_monitor, circuit_breaker)
- ✅ Async test coverage present (test_async_task_agent)

## Context

- Addresses: #511 (disabled test targets without tracking)
- References: #586 (new tracking issue for ThreadPool timeout tests)
- Original evidence: Three targets (`async_agents_tests`, `chaos_engineering_tests`, `test_message_bus_async.cpp`) were already deleted in commit 5dab667 (PR #578) during ADR-015 extraction to ProjectAgamemnon.

Closes #511