### PR TITLE
test(coverage): register nats_status tests + run profiling under coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -320,6 +320,7 @@ add_executable(
   tests/unit/test_nats_connection.cpp # Issue #88: NATS reconnection callbacks
   tests/unit/test_subject_validator.cpp # Issue #280: NATS wildcard-aware token
                                         # validation
+  tests/unit/test_nats_status.cpp # Issue #88: NATS connection status tracker
 )
 
 # The gRPC test fixture (grpc_test_fixture.cpp) and TLS test (test_grpc_tls.cpp)

--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ TEST_PROFILING := profiling_tests
 test: compile
 	@echo "Running all tests..."
 	$(CONTAINER_CHECK)
-	$(CONTAINER_PREFIX) bash -c "cd $(BUILD_DIR)/$(BUILD_SUBDIR) && TSAN_OPTIONS=\"$(CONTAINER_TSAN_OPTIONS)\" ctest --output-on-failure -j$(NPROC) --timeout $(CTEST_TIMEOUT)"
+	$(CONTAINER_PREFIX) bash -c "cd $(BUILD_DIR)/$(BUILD_SUBDIR) && KEYSTONE_PROFILE=1 TSAN_OPTIONS=\"$(CONTAINER_TSAN_OPTIONS)\" ctest --output-on-failure -j$(NPROC) --timeout $(CTEST_TIMEOUT)"
 
 # Individual test suites (run specific executable)
 test.unit: compile


### PR DESCRIPTION
## Summary

Two zero-risk C++ test-coverage wins toward the repo's 85% target. No production code changes, no new NATS broker dependency.

1. **`src/monitoring/nats_status.cpp` (0.0% -> 100.0%).** `tests/unit/test_nats_status.cpp` already existed in the tree (10 GoogleTest cases covering every setter, the state/timestamp getters, the "disconnect/reconnect must not reset the success clock" invariant, and a concurrency stress test) but was **never added to the `unit_tests` source list**, so it never compiled or ran. `keystone_core` already links the source, so the only change needed was registering the test file in `CMakeLists.txt`.

2. **`src/core/profiling.cpp` (28.9% -> 88.9%).** The 7 `ProfilingTest.*` cases `GTEST_SKIP` unless `KEYSTONE_PROFILE=1` is present in the environment (the flag is read once via `std::getenv` at process start). The coverage flow runs `make test`, whose `test:` recipe did not set it, so the tests skipped and profiling stayed uncovered. Exporting `KEYSTONE_PROFILE=1` on the ctest invocation lets the opt-in suite run under the coverage build.

## Coverage evidence

Identical `generate_coverage.sh` pipeline, `build/x86.coverage.debug`, in the `keystone-dev` container. Before = unmodified `origin/main` tree (nats test unregistered, `make test` without the env). After = this branch.

Before (`lines......: 75.3% (2159 of 2869 lines)`):
```
src/core/profiling.cpp          28.9% (39/135)
src/monitoring/nats_status.cpp   0.0% (0/21)
```

After (`lines......: 78.8% (2265 of 2873 lines)`):
```
src/core/profiling.cpp          88.9% (120/135)
src/monitoring/nats_status.cpp  100.0% (21/21)
include/monitoring/nats_status.hpp 100.0% (4/4)
```

Per-file summary:

| File | Before | After |
|------|--------|-------|
| `src/core/profiling.cpp` | 28.9% (39/135) | **88.9% (120/135)** |
| `src/monitoring/nats_status.cpp` | 0.0% (0/21) | **100.0% (21/21)** |
| Overall | 75.3% (2159/2869) | **78.8% (2265/2873)** |

Both target files exceed the 85% goal; overall repo line coverage rises +3.5 pts and does not decrease.

## Tests

`ctest --output-on-failure -j2` with `KEYSTONE_PROFILE=1`: **100% tests passed, 0 failed out of 514.**

Refs #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)
