### PR TITLE
ci: enable merge queue readiness on main

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -5,62 +5,21 @@ security scanning of the Keystone HMAS (Hierarchical Multi-Agent System) codebas
 
 ## Workflow Overview
 
-### Tier 1: Fast Checks (2-5 minutes)
+### Current Workflows
 
-These workflows run on every PR and provide quick feedback:
+- **`_required.yml`** emits the baseline required contexts, including lint,
+  build, test, package, security, schema, and dependency-version checks.
+- **`extras.yml`** emits the separately required `coverage` context and advisory
+  benchmark/NATS checks. Only coverage runs for merge-group events.
+- **`release-please.yml`** manages releases after pushes to `main`. For a
+  merge-group event, mutating release jobs are skipped and the required `release`
+  gate validates repository release metadata instead.
+- **`profiling-weekly.yml`** is scheduled/manual and is not a merge gate.
 
-- **pre-commit.yml** - Code formatting and linting
-  - Runs pre-commit hooks (clang-format, cmake-format)
-  - C++ formatting validation with clang-format-14
-  - Static analysis with clang-tidy and cppcheck
-  - **Triggers**: PR, push to main, manual
-  - **Timeout**: 10-15 minutes
-
-- **unit-tests.yml** - Unit test execution
-  - Builds test environment in Docker
-  - Runs Google Test (GTest) unit tests
-  - Generates coverage reports with gcovr
-  - **Triggers**: PR, push to main, manual
-  - **Timeout**: 15 minutes
-  - **Artifacts**: Test results, coverage reports
-
-### Tier 2: Comprehensive Checks (5-15 minutes)
-
-These workflows provide deeper validation:
-
-- **build-validation.yml** - Docker build verification
-  - Builds all Docker stages (builder, runtime, development)
-  - Validates native CMake builds
-  - Runs smoke tests
-  - **Triggers**: PR, push to main, manual
-  - **Timeout**: 20 minutes
-  - **Artifacts**: Build manifests, build reports
-
-- **integration-tests.yml** - E2E test suites
-  - Runs phase-specific E2E tests (Phase 1-4)
-  - Tests full agent hierarchy delegation
-  - Matrix strategy for parallel execution
-  - **Triggers**: PR, push to main, manual
-  - **Timeout**: 20 minutes
-  - **Artifacts**: Test results, integration reports
-
-- **security-scan.yml** - Security vulnerability scanning
-  - Secret detection with Gitleaks
-  - SAST scanning with Semgrep
-  - CodeQL analysis for C++
-  - Dependency and supply chain scanning
-  - **Triggers**: PR, push to main, weekly schedule, manual
-  - **Timeout**: 15-20 minutes
-  - **Artifacts**: Security reports, SARIF files
-
-- **sanitizers.yml** - Runtime error detection
-  - AddressSanitizer (ASan) for memory errors
-  - UndefinedBehaviorSanitizer (UBSan) for undefined behavior
-  - ThreadSanitizer (TSan) for data races
-  - MemorySanitizer (MSan) on manual trigger
-  - **Triggers**: PR, push to main, manual
-  - **Timeout**: 20-30 minutes
-  - **Artifacts**: Sanitizer logs and reports
+The first three workflows support `merge_group` with only the
+`checks_requested` activity type because they supply contexts required by the
+live `main` rulesets. The event is additive: existing push, pull-request, manual,
+and scheduled behavior remains unchanged.
 
 ## Workflow Details
 
@@ -245,9 +204,21 @@ All workflows run on:
 - PR synchronized (new commits)
 - PR reopened
 
