### PR TITLE
test(core): raise message_bus/message/heartbeat_monitor coverage to >99%

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -298,6 +298,8 @@ add_executable(
   # hierarchy was extracted to ProjectAgamemnon per ADR-015. Transport
   # decoupling is covered by test_message_sink (non-agent IMessageSink routing).
   tests/unit/test_message_sink.cpp # Part A: transport decoupled from agents
+  tests/unit/test_message.cpp # Coverage: KeystoneMessage/Response factories
+  tests/unit/test_message_bus.cpp # Coverage: MessageBus routing/NATS/scheduler
   tests/unit/test_message_serializer.cpp
   tests/unit/test_agent_id_interning.cpp # Phase A2: Agent ID interning tests
   tests/unit/test_metrics.cpp

--- a/tests/unit/test_heartbeat_monitor.cpp
+++ b/tests/unit/test_heartbeat_monitor.cpp
@@ -3,20 +3,19 @@
  * @brief Unit tests for HeartbeatMonitor
  */
 
-#include <gtest/gtest.h>
+#include "core/heartbeat_monitor.hpp"
 
 #include <thread>
 
-#include "core/heartbeat_monitor.hpp"
+#include <gtest/gtest.h>
 
 using namespace keystone::core;
 
 class HeartbeatMonitorTest : public ::testing::Test {
  protected:
-  HeartbeatMonitor::Config default_config_{
-      .heartbeat_interval = std::chrono::milliseconds(100),
-      .timeout_threshold = std::chrono::milliseconds(300),
-      .auto_remove_dead = false};
+  HeartbeatMonitor::Config default_config_{.heartbeat_interval = std::chrono::milliseconds(100),
+                                           .timeout_threshold = std::chrono::milliseconds(300),
+                                           .auto_remove_dead = false};
 };
 
 TEST_F(HeartbeatMonitorTest, DefaultConstruction) {
@@ -69,9 +68,8 @@ TEST_F(HeartbeatMonitorTest, FailureCallback) {
   HeartbeatMonitor monitor(default_config_);
 
   std::string failed_agent;
-  monitor.setFailureCallback([&failed_agent](const std::string& agent_id) {
-    failed_agent = agent_id;
-  });
+  monitor.setFailureCallback(
+      [&failed_agent](const std::string& agent_id) { failed_agent = agent_id; });
 
   monitor.recordHeartbeat("agent1");
   std::this_thread::sleep_for(std::chrono::milliseconds(350));
@@ -99,4 +97,113 @@ TEST_F(HeartbeatMonitorTest, MultipleAgents) {
 
   EXPECT_EQ(monitor.getAliveAgents().size(), 2u);
   EXPECT_EQ(monitor.getDeadAgents().size(), 1u);
+}
+
+// ---------------------------------------------------------------------------
+// Extended coverage: getStatus, removeAgent, reset, auto-remove, recovery.
+// ---------------------------------------------------------------------------
+
+TEST_F(HeartbeatMonitorTest, GetStatusUnknownReturnsNullopt) {
+  HeartbeatMonitor monitor(default_config_);
+  EXPECT_FALSE(monitor.getStatus("ghost").has_value());
+}
+
+TEST_F(HeartbeatMonitorTest, GetStatusReflectsHeartbeatCount) {
+  HeartbeatMonitor monitor(default_config_);
+  monitor.recordHeartbeat("agent1");
+  monitor.recordHeartbeat("agent1");
+
+  auto status = monitor.getStatus("agent1");
+  ASSERT_TRUE(status.has_value());
+  EXPECT_EQ(status->agent_id, "agent1");
+  EXPECT_EQ(status->total_heartbeats, 2u);
+  EXPECT_TRUE(status->is_alive);
+}
+
+TEST_F(HeartbeatMonitorTest, RemoveAgentStopsTracking) {
+  HeartbeatMonitor monitor(default_config_);
+  monitor.recordHeartbeat("agent1");
+  ASSERT_EQ(monitor.getRegisteredAgents().size(), 1u);
+
+  monitor.removeAgent("agent1");
+  EXPECT_TRUE(monitor.getRegisteredAgents().empty());
+  EXPECT_FALSE(monitor.getStatus("agent1").has_value());
+}
+
+TEST_F(HeartbeatMonitorTest, RemoveUnknownAgentIsNoOp) {
+  HeartbeatMonitor monitor(default_config_);
+  monitor.recordHeartbeat("agent1");
+  // Removing an agent that isn't tracked must not throw or drop others.
+  EXPECT_NO_THROW(monitor.removeAgent("ghost"));
+  EXPECT_EQ(monitor.getRegisteredAgents().size(), 1u);
+}
+
+TEST_F(HeartbeatMonitorTest, ResetClearsAgentsAndFailures) {
+  HeartbeatMonitor monitor(default_config_);
+  monitor.recordHeartbeat("agent1");
+  std::this_thread::sleep_for(std::chrono::milliseconds(350));
+  monitor.checkAgents();
+  ASSERT_EQ(monitor.getTotalFailures(), 1u);
+
+  monitor.reset();
+  EXPECT_TRUE(monitor.getRegisteredAgents().empty());
+  EXPECT_EQ(monitor.getTotalFailures(), 0u);
+}
+
+TEST_F(HeartbeatMonitorTest, RecoveryAfterFailureTakesRecoveredBranch) {
+  HeartbeatMonitor monitor(default_config_);
+
+  monitor.recordHeartbeat("agent1");
+  std::this_thread::sleep_for(std::chrono::milliseconds(350));
+  EXPECT_EQ(monitor.checkAgents(), 1u);
+
+  auto before = monitor.getStatus("agent1");
+  ASSERT_TRUE(before.has_value());
+  EXPECT_FALSE(before->is_alive);
+
+  // Heartbeat while dead exercises the was_dead recovery branch.
+  monitor.recordHeartbeat("agent1");
+  auto after = monitor.getStatus("agent1");
+  ASSERT_TRUE(after.has_value());
+  EXPECT_TRUE(after->is_alive);
+  EXPECT_EQ(after->total_heartbeats, 2u);
+}
+
+TEST_F(HeartbeatMonitorTest, AutoRemoveDeadDropsFailedAgents) {
+  HeartbeatMonitor::Config cfg{.heartbeat_interval = std::chrono::milliseconds(100),
+                               .timeout_threshold = std::chrono::milliseconds(300),
+                               .auto_remove_dead = true};
+  HeartbeatMonitor monitor(cfg);
+
+  monitor.recordHeartbeat("agent1");
+  std::this_thread::sleep_for(std::chrono::milliseconds(350));
+
+  EXPECT_EQ(monitor.checkAgents(), 1u);
+  // auto_remove_dead=true → failed agent is erased from the registry.
+  EXPECT_TRUE(monitor.getRegisteredAgents().empty());
+  EXPECT_EQ(monitor.getTotalFailures(), 1u);
+}
+
+TEST_F(HeartbeatMonitorTest, CheckAgentsNoFailuresWhenAllFresh) {
+  HeartbeatMonitor monitor(default_config_);
+  monitor.recordHeartbeat("agent1");
+  monitor.recordHeartbeat("agent2");
+  // Both fresh → no newly-failed agents.
+  EXPECT_EQ(monitor.checkAgents(), 0u);
+}
+
+TEST_F(HeartbeatMonitorTest, IsAliveUnknownAgentIsFalse) {
+  HeartbeatMonitor monitor(default_config_);
+  EXPECT_FALSE(monitor.isAlive("ghost"));
+}
+
+TEST_F(HeartbeatMonitorTest, GetDeadAgentsListsTimedOut) {
+  HeartbeatMonitor monitor(default_config_);
+  monitor.recordHeartbeat("agent1");
+  std::this_thread::sleep_for(std::chrono::milliseconds(350));
+
+  auto dead = monitor.getDeadAgents();
+  ASSERT_EQ(dead.size(), 1u);
+  EXPECT_EQ(dead[0], "agent1");
+  EXPECT_TRUE(monitor.getAliveAgents().empty());
 }

--- a/tests/unit/test_message.cpp
+++ b/tests/unit/test_message.cpp
@@ -1,0 +1,185 @@
+/**
+ * @file test_message.cpp
+ * @brief Unit tests for KeystoneMessage and Response factory helpers.
+ *
+ * Covers the message factory overloads, deadline helpers, and Response
+ * success/error construction that make up the pure-transport message value
+ * type (src/core/message.cpp). These are in-memory value operations — no
+ * broker or scheduler required.
+ */
+
+#include "core/message.hpp"
+
+#include <chrono>
+#include <optional>
+#include <string>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+using namespace keystone::core;
+using namespace std::chrono_literals;
+
+// ---------------------------------------------------------------------------
+// KeystoneMessage::create — legacy (command) overload
+// ---------------------------------------------------------------------------
+
+TEST(MessageFactory, LegacyCreateSetsDefaultsAndFields) {
+  auto msg = KeystoneMessage::create("alice", "bob", "ping", "payload-data");
+
+  EXPECT_EQ(msg.sender_id, "alice");
+  EXPECT_EQ(msg.receiver_id, "bob");
+  ASSERT_TRUE(msg.payload.has_value());
+  EXPECT_EQ(*msg.payload, "payload-data");
+
+  // Legacy overload defaults action/content and priority.
+  EXPECT_EQ(msg.action_type, ActionType::EXECUTE);
+  EXPECT_EQ(msg.content_type, ContentType::TEXT_PLAIN);
+  EXPECT_EQ(msg.priority, Priority::NORMAL);
+
+  // Auto-generated UUID: 32 hex + 4 dashes = 36 chars.
+  EXPECT_EQ(msg.msg_id.size(), 36u);
+  EXPECT_FALSE(msg.hasDeadlinePassed());
+}
+
+TEST(MessageFactory, LegacyCreateWithoutPayloadIsNullopt) {
+  auto msg = KeystoneMessage::create("alice", "bob", "ping");
+  EXPECT_FALSE(msg.payload.has_value());
+}
+
+TEST(MessageFactory, GeneratedIdsAreUnique) {
+  auto a = KeystoneMessage::create("s", "r", "cmd");
+  auto b = KeystoneMessage::create("s", "r", "cmd");
+  EXPECT_NE(a.msg_id, b.msg_id);
+}
+
+// ---------------------------------------------------------------------------
+// KeystoneMessage::create — enhanced (ActionType) overload
+// ---------------------------------------------------------------------------
+
+TEST(MessageFactory, EnhancedCreateSetsActionAndContent) {
+  auto msg = KeystoneMessage::create(
+      "alice", "bob", ActionType::SHUTDOWN, std::nullopt, ContentType::BINARY_CISTA);
+
+  EXPECT_EQ(msg.sender_id, "alice");
+  EXPECT_EQ(msg.receiver_id, "bob");
+  EXPECT_EQ(msg.action_type, ActionType::SHUTDOWN);
+  EXPECT_EQ(msg.content_type, ContentType::BINARY_CISTA);
+  EXPECT_EQ(msg.priority, Priority::NORMAL);
+  EXPECT_FALSE(msg.payload.has_value());
+  EXPECT_FALSE(msg.deadline.has_value());
+  EXPECT_EQ(msg.msg_id.size(), 36u);
+}
+
+TEST(MessageFactory, EnhancedCreateDefaultsToTextPlain) {
+  auto msg = KeystoneMessage::create("alice", "bob", ActionType::RETURN_RESULT, "result");
+  EXPECT_EQ(msg.content_type, ContentType::TEXT_PLAIN);
+  ASSERT_TRUE(msg.payload.has_value());
+  EXPECT_EQ(*msg.payload, "result");
+}
+
+// ---------------------------------------------------------------------------
+// Copy / move special members (defined out-of-line in message.cpp)
+// ---------------------------------------------------------------------------
+
+TEST(MessageFactory, CopyAndMovePreserveFields) {
+  auto original = KeystoneMessage::create("alice", "bob", ActionType::EXECUTE, "data");
+  original.priority = Priority::HIGH;
+
+  KeystoneMessage copied(original);
+  EXPECT_EQ(copied.msg_id, original.msg_id);
+  EXPECT_EQ(copied.priority, Priority::HIGH);
+
+  KeystoneMessage assigned;
+  assigned = original;
+  EXPECT_EQ(assigned.receiver_id, "bob");
+
+  const std::string moved_id = original.msg_id;
+  KeystoneMessage moved(std::move(original));
+  EXPECT_EQ(moved.msg_id, moved_id);
+
+  KeystoneMessage move_assigned;
+  move_assigned = std::move(copied);
+  EXPECT_EQ(move_assigned.sender_id, "alice");
+}
+
+// ---------------------------------------------------------------------------
+// Deadline helpers
+// ---------------------------------------------------------------------------
+
+TEST(MessageDeadline, NoDeadlineByDefault) {
+  auto msg = KeystoneMessage::create("s", "r", "cmd");
+  EXPECT_FALSE(msg.hasDeadlinePassed());
+  EXPECT_FALSE(msg.getTimeUntilDeadline().has_value());
+}
+
+TEST(MessageDeadline, FutureDeadlineNotPassedAndHasTimeRemaining) {
+  auto msg = KeystoneMessage::create("s", "r", "cmd");
+  msg.setDeadlineFromNow(10s);
+
+  EXPECT_FALSE(msg.hasDeadlinePassed());
+
+  auto remaining = msg.getTimeUntilDeadline();
+  ASSERT_TRUE(remaining.has_value());
+  EXPECT_GT(remaining->count(), 0);
+  EXPECT_LE(remaining->count(), 10000);
+}
+
+TEST(MessageDeadline, PassedDeadlineReportsZeroRemaining) {
+  auto msg = KeystoneMessage::create("s", "r", "cmd");
+  // Set a deadline in the past.
+  msg.deadline = std::chrono::system_clock::now() - 1s;
+
+  EXPECT_TRUE(msg.hasDeadlinePassed());
+
+  auto remaining = msg.getTimeUntilDeadline();
+  ASSERT_TRUE(remaining.has_value());
+  EXPECT_EQ(remaining->count(), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Response factory helpers
+// ---------------------------------------------------------------------------
+
+TEST(ResponseFactory, CreateSuccessSwapsSenderReceiver) {
+  auto original = KeystoneMessage::create("requester", "worker", "do-thing");
+  auto resp = Response::createSuccess(original, "worker", "ok-result");
+
+  EXPECT_EQ(resp.msg_id, original.msg_id);
+  EXPECT_EQ(resp.sender_id, "worker");
+  EXPECT_EQ(resp.receiver_id, "requester");
+  EXPECT_EQ(resp.status, Response::Status::Success);
+  EXPECT_EQ(resp.result, "ok-result");
+}
+
+TEST(ResponseFactory, CreateErrorCarriesErrorStatusAndMessage) {
+  auto original = KeystoneMessage::create("requester", "worker", "do-thing");
+  auto resp = Response::createError(original, "worker", "boom");
+
+  EXPECT_EQ(resp.msg_id, original.msg_id);
+  EXPECT_EQ(resp.sender_id, "worker");
+  EXPECT_EQ(resp.receiver_id, "requester");
+  EXPECT_EQ(resp.status, Response::Status::Error);
+  EXPECT_EQ(resp.result, "boom");
+}
+
+// ---------------------------------------------------------------------------
+// Enum-to-string helpers (header inline; exercise all branches)
+// ---------------------------------------------------------------------------
+
+TEST(MessageEnums, PriorityToStringAllValues) {
+  EXPECT_EQ(priorityToString(Priority::HIGH), "HIGH");
+  EXPECT_EQ(priorityToString(Priority::NORMAL), "NORMAL");
+  EXPECT_EQ(priorityToString(Priority::LOW), "LOW");
+}
+
+TEST(MessageEnums, ActionTypeToStringAllValues) {
+  EXPECT_EQ(actionTypeToString(ActionType::EXECUTE), "EXECUTE");
+  EXPECT_EQ(actionTypeToString(ActionType::RETURN_RESULT), "RETURN_RESULT");
+  EXPECT_EQ(actionTypeToString(ActionType::SHUTDOWN), "SHUTDOWN");
+}
+
+TEST(MessageEnums, ContentTypeToStringAllValues) {
+  EXPECT_EQ(contentTypeToString(ContentType::TEXT_PLAIN), "TEXT_PLAIN");
+  EXPECT_EQ(contentTypeToString(ContentType::BINARY_CISTA), "BINARY_CISTA");
+}

--- a/tests/unit/test_message_bus.cpp
+++ b/tests/unit/test_message_bus.cpp
@@ -1,0 +1,222 @@
+/**
+ * @file test_message_bus.cpp
+ * @brief Unit tests for MessageBus registration, routing, NATS forwarding,
+ *        and scheduler integration.
+ *
+ * MessageBus is a pure in-memory transport hub — these tests use only a
+ * minimal non-agent IMessageSink stub and (optionally) a real
+ * WorkStealingScheduler. No live NATS broker is required: the NATS-forwarding
+ * path is exercised via an injected publisher callback.
+ */
+
+#include "concurrency/work_stealing_scheduler.hpp"
+#include "core/config.hpp"
+#include "core/message.hpp"
+#include "core/message_bus.hpp"
+#include "core/message_sink.hpp"
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+using namespace keystone::core;
+using namespace std::chrono_literals;
+
+namespace {
+
+/// Minimal non-agent sink that records and counts received messages.
+struct CountingSink : public IMessageSink {
+  std::atomic<int> count{0};
+  std::mutex mu;
+  std::condition_variable cv;
+
+  void receiveMessage(const KeystoneMessage& /*msg*/) override {
+    {
+      std::lock_guard<std::mutex> lock(mu);
+      count.fetch_add(1, std::memory_order_relaxed);
+    }
+    cv.notify_all();
+  }
+
+  void waitForCount(int expected) {
+    std::unique_lock<std::mutex> lock(mu);
+    cv.wait_for(lock, 2s, [&] { return count.load(std::memory_order_relaxed) >= expected; });
+  }
+};
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Registration error paths
+// ---------------------------------------------------------------------------
+
+TEST(MessageBusRegistration, RegisterNullAgentThrows) {
+  MessageBus bus;
+  EXPECT_THROW(bus.registerAgent("a1", nullptr), std::invalid_argument);
+}
+
+TEST(MessageBusRegistration, DuplicateRegistrationThrows) {
+  MessageBus bus;
+  auto sink = std::make_shared<CountingSink>();
+  EXPECT_NO_THROW(bus.registerAgent("a1", sink));
+  EXPECT_THROW(bus.registerAgent("a1", sink), std::runtime_error);
+}
+
+TEST(MessageBusRegistration, InvalidAgentIdTokenThrows) {
+  MessageBus bus;
+  auto sink = std::make_shared<CountingSink>();
+  // Path-traversal / injection characters are rejected (Issue #113).
+  EXPECT_ANY_THROW(bus.registerAgent("../evil", sink));
+}
+
+// ---------------------------------------------------------------------------
+// Unregister / listing / discovery
+// ---------------------------------------------------------------------------
+
+TEST(MessageBusRegistration, UnregisterUnknownAgentIsNoOp) {
+  MessageBus bus;
+  // Never registered → tryGetId returns nullopt → early return, no throw.
+  EXPECT_NO_THROW(bus.unregisterAgent("never-seen"));
+  EXPECT_FALSE(bus.hasAgent("never-seen"));
+}
+
+TEST(MessageBusRegistration, HasAgentFalseForUnknown) {
+  MessageBus bus;
+  EXPECT_FALSE(bus.hasAgent("nope"));
+}
+
+TEST(MessageBusRegistration, ListAgentsReturnsRegisteredIds) {
+  MessageBus bus;
+  bus.registerAgent("a1", std::make_shared<CountingSink>());
+  bus.registerAgent("a2", std::make_shared<CountingSink>());
+  bus.registerAgent("a3", std::make_shared<CountingSink>());
+
+  auto ids = bus.listAgents();
+  EXPECT_EQ(ids.size(), 3u);
+  EXPECT_NE(std::find(ids.begin(), ids.end(), "a1"), ids.end());
+  EXPECT_NE(std::find(ids.begin(), ids.end(), "a2"), ids.end());
+  EXPECT_NE(std::find(ids.begin(), ids.end(), "a3"), ids.end());
+}
+
+TEST(MessageBusRegistration, ListAgentsEmptyInitially) {
+  MessageBus bus;
+  EXPECT_TRUE(bus.listAgents().empty());
+}
+
+// ---------------------------------------------------------------------------
+// Scheduler integration
+// ---------------------------------------------------------------------------
+
+TEST(MessageBusScheduler, SchedulerDefaultsToNull) {
+  MessageBus bus;
+  EXPECT_EQ(bus.getScheduler(), nullptr);
+}
+
+TEST(MessageBusScheduler, SetAndGetScheduler) {
+  MessageBus bus;
+  keystone::concurrency::WorkStealingScheduler sched(2);
+  bus.setScheduler(&sched);
+  EXPECT_EQ(bus.getScheduler(), &sched);
+
+  bus.setScheduler(nullptr);
+  EXPECT_EQ(bus.getScheduler(), nullptr);
+}
+
+TEST(MessageBusScheduler, AsyncRoutingSubmitsToScheduler) {
+  MessageBus bus;
+  keystone::concurrency::WorkStealingScheduler sched(2);
+  sched.start();
+  bus.setScheduler(&sched);
+
+  auto sink = std::make_shared<CountingSink>();
+  bus.registerAgent("worker", sink);
+
+  auto msg = KeystoneMessage::create("client", "worker", "task");
+  EXPECT_TRUE(bus.routeMessage(msg));
+
+  sink->waitForCount(1);
+  EXPECT_EQ(sink->count.load(), 1);
+}
+
+// ---------------------------------------------------------------------------
+// NATS forwarding (off-host path) — no broker, injected publisher callback
+// ---------------------------------------------------------------------------
+
+TEST(MessageBusNats, PublisherDefaultsToNull) {
+  MessageBus bus;
+  EXPECT_FALSE(static_cast<bool>(bus.getNatsPublisher()));
+}
+
+TEST(MessageBusNats, SetAndGetPublisher) {
+  MessageBus bus;
+  bus.setNatsPublisher([](std::string_view, std::span<const std::byte>) {});
+  EXPECT_TRUE(static_cast<bool>(bus.getNatsPublisher()));
+}
+
+TEST(MessageBusNats, UnregisteredReceiverForwardsToPublisher) {
+  MessageBus bus;
+
+  std::string captured_subject;
+  size_t captured_len = 0;
+  bus.setNatsPublisher([&](std::string_view subject, std::span<const std::byte> payload) {
+    captured_subject = std::string(subject);
+    captured_len = payload.size();
+  });
+
+  // Receiver was never interned → first forwarding branch.
+  auto msg = KeystoneMessage::create("client", "remote-agent", "task");
+  EXPECT_FALSE(bus.routeMessage(msg));
+
+  EXPECT_EQ(captured_subject, "hi.agents.remote-agent");
+  EXPECT_GT(captured_len, 0u);
+}
+
+TEST(MessageBusNats, InternedButUnregisteredReceiverForwards) {
+  MessageBus bus;
+
+  int publish_calls = 0;
+  bus.setNatsPublisher([&](std::string_view, std::span<const std::byte>) { ++publish_calls; });
+
+  auto sink = std::make_shared<CountingSink>();
+  // Register then unregister so the id stays interned but has no live sink,
+  // exercising the second forwarding branch (interned, agents_.find fails).
+  bus.registerAgent("transient", sink);
+  bus.unregisterAgent("transient");
+
+  auto msg = KeystoneMessage::create("client", "transient", "task");
+  EXPECT_FALSE(bus.routeMessage(msg));
+  EXPECT_EQ(publish_calls, 1);
+}
+
+TEST(MessageBusNats, UnregisteredReceiverWithoutPublisherReturnsFalse) {
+  MessageBus bus;
+  // No publisher set → pub is null → no forwarding, just returns false.
+  auto msg = KeystoneMessage::create("client", "remote-agent", "task");
+  EXPECT_FALSE(bus.routeMessage(msg));
+}
+
+// ---------------------------------------------------------------------------
+// Maximum agent limit (DoS guard, FIX P2-10)
+// ---------------------------------------------------------------------------
+
+TEST(MessageBusRegistration, EnforcesMaxAgentLimit) {
+  MessageBus bus;
+  auto sink = std::make_shared<CountingSink>();
+
+  // Fill to the limit; all shall succeed.
+  for (size_t i = 0; i < Config::MAX_AGENTS; ++i) {
+    bus.registerAgent("agent-" + std::to_string(i), sink);
+  }
+
+  // One more must be rejected.
+  EXPECT_THROW(bus.registerAgent("one-too-many", sink), std::runtime_error);
+}


### PR DESCRIPTION
## Summary

Raises C++ GoogleTest coverage for three pure-transport core components by adding **behavioral** tests for previously-uncovered edge and error paths. No production source was changed — tests only, plus their registration in the `unit_tests` target.

These are in-memory components, so no live NATS broker or scheduler daemon is required: the off-host NATS forwarding path is exercised through an injected publisher callback, and the async path uses a real in-process `WorkStealingScheduler`.

## Coverage evidence (`generate_coverage.sh`, build/x86.coverage.debug)

| File | Before | After |
|------|--------|-------|
| `src/core/message.cpp` | 73.2% (60/82) | **100.0% (82/82)** |
| `src/core/message_bus.cpp` | 69.1% (65/94) | **100.0% (94/94)** |
| `src/core/heartbeat_monitor.cpp` | 78.0% (96/123) | **99.2% (122/123)** |
| **Overall repo** | 75.3% (2161/2869) | **78.0% (2248/2882)** |

The single remaining line in `heartbeat_monitor.cpp` (line 23) is a continuation line of the constructor's multi-line `Logger::info(...)` call; the constructor itself is exercised by many tests. It is a spurious llvm-cov partial-line artifact, not an untested behavior path, so no `LCOV_EXCL` regions were needed.

## What was added

- **test_message.cpp** (new): both `create()` overloads, deadline helpers (future/past/absent), `Response::createSuccess`/`createError`, copy/move special members, enum-to-string helpers.
- **test_message_bus.cpp** (new): null/duplicate/invalid-token registration guards, `MAX_AGENTS` DoS limit, unregister/list/discovery, scheduler async-submit path, NATS off-host forwarding (both not-interned and interned-but-unregistered branches).
- **test_heartbeat_monitor.cpp** (extended): `getStatus`, `removeAgent` (present/absent), `reset`, `auto_remove_dead`, recovery-after-failure branch, dead/alive listing.

All **537** unit tests pass (was 497). Overall repo coverage does not drop.

Refs: coverage improvement for core transport layer (no tracking issue closed).
