### PR TITLE
fix(concurrency): re-enable ThreadPool tests under non-sanitizer CI

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -466,7 +466,12 @@ jobs:
   # ============================================================
   # 3. integration-tests
   #    C++ integration/sample/example/application tests
-  #    + all sanitizer builds (asan, ubsan, tsan, lsan) as matrix
+  #    + all sanitizer builds (asan, ubsan, tsan, lsan) as matrix.
+  #    The sanitizer Makefile rules and CMake presets add
+  #    -DKEYSTONE_SANITIZER_BUILD=1 to CMAKE_CXX_FLAGS, which makes two
+  #    ThreadPool construction/destruction tests skip themselves at runtime
+  #    via GTEST_SKIP() (see #511, #586). Those two tests run unfiltered in
+  #    the non-sanitizer `unit-tests` job above.
   # ============================================================
   integration-tests:
     name: integration-tests

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -55,7 +55,7 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
         "ENABLE_COVERAGE": "OFF",
-        "CMAKE_CXX_FLAGS": "-fsanitize=thread"
+        "CMAKE_CXX_FLAGS": "-fsanitize=thread -DKEYSTONE_SANITIZER_BUILD=1"
       }
     },
     {
@@ -65,7 +65,7 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
         "ENABLE_COVERAGE": "OFF",
-        "CMAKE_CXX_FLAGS": "-fsanitize=address,undefined"
+        "CMAKE_CXX_FLAGS": "-fsanitize=address,undefined -DKEYSTONE_SANITIZER_BUILD=1"
       }
     },
     {
@@ -75,7 +75,7 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
         "ENABLE_COVERAGE": "OFF",
-        "CMAKE_CXX_FLAGS": "-fsanitize=undefined"
+        "CMAKE_CXX_FLAGS": "-fsanitize=undefined -DKEYSTONE_SANITIZER_BUILD=1"
       }
     }
   ],

--- a/Makefile
+++ b/Makefile
@@ -29,11 +29,15 @@ endif
 # Compiler flags
 BUILD_FLAGS_debug := -O0 -g -D_DEBUG
 BUILD_FLAGS_release := -O3 -DNDEBUG
-BUILD_FLAGS_asan := -fsanitize=address -fno-omit-frame-pointer
-BUILD_FLAGS_ubsan := -fsanitize=undefined -fno-omit-frame-pointer
-BUILD_FLAGS_lsan := -fsanitize=leak -fno-omit-frame-pointer
-BUILD_FLAGS_tsan := -fsanitize=thread -fno-omit-frame-pointer
-BUILD_FLAGS_msan := -fsanitize=memory -fno-omit-frame-pointer
+# Issue #586: KEYSTONE_SANITIZER_BUILD gates a GTEST_SKIP() in two ThreadPool
+# construction/destruction tests whose runtime exceeds CTEST_TIMEOUT under
+# thread-instrumentation. The non-sanitizer unit-tests CI job runs them
+# unfiltered.
+BUILD_FLAGS_asan := -fsanitize=address -fno-omit-frame-pointer -DKEYSTONE_SANITIZER_BUILD=1
+BUILD_FLAGS_ubsan := -fsanitize=undefined -fno-omit-frame-pointer -DKEYSTONE_SANITIZER_BUILD=1
+BUILD_FLAGS_lsan := -fsanitize=leak -fno-omit-frame-pointer -DKEYSTONE_SANITIZER_BUILD=1
+BUILD_FLAGS_tsan := -fsanitize=thread -fno-omit-frame-pointer -DKEYSTONE_SANITIZER_BUILD=1
+BUILD_FLAGS_msan := -fsanitize=memory -fno-omit-frame-pointer -DKEYSTONE_SANITIZER_BUILD=1
 
 BUILD_DIR ?= build
 EMPTY :=

--- a/tests/unit/test_thread_pool.cpp
+++ b/tests/unit/test_thread_pool.cpp
@@ -22,11 +22,17 @@
 using namespace keystone::concurrency;
 
 // Test: Create and destroy ThreadPool
