### PR TITLE
chore(settings): swap hephaestus plugin -> Athena marketplace

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,35 @@
 {
   "enabledPlugins": {
-    "hephaestus@ProjectHephaestus": true
+    "advise@Athena": true,
+    "brainstorm@Athena": true,
+    "code-review@Athena": true,
+    "create-reusable-utilities@Athena": true,
+    "finish-branch@Athena": true,
+    "git-worktrees@Athena": true,
+    "github-actions-python-cicd@Athena": true,
+    "learn@Athena": true,
+    "myrmidon-swarm@Athena": true,
+    "python-repo-modernization@Athena": true,
+    "repo-analyze@Athena": true,
+    "repo-analyze-full@Athena": true,
+    "repo-analyze-quick@Athena": true,
+    "repo-analyze-quick-full@Athena": true,
+    "repo-analyze-strict@Athena": true,
+    "repo-analyze-strict-full@Athena": true,
+    "review-pr-strict@Athena": true,
+    "skill-advisor@Athena": true,
+    "systematic-debugging@Athena": true,
+    "test-driven-development@Athena": true,
+    "tidy@Athena": true,
+    "verification@Athena": true,
+    "worktree-cleanup@Athena": true
+  },
+  "extraKnownMarketplaces": {
+    "Athena": {
+      "source": {
+        "source": "git",
+        "url": "https://github.com/HomericIntelligence/Athena.git"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

Migrate `.claude/settings.json` off the stale `hephaestus@ProjectHephaestus` plugin. The shared skills were carved out to the **HomericIntelligence/Athena** marketplace (marketplace name: `Athena`, 23 per-skill plugins).

## Changes

- Removed `hephaestus@ProjectHephaestus` from `enabledPlugins`
- Enabled the 23 `<skill>@Athena` per-skill plugins
- Registered the `Athena` marketplace under `extraKnownMarketplaces` (git source: https://github.com/HomericIntelligence/Athena.git)
- All other settings preserved (the file previously contained only `enabledPlugins`)

## Testing

- `jq empty` confirms valid JSON
- 0 `hephaestus` references remain; exactly 23 `@Athena` keys present; Athena marketplace registered

Closes #605