### PR TITLE
ci: unify job naming to canonical 8-category scheme

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -536,6 +536,24 @@ jobs:
           retention-days: 7
 
   # ============================================================
+  # 3a. test  (canonical aggregate)
+  #    Roll-up gate for the test category. Depends on the C++
+  #    unit-tests and integration-tests jobs and emits the
+  #    canonical `test` check-run for the Odysseus ecosystem board.
+  #    The granular unit-tests / integration-tests sub-checks are
+  #    retained above; this job only aggregates their result so a
+  #    single canonical `test` context exists.
+  # ============================================================
+  test:
+    name: test
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    needs: [unit-tests, integration-tests]
+    steps:
+      - name: Aggregate test result
+        run: echo "unit-tests + integration-tests passed; canonical 'test' category satisfied"
+
+  # ============================================================
   # 4. build
   # ============================================================
   build:
@@ -585,6 +603,101 @@ jobs:
       - name: Show sccache stats
         if: always()
         run: sccache --show-stats
+
+  # NOTE: canonical `install` category is not yet wired (no install
+  # smoke test exists for the C++20 library). Tracked in
+  # HomericIntelligence/ProjectKeystone#596.
+  #
+  # ============================================================
+  # 4a. package  (canonical)
+  #    Builds the release tree and produces the CPack artifacts
+  #    (DEB / RPM / TGZ / ZIP) on every push/PR, validating that
+  #    the packaging path stays green between releases. The
+  #    release-time `Publish Release Artifacts` job uploads these
+  #    same packages to a GitHub Release; this job only verifies
+  #    they build, emitting the canonical `package` check-run.
+  # ============================================================
+  package:
+    name: package
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    needs: build
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+
+      - name: Install build dependencies
+        uses: ./.github/actions/install-build-deps
+
+      - name: Cache Conan packages
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: ~/.conan2
+          key: conan-${{ runner.os }}-${{ hashFiles('conanfile.py') }}
+          restore-keys: |
+            conan-${{ runner.os }}-
+
+      - name: Cache FetchContent downloads
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: build/x86.release/_deps
+          key: fetchcontent-release-${{ runner.os }}-${{ hashFiles('CMakeLists.txt') }}
+          restore-keys: |
+            fetchcontent-release-${{ runner.os }}-
+
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696  # v0.0.10
+
+      - name: Configure sccache
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+          echo "CMAKE_C_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+          echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+
+      - name: Install Conan dependencies
+        run: make deps.native
+
+      - name: Build release
+        run: make compile.release.native
+
+      - name: Build CPack packages (DEB, RPM, TGZ, ZIP)
+        run: |
+          set -euo pipefail
+          cd build/x86.release
+          cpack -G DEB
+          cpack -G RPM
+          cpack -G TGZ
+          cpack -G ZIP
+
+      - name: List produced packages
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          pkgs=(build/x86.release/*.deb build/x86.release/*.rpm \
+                build/x86.release/*.tar.gz build/x86.release/*.zip)
+          if [ "${#pkgs[@]}" -eq 0 ]; then
+            echo "::error::CPack produced no package artifacts"
+            exit 1
+          fi
+          printf '%s\n' "${pkgs[@]}"
+
+      - name: Show sccache stats
+        if: always()
+        run: sccache --show-stats
+
+      - name: Upload package artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: cpack-packages
+          path: |
+            build/x86.release/*.deb
+            build/x86.release/*.rpm
+            build/x86.release/*.tar.gz
+            build/x86.release/*.zip
+          retention-days: 30
+          if-no-files-found: ignore
 
   # ============================================================
   # 5. schema-validation

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -30,9 +30,11 @@ jobs:
           manifest-file: .release-please-manifest.json
           token: ${{ secrets.GITHUB_TOKEN }}
 
-  # Build and publish release artifacts when a new release is created
+  # Build and publish release artifacts when a new release is created.
+  # Emits the canonical `release` check-run for the Odysseus ecosystem
+  # board (renamed from "Publish Release Artifacts").
   publish:
-    name: Publish Release Artifacts
+    name: release
     runs-on: ubuntu-24.04
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'


### PR DESCRIPTION
## Summary

Aligns ProjectKeystone CI check-run names with the Odysseus ecosystem **canonical 8-category scheme** — **build, test, lint, package, install, release, security, custom** — so the ecosystem board can map every repo uniformly. Keystone is the **pilot** repo; this pattern rolls out to 12 more.

## Category mapping (after this PR)

| Category | Emitting check | Status |
|----------|----------------|--------|
| build | `build` | already canonical |
| test | `test` (aggregate) + `unit-tests`, `integration-tests` | **added aggregate** |
| lint | `lint` | already canonical |
| package | `package` (CPack DEB/RPM/TGZ/ZIP) | **newly wired** |
| install | — | **gap, tracked in #596** |
| release | `release` (release-please publish) | **renamed** |
| security | `security/dependency-scan`, `security/secrets-scan` | already canonical |
| custom | benchmarks, coverage, deps/version-sync, pixi-check, schema-validation, symlink-check, ... | n/a |

## Changes

- **test**: added an aggregate `test` job (`needs: unit-tests, integration-tests`) emitting the canonical `test` check-run. The granular `unit-tests` / `integration-tests` sub-checks are retained.
- **package**: added a `package` job that builds the release tree and runs CPack (DEB/RPM/TGZ/ZIP) on every push/PR, emitting canonical `package`. Previously CPack ran only at release time inside the conditional publish job, so packaging breakage was invisible between releases.
- **release**: renamed the release-please `publish` job's `name:` from `Publish Release Artifacts` to canonical `release`.

`build`, `lint`, `security/dependency-scan`, and `security/secrets-scan` already emit canonical names — left unchanged.

### Notes / deviations from the rollout plan
- **CodeQL**: the `Analyze (python)` / `Analyze (c-cpp)` check-runs are generated by `github/codeql-action`, derived from the analysis language — they are **not** job `name:` fields, so they cannot be renamed to `security/codeql-cpp` via a job rename. The CodeQL run already lives inside the canonical `security/secrets-scan` job, so the security category is satisfied. No change made.
- **SBOM**: there is no cyclonedx/SBOM tooling in the repo today, so `package` is wired off the existing CPack path rather than an SBOM build.
- **install**: no install smoke test exists for the C++20 library; wiring one needs design (staged `cmake --install` + `find_package(Keystone CONFIG)` consumer compile). Split out to #596.

## Coordination with #568
This is on a separate branch off `origin/main`. PR #568 (`501-impl`, NATIVE→Podman migration) also edits `_required.yml`; whichever merges second rebases. #568's branch was not touched.

## Required-checks ruleset
The `homeric-main-baseline` ruleset (`required_status_checks`, integration_id 15368) is **not** updated in this PR — the new `test` / `package` contexts must be observed green on `main` first to avoid an emitted-vs-required deadlock. Ruleset alignment is a follow-up once these land.

Refs #596

🤖 Generated with [Claude Code](https://claude.com/claude-code)