### PR TITLE
ci: fast (<5 min) merge-queue smoke gate

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -10,16 +10,15 @@ security scanning of the Keystone HMAS (Hierarchical Multi-Agent System) codebas
 - **`_required.yml`** emits the baseline required contexts, including lint,
   build, test, package, security, schema, and dependency-version checks.
 - **`extras.yml`** emits the separately required `coverage` context and advisory
-  benchmark/NATS checks. Only coverage runs for merge-group events.
-- **`release-please.yml`** manages releases after pushes to `main`. For a
-  merge-group event, mutating release jobs are skipped and the required `release`
-  gate validates repository release metadata instead.
-- **`profiling-weekly.yml`** is scheduled/manual and is not a merge gate.
+  benchmark/NATS checks.
+- **`release-please.yml`** manages releases after pushes to `main`.
+- **`merge-queue-smoke.yml`** is the ONLY workflow that runs for
+  `merge_group/checks_requested`. It runs a single fast `merge-queue-smoke`
+  job (< 5 minutes, one runner slot) of real validation steps. Full CI
+  validates every commit at pull-request time and is left untouched.
 
-The first three workflows support `merge_group` with only the
-`checks_requested` activity type because they supply contexts required by the
-live `main` rulesets. The event is additive: existing push, pull-request, manual,
-and scheduled behavior remains unchanged.
+Existing push, pull-request, manual, and scheduled behavior is unchanged; only
+the merge-queue surface moved to the dedicated smoke workflow.
 
 ## Workflow Details
 
@@ -206,12 +205,13 @@ All workflows run on:
 
 ### Merge Queue
 
-Required-context workflows also run for `merge_group/checks_requested`. GitHub
-creates that event against the speculative group ref, allowing all required
-checks to validate the exact commit group that would reach `main`.
+Only `merge-queue-smoke.yml` runs for `merge_group/checks_requested`. GitHub
+creates that event against the speculative group ref; the `merge-queue-smoke`
+job re-validates fast repository invariants there, while the exhaustive suites
+run at pull-request time (each queued commit already passed them on its PR).
 
