### PR TITLE
fix(ci): install just via pinned setup-just to stop 403 on lint job

### DIFF
--- a/.github/actions/install-build-deps/action.yml
+++ b/.github/actions/install-build-deps/action.yml
@@ -71,9 +71,13 @@ runs:
 
     - name: Install just
       if: inputs.include-just == 'true'
-      run: |
-        curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
-      shell: bash
+      # Use the pinned setup-just action instead of piping just.systems/install.sh
+      # into bash: the install script's unauthenticated GitHub release download
+      # intermittently returns HTTP 403 on CI runners, which turned main red on
+      # the required `lint` job. setup-just downloads via the Actions toolkit
+      # (authenticated, cached) and is already the canonical pattern used in
+      # _required.yml.
+      uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4.0.0
 
     - name: Set up compiler alternatives
       run: |


### PR DESCRIPTION
## Summary

`main` is red on the required **`lint`** check. The job fails at *Install build dependencies (just + linters)* with:

```
curl: (22) The requested URL returned error: 403
```

The `install-build-deps` composite action installed `just` by piping `just.systems/install.sh` into bash. That script's unauthenticated GitHub release download intermittently 403s on CI runners (a known just.systems install-script flake).

## Fix

Replace the curl|bash step with the SHA-pinned **`extractions/setup-just@v4.0.0`** action — the same authenticated, cached install already used elsewhere in `_required.yml` (line ~378). No behavioral change other than a reliable `just` on PATH.

## Verification

- action.yml parses as valid YAML.
- setup-just is already proven in this same workflow, so the lint job's `just` invocations are unaffected.
- CI `lint` should now pass, turning main green and unblocking #568.

🤖 Generated with [Claude Code](https://claude.com/claude-code)