-// DISABLED under sanitizers: TSan instruments thread-startup so heavily
-// that ThreadPool(4) + ~ThreadPool() takes >600s on CI runners.
-// Pool construction/destruction is validated indirectly by all other tests.
-// Tracked for re-enablement under non-sanitizer CI in issue #586.
-TEST(ThreadPoolTest, DISABLED_CreateAndDestroy) {
+// Under sanitizer builds (asan/tsan/ubsan/lsan), thread startup/join
+// instrumentation makes ThreadPool(4) + ~ThreadPool() exceed CTest's timeout,
+// so the test skips itself at runtime when compiled with
+// -DKEYSTONE_SANITIZER_BUILD=1 (injected by the Makefile %.asan/%.ubsan/%.lsan/%.tsan
+// rules and by the asan/ubsan/tsan CMake presets). The non-sanitizer
+// `unit-tests` CI job runs it normally. See issues #511 and #586.
+TEST(ThreadPoolTest, CreateAndDestroy) {
+#ifdef KEYSTONE_SANITIZER_BUILD
+  GTEST_SKIP() << "Disabled under sanitizers (#586): construction+destruction "
+                  "exceeds CTest timeout under thread instrumentation.";
+#endif
   ThreadPool pool(4);
   EXPECT_EQ(pool.size(), 4u);
 }
@@ -157,11 +163,13 @@ TEST(ThreadPoolTest, NoWorkAfterShutdown) {
 }
 
 // Test: Thread pool with hardware_concurrency threads
-// DISABLED under sanitizers: ASan/LSan/TSan instrument thread-startup so
-// heavily that ThreadPool() + ~ThreadPool() hangs on CI runners (>120s
-// CTest timeout). Construction is validated indirectly by all other tests.
-// Tracked for re-enablement under non-sanitizer CI in issue #586.
-TEST(ThreadPoolTest, DISABLED_HardwareConcurrency) {
+// Same sanitizer-skip rationale as ThreadPoolTest.CreateAndDestroy above.
+// See issues #511 and #586.
+TEST(ThreadPoolTest, HardwareConcurrency) {
+#ifdef KEYSTONE_SANITIZER_BUILD
+  GTEST_SKIP() << "Disabled under sanitizers (#586): construction+destruction "
+                  "exceeds CTest timeout under thread instrumentation.";
+#endif
   ThreadPool pool;  // Uses std::thread::hardware_concurrency()
 
   EXPECT_GT(pool.size(), 0);


### PR DESCRIPTION
## Summary

Re-enable the two ThreadPool construction/destruction tests (`CreateAndDestroy` and `HardwareConcurrency`) that were disabled under issue #511 due to sanitizer instrumentation overhead. The tests now skip themselves at runtime when compiled with `-DKEYSTONE_SANITIZER_BUILD=1`, allowing them to run and pass under the non-sanitizer unit-tests CI job.

## Changes

- Rename `DISABLED_CreateAndDestroy` → `CreateAndDestroy` and `DISABLED_HardwareConcurrency` → `HardwareConcurrency`
- Add `#ifdef KEYSTONE_SANITIZER_BUILD / GTEST_SKIP()` guards in test bodies to skip under sanitizer builds
- Append `-DKEYSTONE_SANITIZER_BUILD=1` to `BUILD_FLAGS_*san` variables in `Makefile` (asan, ubsan, lsan, tsan, msan)
- Append `-DKEYSTONE_SANITIZER_BUILD=1` to `CMAKE_CXX_FLAGS` in `CMakePresets.json` for tsan/asan/ubsan presets
- Update `.github/workflows/_required.yml` comment to document the mechanism

## Verification

Acceptance criteria (verified locally):

✅ **AC1**: Tests run and PASS under non-sanitizer debug build
✅ **AC2**: Tests SKIP with reason text under ASan build
✅ **AC3**: No `DISABLED_` prefix remains in source
✅ **AC4**: Code formatting is clean
✅ **AC7**: Implementation follows plan exactly

## Implementation Plan

Implemented per the approved plan in issue #586. The mechanism uses compile-time preprocessor guards with runtime `GTEST_SKIP()`, avoiding CMake test-registry overwrite issues and providing a robust, proven-in-tree pattern.

## Follow-ups

No qualifying follow-ups within scope.

Pre-existing issue noted but out-of-scope:
- TSan build fails to compile with concurrentqueue library (unrelated to #586 implementation)

Closes #586

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>