### PR TITLE
fix(ci): pin actions/upload-artifact to SHA (v7.0.1)

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -800,7 +800,7 @@ jobs:
           fi
 
       - name: Upload scan artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         if: always()
         with:
           name: dependency-scan-results


### PR DESCRIPTION
Pins remaining floating tag to full 40-char SHA.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>