-The repository-owned workflows are queue-ready, but queue activation is a
-separate post-merge administration step. See
+Queue activation is a separate post-merge administration step (every ruleset's
+required contexts must first be replaced with `merge-queue-smoke`). See
 [CI/CD Quality Gates](../../docs/CICD_QUALITY_GATES.md#merge-queue-activation)
 for the preserved required-context baseline and approved queue policy.
 

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -10,8 +10,6 @@ on:
     branches: [main, develop, "claude/**"]
   pull_request:
     branches: [main, develop]
-  merge_group:
-    types: [checks_requested]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/extras.yml
+++ b/.github/workflows/extras.yml
@@ -9,7 +9,9 @@ on:
   pull_request:
     branches: [main, develop]
   # The `coverage` context is required by the live main ruleset, so this
-  # workflow must keep triggering on merge_group to emit it. Every job below
+  # workflow must keep triggering on merge_group to emit it until the
+  # ruleset is flipped to require only merge-queue-smoke (tracked
+  # separately; needs org-admin credentials to execute). Every job below
   # skips merge-queue builds (`if: github.event_name != 'merge_group'`): the
   # skipped conclusion satisfies the required context, while under ALLGREEN
   # grouping an actually-run sub-threshold `coverage` reading (it exits 1

--- a/.github/workflows/extras.yml
+++ b/.github/workflows/extras.yml
@@ -16,8 +16,6 @@ on:
   # skipped conclusion satisfies the required context, while under ALLGREEN
   # grouping an actually-run sub-threshold `coverage` reading (it exits 1
   # below its 75% target) would eject otherwise-green PRs from the queue.
-  merge_group:
-    types: [checks_requested]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/merge-queue-smoke.yml
+++ b/.github/workflows/merge-queue-smoke.yml
@@ -1,0 +1,82 @@
+name: Merge Queue Smoke
+
+# Sole merge_group workflow. Full CI (up to 16 jobs re-queued per merge group,
+# 70-90 min under runner-slot starvation) already ran on the pull_request; the
+# queue only needs a fast real sanity gate. One job = one runner slot, < 5 min.
+# PR-side CI is untouched: this workflow emits the single `merge-queue-smoke`
+# context that the branch rulesets gate the queue on after rollout.
+
+on:
+  merge_group:
+    types: [checks_requested]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mq-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  merge-queue-smoke:
+    name: merge-queue-smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - name: Run symlink check
+        run: bash scripts/check-symlinks.sh
+
+      - name: Validate merge-queue readiness contract
+        run: ./scripts/check-merge-queue-readiness.sh
+
+      - name: Validate GitHub Actions workflow YAML files
+        run: |
+          pip install --quiet check-jsonschema
+          find .github/workflows -name "*.yml" | sort | \
+            xargs check-jsonschema \
+              --schemafile https://json.schemastore.org/github-workflow
+
+      - name: Verify version consistency across release surfaces
+        run: |
+          python3 - <<'PYEOF'
+          import json, re, pathlib, sys, tomllib
+
+          root = pathlib.Path(".")
+
+          manifest_ver = json.loads(
+              (root / ".release-please-manifest.json").read_text()
+          ).get(".")
+
+          cmake_text = (root / "CMakeLists.txt").read_text()
+          cmake_m = re.search(r"project\s*\([^)]*VERSION\s+([\d.]+)", cmake_text, re.DOTALL)
+          cmake_ver = cmake_m.group(1) if cmake_m else None
+
+          conan_m = re.search(
+              r'version\s*=\s*["\']([^"\']+)["\']',
+              (root / "conanfile.py").read_text(),
+          )
+          conan_ver = conan_m.group(1) if conan_m else None
+
+          with open(root / "pixi.toml", "rb") as fh:
+              pixi_ver = tomllib.load(fh).get("project", {}).get("version")
+
+          versions = {
+              ".release-please-manifest.json": manifest_ver,
+              "CMakeLists.txt":                cmake_ver,
+              "conanfile.py":                  conan_ver,
+              "pixi.toml":                     pixi_ver,
+          }
+          for k, v in versions.items():
+              print(f"{k:32s}: {v}")
+
+          missing = [k for k, v in versions.items() if v is None]
+          if missing:
+              print(f"\nVersion not found in: {', '.join(missing)}")
+              sys.exit(1)
+          if len(set(versions.values())) != 1:
+              print("\nRelease surfaces disagree on version")
+              sys.exit(1)
+          print(f"\nAll release surfaces agree: {manifest_ver}")
+          PYEOF

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,8 +3,6 @@ name: Release Please
 on:
   push:
     branches: [main]
-  merge_group:
-    types: [checks_requested]
   workflow_dispatch:
 
 permissions:

--- a/scripts/check-merge-queue-readiness.sh
+++ b/scripts/check-merge-queue-readiness.sh
@@ -32,12 +32,33 @@ require_merge_group_trigger() {
     fi
 }
 
+forbid_merge_group_trigger() {
+    local file=$1
+    local trigger_block
+
+    trigger_block=$(sed -n '/^on:/,/^[^[:space:]]/p' "$file")
+    if grep -Eq '^  merge_group:$' <<<"$trigger_block"; then
+        fail "$file: must not trigger on merge_group — queue builds run only merge-queue-smoke.yml (single fast runner slot)"
+    fi
+}
+
+# merge_group is carried EXCLUSIVELY by the dedicated smoke workflow so a
+# merge group consumes one runner slot for < 5 minutes instead of re-running
+# the full 16-job suite (70-90 min under runner-slot starvation).
+require_merge_group_trigger .github/workflows/merge-queue-smoke.yml
+
 for workflow in \
     .github/workflows/_required.yml \
     .github/workflows/extras.yml \
     .github/workflows/release-please.yml; do
-    require_merge_group_trigger "$workflow"
+    forbid_merge_group_trigger "$workflow"
 done
+
+# The smoke workflow must emit exactly the merge-queue-smoke context the
+# queue gates on; PR-side workflows are left untouched.
+require_line .github/workflows/merge-queue-smoke.yml \
+    '^    name: merge-queue-smoke$' \
+    'merge-queue-smoke context in the smoke workflow'
 
 required_contexts=(
     lint


### PR DESCRIPTION
## Diagnosis

Merge-group events re-executed the full required CI surface (`_required.yml`'s 18 jobs plus `extras.yml`'s coverage and `release-please.yml`, a 16-job-class rerun). Under runner-slot starvation each job waits 8-16+ minutes just for a slot, so a single merge-queue entry took 70-90 minutes — for commits that already passed the identical suite on their pull request.

## Design

- **merge_group now triggers exactly one workflow**: the new `.github/workflows/merge-queue-smoke.yml`, a single `merge-queue-smoke` job (`timeout-minutes: 5`, one runner slot) running real validation borrowed from the repo's fastest existing jobs: `scripts/check-symlinks.sh`, `scripts/check-merge-queue-readiness.sh`, `check-jsonschema` workflow-schema validation, and the release-surface version-consistency cross-check. No `continue-on-error`, no `|| true`, no `::warning::`.
- **`merge_group` removed** from `_required.yml`, `extras.yml`, and `release-please.yml`. That is the ONLY change to existing workflows — no jobs added, removed, or modified; the now-vacuous `if: github.event_name != 'merge_group'` job guards are left in place as defense in depth. PR/push/dispatch testing is byte-for-byte as before.
- `scripts/check-merge-queue-readiness.sh` (run by the required `schema-validation` job) is updated to pin the new contract: `merge_group` exclusively on `merge-queue-smoke.yml` with its single `merge-queue-smoke` context; all other assertions (contexts, push/PR triggers, release-please guard, queue-policy doc pins) unchanged. This file had to change or the required check would fail on this PR. `.github/workflows/README.md`'s merge-queue rows are refreshed to match.

## Post-merge ruleset rollout (REQUIRED before using the queue)

After merge, replace ALL `required_status_checks` contexts (in every ruleset, including the extras rulesets) with the single context `merge-queue-smoke` and set `min_entries_to_merge_wait_minutes` to 0; PR-side checks keep running but become non-blocking; the queue must not be used between merge and flip.

For Keystone that means both ruleset 15556488 (homeric-main-baseline: lint, unit-tests, integration-tests, security/dependency-scan, security/secrets-scan, build, schema-validation, deps/version-sync, test, package, release, install) and ruleset 18221122 (homeric-main-extras: coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
