### PR TITLE
ci(codeql): exclude vendored build/_deps from CodeQL analysis

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,15 @@
+# CodeQL configuration for Keystone.
+#
+# Scope CodeQL analysis to first-party source. The C/C++ analysis builds into
+# `build/codeql` and vendored dependencies are fetched under `build/**/_deps/`
+# (nats.c, cista, …) and `build/conan-deps/`. Those trees are third-party code
+# we do not maintain, so their findings — including alerts that surface as
+# "critical" (cpp/use-after-free) or "high" (cpp/world-writable-file-creation)
+# but actually point at upstream nats.c — must not be reported against this repo.
+#
+# See HomericIntelligence/Keystone#612.
+name: "Keystone CodeQL config"
+
+paths-ignore:
+  - build/**
+  - "**/_deps/**"

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -1334,6 +1334,7 @@ jobs:
           languages: c-cpp
           build-mode: manual
           queries: security-and-quality
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Install C++ build deps for CodeQL
         id: codeql_deps
@@ -1393,6 +1394,7 @@ jobs:
           languages: python
           build-mode: none
           queries: security-and-quality
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis (python)
         uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4


### PR DESCRIPTION
## Summary

CodeQL analyzes the vendored FetchContent/Conan dependency tree under `build/**/_deps/`
(nats.c, cista, …), inflating the code-scanning alert count with ~115 third-party findings
that are not this repo's code — including alerts that surface as **critical**
(`cpp/use-after-free`) and **high** (`cpp/world-writable-file-creation`) but actually point
at upstream nats.c, causing false urgency in triage and burying the ~198 findings that are
in Keystone's own source.

This scopes CodeQL to first-party code.

## Changes

- Add `.github/codeql/codeql-config.yml` with `paths-ignore: [build/**, "**/_deps/**"]`.
- Reference it via `config-file:` from both CodeQL `init` steps (c-cpp and python) in
  `.github/workflows/_required.yml`.

## Testing

- [x] All existing tests pass — no code changed; this only scopes CodeQL analysis paths.
- [ ] New tests added (if applicable) — N/A (CI configuration only).
- [x] Sanitizers pass (ASan, UBSan, TSan) — unaffected (no source change).

Effect is observable on the next CodeQL run: the ~115 `build/**/_deps/**` alerts (incl. the
false "critical" use-after-free / "high" world-writable) should be excluded, leaving only
first-party findings. The companion cleanup for those first-party notes is tracked in #613.

## Checklist

- [x] Code formatted (`make format`) — no C++/source touched; both YAML files parse and add
  no new yamllint violations.
- [x] On feature branch (not main)
- [x] Commit messages follow conventional commits
- [x] CHANGELOG.md is managed by release-please — do not edit manually

Closes #612

🤖 Generated with [Claude Code](https://claude.com/claude-code)