+### Merge Queue
+
+Required-context workflows also run for `merge_group/checks_requested`. GitHub
+creates that event against the speculative group ref, allowing all required
+checks to validate the exact commit group that would reach `main`.
+
+The repository-owned workflows are queue-ready, but queue activation is a
+separate post-merge administration step. See
+[CI/CD Quality Gates](../../docs/CICD_QUALITY_GATES.md#merge-queue-activation)
+for the preserved required-context baseline and approved queue policy.
+
 ### Push Events
 
-All workflows run on pushes to `main` branch
+The required, extras, and release workflows run on pushes to `main`; required
+and extras retain their existing `develop` and `claude/**` push behavior.
 
 ### Scheduled
 
@@ -255,7 +226,7 @@ All workflows run on pushes to `main` branch
 
 ### Manual
 
-All workflows support `workflow_dispatch` for manual triggering
+All workflows support `workflow_dispatch` for manual triggering.
 
 ## Artifacts and Retention
 

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -20,8 +20,6 @@ concurrency:
 
 permissions:
   contents: read
-  pull-requests: write
-  security-events: write
   actions: read
 
 jobs:
@@ -1126,6 +1124,9 @@ jobs:
     name: security/dependency-scan
     runs-on: ubuntu-24.04
     timeout-minutes: 20
+    permissions:
+      contents: read
+      security-events: write
 
     steps:
       - name: Checkout code
@@ -1268,6 +1269,9 @@ jobs:
     name: security/secrets-scan
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    permissions:
+      contents: read
+      security-events: write
 
     steps:
       - name: Checkout code (full history)

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -10,6 +10,8 @@ on:
     branches: [main, develop, "claude/**"]
   pull_request:
     branches: [main, develop]
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 concurrency:
@@ -866,6 +868,9 @@ jobs:
               "$f" && echo "  OK" || { echo "  FAIL"; FAILED=1; }
           done
           [ -z "${FAILED}" ] || exit 1
+
+      - name: Validate merge-queue readiness contract
+        run: ./scripts/check-merge-queue-readiness.sh
 
   # ============================================================
   # 7. deps/version-sync

--- a/.github/workflows/extras.yml
+++ b/.github/workflows/extras.yml
@@ -8,6 +8,8 @@ on:
     branches: [main, develop, "claude/**"]
   pull_request:
     branches: [main, develop]
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 concurrency:
@@ -20,6 +22,7 @@ permissions:
 jobs:
   benchmarks:
     name: benchmarks
+    if: github.event_name != 'merge_group'
     runs-on: ubuntu-24.04
     timeout-minutes: 20
 
@@ -85,6 +88,7 @@ jobs:
 
   nats-integration:
     name: NATS integration tests
+    if: github.event_name != 'merge_group'
     runs-on: ubuntu-24.04
     # 20 (was 15): leave headroom for a cold dev-image rebuild — any
     # Containerfile/conanfile.py change misses the exact-match image cache in

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,6 +3,8 @@ name: Release Please
 on:
   push:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 permissions:
@@ -12,6 +14,7 @@ permissions:
 jobs:
   release-please:
     name: Release Please
+    if: github.event_name != 'merge_group'
     runs-on: ubuntu-24.04
 
     outputs:
@@ -91,3 +94,45 @@ jobs:
             build/x86.release/*.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release-gate:
+    name: release
+    runs-on: ubuntu-24.04
+    needs: [release-please, publish]
+    if: always()
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout merge-group release metadata
+        if: github.event_name == 'merge_group'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - name: Validate release metadata for the merge group
+        if: github.event_name == 'merge_group'
+        run: jq -e . release-please-config.json .release-please-manifest.json >/dev/null
+
+      - name: Check release workflow result
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_PLEASE_RESULT: ${{ needs.release-please.result }}
+          PUBLISH_RESULT: ${{ needs.publish.result }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "merge_group" ]; then
+            echo "Release metadata is valid; mutating release jobs were skipped for the merge group."
+            exit 0
+          fi
+
+          if [ "$RELEASE_PLEASE_RESULT" != "success" ]; then
+            echo "::error::release-please failed ($RELEASE_PLEASE_RESULT)"
+            exit 1
+          fi
+
+          case "$PUBLISH_RESULT" in
+            success|skipped) ;;
+            *)
+              echo "::error::release artifact publication failed ($PUBLISH_RESULT)"
+              exit 1
+              ;;
+          esac

--- a/docs/CICD_QUALITY_GATES.md
+++ b/docs/CICD_QUALITY_GATES.md
@@ -295,21 +295,62 @@ The `quality-summary` job runs after all quality gates complete:
 
 ## Branch Protection Rules
 
-**Recommended Settings** (for `main` branch):
+The live `main` rulesets require these existing GitHub Actions contexts. Merge
+queue rollout must preserve all of them:
 
-1. **Require status checks to pass**:
-   - ☑ `quality-summary`
-   - ☑ `coverage`
-   - ☑ `static-analysis`
-   - ☑ `fuzz-testing`
-   - ☑ `benchmarks`
-   - ☑ `tests`
+- `lint`, `unit-tests`, `integration-tests`, `test`, `build`, and `package`
+- `security/dependency-scan` and `security/secrets-scan`
+- `schema-validation` and `deps/version-sync`
+- `coverage` and `release`
 
-2. **Require branches to be up to date**: ☑
+The rulesets also preserve required signatures, linear history, deletion and
+non-fast-forward protection, zero required approvals, review-thread resolution,
+and non-strict status checks. Queue activation does not weaken or replace those
+rules.
 
-3. **Require linear history**: ☑
+## Merge Queue Activation
 
-4. **Do not allow bypassing**: ☑
+The workflows are prepared for a staged merge-queue rollout by handling
+`merge_group/checks_requested`. This repository has no canonical, repo-owned
+ruleset configuration file, so an administrator must perform activation only
+after this readiness change merges and the repository smoke check is ready.
+
+Add one `merge_queue` rule to the existing active `homeric-main-baseline`
+ruleset while preserving every existing condition, bypass actor, rule, required
+context, and enforcement field. The rule must use this exact payload:
+
+```json
+{
+  "type": "merge_queue",
+  "parameters": {
+    "check_response_timeout_minutes": 60,
+    "grouping_strategy": "ALLGREEN",
+    "max_entries_to_build": 10,
+    "max_entries_to_merge": 5,
+    "merge_method": "SQUASH",
+    "min_entries_to_merge": 1,
+    "min_entries_to_merge_wait_minutes": 5
+  }
+}
+```
+
+Activation is a full-replacement ruleset write and therefore requires this
+operator sequence:
+
+1. Fetch and retain the complete live ruleset as the rollback snapshot.
+2. Verify the snapshot includes all required contexts listed above and every
+   current non-queue rule.
+3. Append only the queue rule, update the ruleset, and read it back.
+4. Compare the read-back with the snapshot, allowing only the new queue rule.
+   If any unrelated field changed, immediately restore the snapshot.
+5. Enqueue one representative pull request and record the
+   `merge_group/checks_requested` workflow run, all required check conclusions,
+   and the queued squash merge result on
+   [Keystone #610](https://github.com/HomericIntelligence/Keystone/issues/610).
+
+This activation belongs to the post-merge rollout tracked by
+[Odysseus #386](https://github.com/HomericIntelligence/Odysseus/issues/386); it
+must not be performed from the implementation PR.
 
 ## Local Validation
 

--- a/justfile
+++ b/justfile
@@ -44,6 +44,10 @@ lint:
 check-extraction:
   ./scripts/check-extraction.sh
 
+# Validate that required workflows and activation docs remain merge-queue ready.
+check-merge-queue-readiness:
+  ./scripts/check-merge-queue-readiness.sh
+
 format:
   make format
 

--- a/scripts/check-merge-queue-readiness.sh
+++ b/scripts/check-merge-queue-readiness.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+failures=0
+
+fail() {
+    echo "ERROR: $*" >&2
+    failures=$((failures + 1))
+}
+
+require_line() {
+    local file=$1
+    local pattern=$2
+    local description=$3
+
+    if ! grep -Eq "$pattern" "$file"; then
+        fail "$file: missing $description"
+    fi
+}
+
+require_merge_group_trigger() {
+    local file=$1
+    local trigger_block
+
+    trigger_block=$(sed -n '/^on:/,/^[^[:space:]]/p' "$file")
+    if ! grep -Eq '^  merge_group:$' <<<"$trigger_block"; then
+        fail "$file: missing merge_group trigger"
+    fi
+    if ! grep -Eq '^    types: \[checks_requested\]$' <<<"$trigger_block"; then
+        fail "$file: merge_group must be limited to checks_requested"
+    fi
+}
+
+for workflow in \
+    .github/workflows/_required.yml \
+    .github/workflows/extras.yml \
+    .github/workflows/release-please.yml; do
+    require_merge_group_trigger "$workflow"
+done
+
+required_contexts=(
+    lint
+    unit-tests
+    integration-tests
+    security/dependency-scan
+    security/secrets-scan
+    build
+    schema-validation
+    deps/version-sync
+    test
+    package
+    release
+    coverage
+)
+
+for context in "${required_contexts[@]}"; do
+    if ! grep -Ehq "^[[:space:]]+name: ${context}$" \
+        .github/workflows/_required.yml \
+        .github/workflows/extras.yml \
+        .github/workflows/release-please.yml; then
+        fail "required context is not emitted by a queue-enabled workflow: $context"
+    fi
+done
+
+# Preserve the existing push and pull-request surfaces while adding queue builds.
+for workflow in .github/workflows/_required.yml .github/workflows/extras.yml; do
+    require_line "$workflow" '^  push:$' 'push trigger'
+    require_line "$workflow" '^  pull_request:$' 'pull_request trigger'
+    require_line "$workflow" '^    branches: \[main, develop, "claude/\*\*"\]$' \
+        'existing push branches'
+    require_line "$workflow" '^    branches: \[main, develop\]$' \
+        'existing pull-request branches'
+done
+
+# Merge-group refs must never execute release-please or publish release artifacts.
+require_line .github/workflows/release-please.yml \
+    "^    if: github\.event_name != 'merge_group'$" \
+    'merge-group guard on release-please'
+require_line .github/workflows/release-please.yml \
+    '^    name: release$' \
+    'stable release required-check gate'
+require_line .github/workflows/release-please.yml \
+    "github\.event_name == 'merge_group'" \
+    'merge-group release validation path'
+require_line .github/workflows/_required.yml \
+    '^        run: \./scripts/check-merge-queue-readiness\.sh$' \
+    'required schema-validation invocation of this contract'
+
+# extras.yml supplies the required coverage context. Its advisory heavy jobs stay
+# available on push/PR, but do not consume merge-queue build capacity.
+for job in benchmarks nats-integration; do
+    if ! awk -v job="$job" '
+        $0 == "  " job ":" { in_job=1; next }
+        in_job && /^  [[:alnum:]_-]+:/ { exit }
+        in_job && /if: github\.event_name != '\''merge_group'\''/ { found=1 }
+        END { exit(found ? 0 : 1) }
+    ' .github/workflows/extras.yml; then
+        fail ".github/workflows/extras.yml: $job must skip merge_group builds"
+    fi
+done
+
+# The repository has no canonical ruleset file, so the activation contract must
+# remain exact and reviewable in version-controlled documentation.
+for policy in \
+    '"check_response_timeout_minutes": 60' \
+    '"grouping_strategy": "ALLGREEN"' \
+    '"max_entries_to_build": 10' \
+    '"max_entries_to_merge": 5' \
+    '"merge_method": "SQUASH"' \
+    '"min_entries_to_merge": 1' \
+    '"min_entries_to_merge_wait_minutes": 5'; do
+    if ! grep -Fq "$policy" docs/CICD_QUALITY_GATES.md; then
+        fail "docs/CICD_QUALITY_GATES.md: missing queue policy $policy"
+    fi
+done
+
+if ((failures > 0)); then
+    echo "Merge-queue readiness validation failed with $failures error(s)." >&2
+    exit 1
+fi
+
+echo "Merge-queue readiness validation passed."


### PR DESCRIPTION
Closes #610

Implements the repository-owned workflow, validation, documentation, and ruleset-readiness changes for the HomericIntelligence merge-queue rollout tracked by Odysseus #386.

Live ruleset activation remains staged for post-merge smoke validation.