### PR TITLE
fix(ci): pin actions/cache to SHA (v5.0.5)

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -224,7 +224,7 @@ jobs:
           include-static-analysis: "true"
 
       - name: Cache Conan packages (clang-tidy)
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: ~/.conan2
           key: conan-${{ runner.os }}-${{ hashFiles('conanfile.py') }}
@@ -232,7 +232,7 @@ jobs:
             conan-${{ runner.os }}-
 
       - name: Cache FetchContent (clang-tidy)
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: build/x86.debug.clang-tidy/_deps
           key: fetchcontent-clang-tidy-${{ runner.os }}-${{ hashFiles('CMakeLists.txt') }}


### PR DESCRIPTION
## Summary
- Pins 2 remaining `actions/cache@v5` floating tags to full 40-char SHA
- These were missed in the previous SHA-pinning pass

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>