### PR TITLE
test(coverage): raise work_stealing_scheduler + simulated_network coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,13 +359,23 @@ add_executable(
   tests/unit/test_pull_or_steal.cpp
   tests/unit/test_work_stealing_scheduler.cpp
   tests/unit/test_cpu_affinity.cpp # Phase D.2: CPU affinity tests
-  tests/unit/test_scheduler_backoff.cpp # Stream C1: 3-phase backoff tests
 )
 
 target_link_libraries(concurrency_unit_tests keystone_concurrency keystone_core
                       GTest::gtest_main)
 
 gtest_discover_tests(concurrency_unit_tests)
+
+# Stream C1: 3-phase backoff tests. Kept in their own binary and marked
+# RUN_SERIAL because they assert wall-clock latency bounds: under `ctest -jN`
+# the other scheduler suites saturate the runner's cores and inflate the
+# measured SPIN/SLEEP wake-up latencies past their assertions.
+add_executable(scheduler_backoff_tests tests/unit/test_scheduler_backoff.cpp)
+
+target_link_libraries(scheduler_backoff_tests keystone_concurrency
+                      keystone_core GTest::gtest_main)
+
+gtest_discover_tests(scheduler_backoff_tests PROPERTIES RUN_SERIAL TRUE)
 
 # Unit Tests - Simulation (Phase D.3)
 add_executable(

--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,7 @@ TEST_ASYNC := async_delegation_tests
 TEST_DISTRIBUTED := distributed_hierarchy_tests
 TEST_UNIT := unit_tests
 TEST_CONCURRENCY := concurrency_unit_tests
+TEST_SCHEDULER_BACKOFF := scheduler_backoff_tests
 TEST_SIMULATION := simulation_unit_tests
 TEST_PROFILING := profiling_tests
 
@@ -163,6 +164,7 @@ test.concurrency: compile
 	@echo "Running concurrency unit tests..."
 	$(CONTAINER_CHECK)
 	$(CONTAINER_PREFIX) ./$(BUILD_DIR)/$(BUILD_SUBDIR)/$(TEST_CONCURRENCY)
+	$(CONTAINER_PREFIX) ./$(BUILD_DIR)/$(BUILD_SUBDIR)/$(TEST_SCHEDULER_BACKOFF)
 
 test.simulation: compile
 	@echo "Running simulation unit tests..."

--- a/tests/unit/test_simulated_network.cpp
+++ b/tests/unit/test_simulated_network.cpp
@@ -312,3 +312,102 @@ TEST_F(SimulatedNetworkTest, PendingMessageCount) {
 
   EXPECT_EQ(network.getPendingMessages(), 0);
 }
+
+// ===========================================================================
+// Coverage extension tests (test/coverage-scheduler-sim-network)
+// Target uncovered regions: default constructor, network partition
+// (create/heal/isPartitioned/canCommunicate branches) and the partition-drop
+// path in send().
+// ===========================================================================
+
+// Test: default constructor delegates to Config{} and starts clean
+TEST_F(SimulatedNetworkTest, DefaultConstructor) {
+  SimulatedNetwork network;  // SimulatedNetwork() -> SimulatedNetwork(Config{})
+
+  EXPECT_FALSE(network.isPartitioned());
+  EXPECT_EQ(network.getTotalMessages(), 0);
+  EXPECT_EQ(network.getPartitionDroppedMessages(), 0);
+
+  // Default config has zero packet loss, so a message is queued (not dropped).
+  network.send(0, 1, []() {});
+  EXPECT_EQ(network.getTotalMessages(), 1);
+  EXPECT_EQ(network.getDroppedMessages(), 0);
+  EXPECT_EQ(network.getPendingMessages(), 1);
+}
+
+// Test: no partition -> canCommunicate always true (early-return branch)
+TEST_F(SimulatedNetworkTest, CanCommunicateNoPartition) {
+  SimulatedNetwork network;
+  EXPECT_FALSE(network.isPartitioned());
+  EXPECT_TRUE(network.canCommunicate(0, 1));
+  EXPECT_TRUE(network.canCommunicate(5, 5));
+}
+
+// Test: createPartition sets state and isPartitioned reports true
+TEST_F(SimulatedNetworkTest, CreatePartitionSetsState) {
+  SimulatedNetwork network;
+  EXPECT_FALSE(network.isPartitioned());
+
+  network.createPartition({0, 1}, {2, 3});
+  EXPECT_TRUE(network.isPartitioned());
+}
+
+// Test: canCommunicate honours partition membership on every branch
+TEST_F(SimulatedNetworkTest, CanCommunicateAcrossPartition) {
+  SimulatedNetwork network;
+  network.createPartition({0, 1}, {2, 3});
+
+  // Both in A
+  EXPECT_TRUE(network.canCommunicate(0, 1));
+  // Both in B
+  EXPECT_TRUE(network.canCommunicate(2, 3));
+  // A -> B (different partitions)
+  EXPECT_FALSE(network.canCommunicate(0, 2));
+  // B -> A (different partitions)
+  EXPECT_FALSE(network.canCommunicate(3, 1));
+  // from in A, to in neither -> different partitions
+  EXPECT_FALSE(network.canCommunicate(0, 9));
+  // from in B, to in neither -> different partitions
+  EXPECT_FALSE(network.canCommunicate(2, 9));
+  // neither node in any partition -> cannot communicate
+  EXPECT_FALSE(network.canCommunicate(8, 9));
+}
+
+// Test: send across a partition is dropped and counted separately
+TEST_F(SimulatedNetworkTest, SendDroppedByPartition) {
+  SimulatedNetwork::Config config{.min_latency = 10us, .max_latency = 20us};
+  SimulatedNetwork network(config);
+  network.createPartition({0, 1}, {2, 3});
+
+  // Cross-partition send -> dropped by partition.
+  network.send(0, 2, []() {});
+  EXPECT_EQ(network.getTotalMessages(), 1);
+  EXPECT_EQ(network.getPartitionDroppedMessages(), 1);
+  EXPECT_EQ(network.getDroppedMessages(), 0);  // not a packet-loss drop
+  EXPECT_EQ(network.getPendingMessages(), 0);
+
+  // Same-partition send -> delivered normally.
+  network.send(0, 1, []() {});
+  EXPECT_EQ(network.getTotalMessages(), 2);
+  EXPECT_EQ(network.getPartitionDroppedMessages(), 1);
+  EXPECT_EQ(network.getPendingMessages(), 1);
+}
+
+// Test: healPartition restores full connectivity
+TEST_F(SimulatedNetworkTest, HealPartitionRestoresConnectivity) {
+  SimulatedNetwork::Config config{.min_latency = 10us, .max_latency = 20us};
+  SimulatedNetwork network(config);
+
+  network.createPartition({0}, {1});
+  EXPECT_TRUE(network.isPartitioned());
+  EXPECT_FALSE(network.canCommunicate(0, 1));
+
+  network.healPartition();
+  EXPECT_FALSE(network.isPartitioned());
+  EXPECT_TRUE(network.canCommunicate(0, 1));
+
+  // After healing, a previously-blocked send now goes through.
+  network.send(0, 1, []() {});
+  EXPECT_EQ(network.getPartitionDroppedMessages(), 0);
+  EXPECT_EQ(network.getPendingMessages(), 1);
+}

--- a/tests/unit/test_work_stealing_scheduler.cpp
+++ b/tests/unit/test_work_stealing_scheduler.cpp
@@ -303,3 +303,175 @@ TEST(WorkStealingSchedulerTest, HeavyLoad) {
 
   scheduler.shutdown();
 }
+
+// ===========================================================================
+// Coverage extension tests (test/coverage-scheduler-sim-network)
+// Target uncovered regions: MAX_WORKER_THREADS guard, coroutine submitTo,
+// tryStealWork() (NUMA steal, done/valid coroutine handling), CPU affinity.
+// ===========================================================================
+
+#include <coroutine>
+
+namespace {
+
+// Minimal manually-driven coroutine used ONLY to obtain a raw
+// std::coroutine_handle<> for exercising the scheduler's coroutine paths.
+// The handle is owned by the test (via CoroTask) and destroyed at scope exit,
+// so there is no lifetime race with worker threads (work executes inline here).
+struct CoroTask {
+  struct promise_type {
+    CoroTask get_return_object() {
+      return CoroTask{
+          std::coroutine_handle<promise_type>::from_promise(*this)};
+    }
+    std::suspend_always initial_suspend() noexcept { return {}; }
+    std::suspend_always final_suspend() noexcept { return {}; }
+    void return_void() noexcept {}
+    void unhandled_exception() noexcept {}
+  };
+
+  // Type-erased handle so passing it to submitTo() unambiguously selects the
+  // coroutine_handle<> overload (a typed handle<promise_type> is convertible to
+  // both submitTo overloads and would be ambiguous).
+  std::coroutine_handle<> handle;
+
+  explicit CoroTask(std::coroutine_handle<> h) : handle(h) {}
+  CoroTask(const CoroTask&) = delete;
+  CoroTask& operator=(const CoroTask&) = delete;
+  ~CoroTask() {
+    if (handle) {
+      handle.destroy();
+    }
+  }
+};
+
+CoroTask makeCounterCoro(std::shared_ptr<std::atomic<int32_t>> counter) {
+  counter->fetch_add(1);
+  co_return;
+}
+
+}  // namespace
+
+// Test: Requesting more than MAX_WORKER_THREADS throws (DoS guard, FIX P2-10)
+TEST(WorkStealingSchedulerTest, TooManyWorkersThrows) {
+  // MAX_WORKER_THREADS is 256; request well above it.
+  EXPECT_THROW(WorkStealingScheduler(100000), std::invalid_argument);
+}
+
+// Test: submitTo coroutine overload runs the coroutine on a worker
+TEST(WorkStealingSchedulerTest, SubmitToCoroutine) {
+  WorkStealingScheduler scheduler(2);
+  scheduler.start();
+
+  auto counter = std::make_shared<std::atomic<int32_t>>(0);
+  CoroTask task = makeCounterCoro(counter);
+
+  scheduler.submitTo(1, task.handle);
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+  EXPECT_EQ(counter->load(), 1);
+  EXPECT_TRUE(task.handle.done());
+
+  scheduler.shutdown();
+}
+
+// Test: submitTo coroutine overload with invalid index is a safe no-op
+TEST(WorkStealingSchedulerTest, SubmitToCoroutineInvalidIndex) {
+  WorkStealingScheduler scheduler(2);
+  scheduler.start();
+
+  auto counter = std::make_shared<std::atomic<int32_t>>(0);
+  CoroTask task = makeCounterCoro(counter);
+
+  scheduler.submitTo(42, task.handle);  // out of range
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+  EXPECT_EQ(counter->load(), 0);  // never scheduled
+  EXPECT_FALSE(task.handle.done());
+
+  scheduler.shutdown();
+}
+
+// Test: tryStealWork returns nullopt when all queues are empty
+TEST(WorkStealingSchedulerTest, TryStealWorkEmpty) {
+  WorkStealingScheduler scheduler(3);
+  // Not started: no workers draining, queues empty.
+  auto stolen = scheduler.tryStealWork();
+  EXPECT_FALSE(stolen.has_value());
+}
+
+// Test: tryStealWork steals a submitted function work item (NUMA path)
+TEST(WorkStealingSchedulerTest, TryStealWorkFunction) {
+  // Single worker so the random victim is deterministic (index 0).
+  WorkStealingScheduler scheduler(1);
+  // Do NOT start(): keep the item in the queue so tryStealWork can grab it.
+
+  auto counter = std::make_shared<std::atomic<int32_t>>(0);
+  scheduler.submitTo(0, [counter]() { counter->fetch_add(1); });
+
+  auto stolen = scheduler.tryStealWork();
+  ASSERT_TRUE(stolen.has_value());
+  (*stolen)();
+  EXPECT_EQ(counter->load(), 1);
+
+  // Queue should now be drained; a second steal yields nothing.
+  auto again = scheduler.tryStealWork();
+  EXPECT_FALSE(again.has_value());
+}
+
+// Test: tryStealWork on a valid coroutine handle wraps + resumes it
+TEST(WorkStealingSchedulerTest, TryStealWorkValidCoroutine) {
+  WorkStealingScheduler scheduler(1);
+
+  auto counter = std::make_shared<std::atomic<int32_t>>(0);
+  CoroTask task = makeCounterCoro(counter);
+  ASSERT_FALSE(task.handle.done());
+
+  scheduler.submitTo(0, task.handle);
+
+  auto stolen = scheduler.tryStealWork();
+  ASSERT_TRUE(stolen.has_value());
+  (*stolen)();  // resumes the coroutine
+
+  EXPECT_EQ(counter->load(), 1);
+  EXPECT_TRUE(task.handle.done());
+}
+
+// Test: tryStealWork on an already-completed coroutine handle returns nullopt
+TEST(WorkStealingSchedulerTest, TryStealWorkDoneCoroutine) {
+  WorkStealingScheduler scheduler(1);
+
+  auto counter = std::make_shared<std::atomic<int32_t>>(0);
+  CoroTask task = makeCounterCoro(counter);
+
+  // Drive the coroutine to completion before submitting the handle.
+  task.handle.resume();
+  ASSERT_TRUE(task.handle.done());
+  EXPECT_EQ(counter->load(), 1);
+
+  scheduler.submitTo(0, task.handle);
+
+  // The victim queue holds a done handle; tryStealWork must detect it,
+  // warn, and return nullopt rather than resuming a finished coroutine.
+  auto stolen = scheduler.tryStealWork();
+  EXPECT_FALSE(stolen.has_value());
+  EXPECT_EQ(counter->load(), 1);  // not resumed again
+}
+
+// Test: CPU affinity enabled path executes work without error
+TEST(WorkStealingSchedulerTest, CpuAffinityEnabled) {
+  WorkStealingScheduler scheduler(2, /*enable_cpu_affinity=*/true);
+  scheduler.start();
+
+  auto counter = std::make_shared<std::atomic<int32_t>>(0);
+  for (int32_t i = 0; i < 10; ++i) {
+    scheduler.submit([counter]() { counter->fetch_add(1); });
+  }
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  EXPECT_EQ(counter->load(), 10);
+
+  scheduler.shutdown();
+}


### PR DESCRIPTION
## Summary

Raises C++ line coverage for two owned source files by **extending the existing GoogleTest suites** — no production code is modified.

| File | Before | After | Uncovered (before → after) |
|------|-------:|------:|----------------------------|
| `src/concurrency/work_stealing_scheduler.cpp` | 80.3% | **92.4%** | 39 → 15 |
| `src/simulation/simulated_network.cpp`        | 70.3% | **99.2%** | 35 → 1  |

Both files now clear the 85% target. Overall repo coverage: **77.4%** (rises — the new tests only add covered lines; no source removed).

## New test coverage

**`test_work_stealing_scheduler.cpp`**
- `MAX_WORKER_THREADS` DoS guard throws `std::invalid_argument`
- `submitTo(coroutine_handle)` — valid dispatch + out-of-range no-op
- `tryStealWork()` (NUMA steal path): empty queues, function-item steal, valid coroutine wrap+resume, already-done coroutine detection/warn
- CPU-affinity-enabled worker path

**`test_simulated_network.cpp`**
- default constructor delegation to `Config{}`
- `createPartition` / `healPartition` / `isPartitioned`
- `canCommunicate` across every partition-membership branch
- `send()` cross-partition drop + `partition_dropped_messages_` counter

## Verification
- `ctest`: **511/511 passed, 0 failed** (coverage build, run in `keystone-dev-c`)
- No `LCOV_EXCL` regions added; remaining uncovered lines are timing/thread-race-dependent trace logs and a platform affinity-error branch — all reachable, none asserted as covered.

Refs: work-stealing scheduler + simulated network coverage uplift.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
