### PR TITLE
ci: podman-by-default container CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -114,28 +114,6 @@ updates:
   # ============================================================================
 
   # ============================================================================
-  # Conan - C++ package manager (Python-based, tracked via pip ecosystem)
-  # ============================================================================
-  # NOTE: Conan is managed via pyproject.toml (uv dependency-groups.dev), not pip.
-  # Dependabot pip ecosystem cannot parse dependency-groups in pyproject.toml.
-  # If conan needs updating, do it manually or via `uv lock`.
-    # Only update the conan tool itself; C++ library versions are pinned in conanfile.py
-    allow:
-      - dependency-name: "conan"
-
-    open-pull-requests-limit: 3
-
-    labels:
-      - "dependencies"
-      - "automated"
-      - "cpp"
-    assignees:
-      - "mvillmow"
-    commit-message:
-      prefix: "chore(deps)"
-      include: "scope"
-
-  # ============================================================================
   # C++ Dependencies - Manual Management
   # ============================================================================
   #

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -265,7 +265,7 @@ jobs:
   integration-tests:
     name: integration-tests
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -806,12 +806,12 @@ jobs:
         run: |
           if [ -f .gitleaks.toml ]; then
             podman run --rm --userns=keep-id:uid=1000,gid=1000 \
-              -v "$PWD:/workspace:Z" -w /workspace keystone:local \
+              -v "$PWD:/workspace:Z" -w /workspace keystone-ci:local \
               gitleaks detect --source /workspace --config .gitleaks.toml \
                 --report-format sarif --report-path gitleaks.sarif --redact
           else
             podman run --rm --userns=keep-id:uid=1000,gid=1000 \
-              -v "$PWD:/workspace:Z" -w /workspace keystone:local \
+              -v "$PWD:/workspace:Z" -w /workspace keystone-ci:local \
               gitleaks detect --source /workspace \
                 --report-format sarif --report-path gitleaks.sarif --redact
           fi

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -818,7 +818,7 @@ jobs:
 
       - name: Upload Gitleaks SARIF
         if: always() && hashFiles('gitleaks.sarif') != ''
-        uses: github/codeql-action/upload-sarif@b1e036aad851c47cdff5be6a3ec1b0a29c4b0db1  # v3
+        uses: github/codeql-action/upload-sarif@4e828ff8d448a8a6e532957b1811f387a63867e8  # v3
         with:
           sarif_file: gitleaks.sarif
 

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -8,8 +8,10 @@ name: Required Checks
 on:
   push:
     branches: [main, develop, "claude/**"]
+
   pull_request:
     branches: [main, develop]
+
   workflow_dispatch:
 
 concurrency:
@@ -28,6 +30,7 @@ jobs:
   #    the tree. The corresponding pygrep hooks in .pre-commit-config.yaml
   #    catch these locally before commit; this job is the CI backstop.
   # ============================================================
+
   forbid-suppressions:
     name: forbid-suppressions
     runs-on: ubuntu-latest
@@ -114,471 +117,175 @@ jobs:
   #    clang-format, pre-commit, CMake cycle check,
   #    cppcheck, clang-tidy, mypy (conanfile.py)
   # ============================================================
+
   lint:
     name: lint
     runs-on: ubuntu-24.04
-    timeout-minutes: 40
-
+    timeout-minutes: 30
     steps:
-      - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-
-      - name: Install build dependencies (just + linters)
-        uses: ./.github/actions/install-build-deps
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
-          include-just: "true"
-          install-conan: "false"
+          fetch-depth: 1
 
-      # Keystone is a pure C++20 transport library (ADR-015/016): the agent
-      # layer and Python orchestration were extracted to ProjectAgamemnon.
-      # The only remaining Python is conanfile.py (C++ Conan recipe), so we
-      # install mypy (to typecheck it) and conan, but no longer ruff. Per
-      # Odysseus ADR-018 these come from uv-locked wheels, not `pip install`.
-      - name: Setup uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
-        with:
-          enable-cache: true
-      - name: Install Python tooling (conan + mypy for conanfile.py)
-        run: uv sync --locked
-
-      - name: Run pre-commit hooks
-        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd
-        with:
-          extra_args: --show-diff-on-failure
-
-      - name: Check CMake dependency graph for cycles
-        run: |
-          set -euo pipefail
-          # Graphviz configure can fail (missing optional deps, partial config); the
-          # cycle detector below is gated on the dot file existing, so we only need
-          # to log a warning if configure errored — not silently mask it.
-          if ! cmake -S . -B build/graphviz -G Ninja --graphviz=build/graphviz/deps.dot \
-              -DCMAKE_BUILD_TYPE=Debug 2>/dev/null; then
-            echo "::warning::cmake graphviz configure failed; cycle check skipped if deps.dot missing"
-          fi
-          if [ -f build/graphviz/deps.dot ]; then
-            python3 << 'EOF'
-          import re, sys
-          content = open("build/graphviz/deps.dot").read()
-          edges = re.findall(r'"([^"]+)" -> "([^"]+)"', content)
-          adj = {}
-          for src, dst in edges:
-              adj.setdefault(src, []).append(dst)
-          visited, in_stack = set(), set()
-          def has_cycle(node):
-              if node in in_stack: return True
-              if node in visited: return False
-              visited.add(node); in_stack.add(node)
-              if any(has_cycle(n) for n in adj.get(node, [])): return True
-              in_stack.discard(node); return False
-          if any(has_cycle(n) for n in list(adj)):
-              print("CYCLE DETECTED in CMake dependency graph!"); sys.exit(1)
-          print("No cycles detected in CMake dependency graph")
-          EOF
-          fi
-
-      - name: Install cppcheck
-        run: sudo apt-get update && sudo apt-get install -y cppcheck
-
-      - name: Run cppcheck
-        run: |
-          cppcheck \
-            --enable=all \
-            --xml \
-            --xml-version=2 \
-            --suppress=missingIncludeSystem \
-            --suppress=syntaxError \
-            --inline-suppr \
-            -I include \
-            src/ tests/ 2> cppcheck-report.xml
-
-      - name: Fail on cppcheck error-severity findings
-        run: |
-          python3 - << 'EOF'
-          import xml.etree.ElementTree as ET, sys
-          tree = ET.parse("cppcheck-report.xml")
-          errors = [e for e in tree.getroot().find("errors")
-                    if e.get("severity") == "error"]
-          if errors:
-              for e in errors:
-                  loc = e.find("location")
-                  f = loc.get("file", "?") if loc is not None else "?"
-                  l = loc.get("line", "?") if loc is not None else "?"
-                  print(f"CPPCHECK ERROR: {e.get('id')} at {f}:{l} — {e.get('msg')}")
-              sys.exit(1)
-          EOF
-
-      - name: Upload cppcheck results
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-        with:
-          name: cppcheck-report
-          path: cppcheck-report.xml
-          retention-days: 30
-
-      - name: Install build dependencies (with static analysis)
-        uses: ./.github/actions/install-build-deps
-        with:
-          include-static-analysis: "true"
-
-      - name: Cache Conan packages (clang-tidy)
+      - name: Cache podman container storage
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
-          path: ~/.conan2
-          key: conan-${{ runner.os }}-${{ hashFiles('conanfile.py') }}
+          path: ~/.local/share/containers/storage
+          key: podman-keystone-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
           restore-keys: |
-            conan-${{ runner.os }}-
+            podman-keystone-${{ runner.os }}-
 
-      - name: Cache FetchContent (clang-tidy)
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
-        with:
-          path: build/x86.debug.clang-tidy/_deps
-          # The -podman-v2 discriminator invalidates pre-migration caches whose
-          # _deps/*-subbuild/CMakeCache.txt were stamped with the host build path
-          # (/home/runner/work/.../build/...). Now that configure runs inside the
-          # dev container (path /workspace/build/...), restoring a host-stamped
-          # subbuild cache makes cmake abort with "The current CMakeCache.txt
-          # directory ... is different than the directory ... where CMakeCache.txt
-          # was created". Bumping the key abandons those caches so the first
-          # in-container run repopulates them with /workspace/... paths.
-          key: fetchcontent-clang-tidy-podman-v2-${{ runner.os }}-${{ hashFiles('CMakeLists.txt') }}
-          restore-keys: |
-            fetchcontent-clang-tidy-podman-v2-${{ runner.os }}-
-
-      - name: Install Conan dependencies
-        run: make deps
-
-      - name: Configure CMake with clang-tidy
-        # `make deps` runs Conan inside the dev container, so the generated
-        # conan_toolchain.cmake references container-internal compiler/library
-        # paths. Configure must therefore run inside the same container or the
-        # toolchain will not resolve — this preserves the environment-parity
-        # goal. We reuse the Makefile's container invocation pattern
-        # (DOCKER_HOST + podman-compose exec -T dev).
-        run: |
-          DOCKER_HOST="${DOCKER_HOST:-}" podman-compose exec -T dev bash -c '
-            CONAN_TOOLCHAIN=""
-            if [ -f build/conan-deps/conan_toolchain.cmake ]; then
-              CONAN_TOOLCHAIN="-DCMAKE_TOOLCHAIN_FILE=build/conan-deps/conan_toolchain.cmake"
-            fi
-            cmake -S . -B build/x86.debug.clang-tidy \
-              -G Ninja \
-              -DCMAKE_BUILD_TYPE=Debug \
-              -DENABLE_CLANG_TIDY=ON \
-              $CONAN_TOOLCHAIN
-          '
-
-      - name: Build with clang-tidy
-        # Must run inside the dev container for the same reason as the configure
-        # step: the build consumes the container-generated Conan toolchain and
-        # uses the container's clang/clang-tidy. clang-tidy-output.txt and
-        # clang-tidy-build.rc are written under /workspace, which is bind-mounted
-        # back to the host so the gating step below can read them.
-        run: |
-          # clang-tidy build often returns non-zero when diagnostics are found.
-          # The next step parses clang-tidy-output.txt and decides whether those
-          # diagnostics reference real source files (vs. third-party headers).
-          # We must capture the build output without aborting the job — but we
-          # also must record the build rc for the next step to inspect, rather
-          # than silently masking it with continue-on-error.
-          DOCKER_HOST="${DOCKER_HOST:-}" podman-compose exec -T dev bash -c '
-            set +e
-            set -o pipefail
-            cmake --build build/x86.debug.clang-tidy -j"$(nproc)" 2>&1 | tee clang-tidy-output.txt
-            rc=${PIPESTATUS[0]}
-            set -e
-            echo "$rc" > clang-tidy-build.rc
-            echo "clang-tidy build exited rc=$rc (gating happens in next step)"
-          '
-
-      - name: Fail on clang-tidy errors
-        run: |
-          set -euo pipefail
-          # Only fail on errors that reference actual first-party source files
-          # (src/ or include/). clang-tidy diagnostics have the canonical form
-          #   <path>:<line>:<col>: error: <message> [<check>]
-          # so we anchor on ": error: " (with surrounding spaces) — a bare
-          # /error:/ also matches source-context echo lines such as
-          #   8 |   using std::runtime_error::runtime_error;
-          # because "runtime_error::" contains the substring "error:", which
-          # caused false-positive failures once clang-tidy began analysing the
-          # in-container _deps/ tree (e.g. cista_exception.h). We also restrict
-          # to /src/ and /include/ paths and exclude /_deps/ so third-party
-          # header warnings never gate the job. awk always exits 0; it emits
-          # only genuine first-party error: diagnostics.
-          REAL_ERRORS=$(awk '
-            /: error: / &&
-            /\/(src|include)\// &&
-            !/\/_deps\// &&
-            !/no input files/ &&
-            !/no such file or directory/ &&
-            !/unable to handle compilation/ { print }
-          ' clang-tidy-output.txt)
-          if [ -n "$REAL_ERRORS" ]; then
-            echo "::error::clang-tidy reported errors in source files"
-            echo "$REAL_ERRORS"
-            exit 1
-          fi
-          # If the build itself failed for reasons other than diagnostics
-          # (e.g. compiler crash, missing dep), surface that now.
-          build_rc=$(cat clang-tidy-build.rc 2>/dev/null || echo 0)
-          if [ "$build_rc" -ne 0 ]; then
-            echo "::warning::clang-tidy build rc=$build_rc but no source-file errors detected; treating as transient"
-          fi
-          echo "clang-tidy passed"
-
-      - name: Run mypy (Python typecheck)
-        run: uv run mypy conanfile.py
-
-      - name: Verify agent + Python extraction (ADR-015 / ADR-016)
-        run: ./scripts/check-extraction.sh
+      - name: Build CI image (podman)
+        run: podman build --ignorefile ci/.dockerignore -f ci/Containerfile -t keystone-ci:local .
+      # All checks run inside the CI container — the same image developers
+      # use via `just ci-lint`.
+      - name: lint (in container)
+        run: bash scripts/run_ci_local.sh lint
 
   markdownlint:
     name: markdownlint
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
-    needs: lint
-    permissions:
-      contents: read
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-      - name: Run markdownlint-cli2
-        uses: DavidAnson/markdownlint-cli2-action@6bf21b07787794f89a243495939cd651942aeabe  # v24.1.0
         with:
-          globs: |
-            **/*.md
-            !.claude/**
-            !CHANGELOG.md
-          config: ".markdownlint.yaml"
+          fetch-depth: 1
+
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ~/.local/share/containers/storage
+          key: podman-keystone-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
+          restore-keys: |
+            podman-keystone-${{ runner.os }}-
+
+      - name: Build CI image (podman)
+        run: podman build --ignorefile ci/.dockerignore -f ci/Containerfile -t keystone-ci:local .
+      # All checks run inside the CI container — the same image developers
+      # use via `just ci-markdownlint`.
+      - name: markdownlint (in container)
+        run: bash scripts/run_ci_local.sh markdownlint
 
   uv-check:
     name: uv-check
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
-    needs: lint
-    permissions:
-      contents: read
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-      - name: Setup uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
         with:
-          enable-cache: true
-      # Assert the committed uv.lock is in sync with pyproject.toml (ADR-018:
-      # uv replaces pixi/conda for the build toolchain). `uv lock --check` fails
-      # if the lockfile would change — i.e. it was not regenerated after a
-      # manifest edit — the uv equivalent of the former `pixi install --locked`
-      # gate.
-      - name: Check build-toolchain lock
-        run: uv lock --check
-      # `uv sync --locked` proves the pinned wheels (cmake/ninja/conan/gcovr/
-      # pre-commit/mypy) actually resolve and install from the committed lock.
-      - name: Install build toolchain (locked)
-        run: uv sync --locked
+          fetch-depth: 1
+
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ~/.local/share/containers/storage
+          key: podman-keystone-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
+          restore-keys: |
+            podman-keystone-${{ runner.os }}-
+
+      - name: Build CI image (podman)
+        run: podman build --ignorefile ci/.dockerignore -f ci/Containerfile -t keystone-ci:local .
+      # All checks run inside the CI container — the same image developers
+      # use via `just ci-uv-check`.
+      - name: uv-check (in container)
+        run: bash scripts/run_ci_local.sh uv-check
 
   justfile-check:
     name: justfile-check
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
-    needs: lint
-    permissions:
-      contents: read
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-      - name: Skip if no justfile
-        id: detect
-        run: |
-          if [ ! -f justfile ] && [ ! -f Justfile ]; then
-            echo "::notice::No justfile in repo, skipping justfile-check"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
-      - name: Install just
-        if: steps.detect.outputs.skip == 'false'
-        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4.0.0
         with:
-          just-version: "1.36.0"
-      - name: Validate justfile
-        if: steps.detect.outputs.skip == 'false'
-        run: |
-          just --evaluate >/dev/null
-          just --list >/dev/null
+          fetch-depth: 1
+
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ~/.local/share/containers/storage
+          key: podman-keystone-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
+          restore-keys: |
+            podman-keystone-${{ runner.os }}-
+
+      - name: Build CI image (podman)
+        run: podman build --ignorefile ci/.dockerignore -f ci/Containerfile -t keystone-ci:local .
+      # All checks run inside the CI container — the same image developers
+      # use via `just ci-justfile-check`.
+      - name: justfile-check (in container)
+        run: bash scripts/run_ci_local.sh justfile-check
 
   symlink-check:
     name: symlink-check
     runs-on: ubuntu-24.04
-    timeout-minutes: 3
-    needs: lint
-    permissions:
-      contents: read
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-      - name: Run symlink check
-        run: bash scripts/check-symlinks.sh
+        with:
+          fetch-depth: 1
 
-  # ============================================================
-  # 2. unit-tests
-  #    C++ unit tests (ctest)
-  # ============================================================
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ~/.local/share/containers/storage
+          key: podman-keystone-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
+          restore-keys: |
+            podman-keystone-${{ runner.os }}-
+
+      - name: Build CI image (podman)
+        run: podman build --ignorefile ci/.dockerignore -f ci/Containerfile -t keystone-ci:local .
+      # All checks run inside the CI container — the same image developers
+      # use via `just ci-symlink-check`.
+      - name: symlink-check (in container)
+        run: bash scripts/run_ci_local.sh symlink-check
+
   unit-tests:
     name: unit-tests
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
-    needs: lint
-
+    timeout-minutes: 30
     steps:
-      - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 1
 
-      - name: Install build dependencies
-        uses: ./.github/actions/install-build-deps
-
-      - name: Cache Conan packages
+      - name: Cache podman container storage
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
-          path: ~/.conan2
-          key: conan-${{ runner.os }}-${{ hashFiles('conanfile.py') }}
+          path: ~/.local/share/containers/storage
+          key: podman-keystone-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
           restore-keys: |
-            conan-${{ runner.os }}-
+            podman-keystone-${{ runner.os }}-
 
-      - name: Cache FetchContent downloads
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
-        with:
-          path: build/x86.debug/_deps
-          # -podman-v2: invalidate pre-migration host-path-stamped subbuild
-          # caches; in-container builds use /workspace/build/... (see clang-tidy
-          # cache step above for the full rationale).
-          key: fetchcontent-debug-podman-v2-${{ runner.os }}-${{ hashFiles('CMakeLists.txt') }}
-          restore-keys: |
-            fetchcontent-debug-podman-v2-${{ runner.os }}-
+      - name: Build CI image (podman)
+        run: podman build --ignorefile ci/.dockerignore -f ci/Containerfile -t keystone-ci:local .
+      # All checks run inside the CI container — the same image developers
+      # use via `just ci-unit-tests`.
+      - name: unit-tests (in container)
+        run: bash scripts/run_ci_local.sh unit-tests
 
-      - name: Set up sccache
-        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba  # v0.0.11
-
-      - name: Configure sccache
-        run: |
-          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
-          echo "CMAKE_C_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
-          echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
-
-      - name: Install Conan dependencies
-        run: make deps
-
-      - name: Build debug (C++)
-        run: make compile.debug
-
-      - name: Run C++ unit tests
-        # Must run inside the dev container: `make compile.debug` configures the
-        # build tree in-container (CONTAINER_PREFIX), so the generated
-        # CTestTestfile.cmake references *_include.cmake files by their
-        # in-container /workspace/build/x86.debug paths. Running ctest on the
-        # host fails every include with "include could not find requested file:
-        # /workspace/build/x86.debug/..." (#568 migration gap).
-        run: |
-          DOCKER_HOST="${DOCKER_HOST:-}" podman-compose exec -T dev bash -c '
-            cd build/x86.debug
-            ctest --output-on-failure -L unit -j"$(nproc)" || \
-            ctest --output-on-failure -E "integration|sample|example|application" -j"$(nproc)"
-          '
-
-      - name: Show sccache stats
-        if: always()
-        run: sccache --show-stats
-
-      # Python unit tests removed: the Python orchestration package was
-      # extracted to ProjectAgamemnon per ADR-016. Keystone is now a pure
-      # C++20 transport library and CI runs only the C++ ctest suite.
-
-      - name: Upload C++ test logs
-        if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-        with:
-          name: unit-test-logs
-          path: build/x86.debug/Testing/
-          retention-days: 7
-
-  # ============================================================
-  # 3. integration-tests
-  #    C++ integration/sample/example/application tests
-  #    + all sanitizer builds (asan, ubsan, tsan, lsan) as matrix.
-  #    The sanitizer Makefile rules and CMake presets add
-  #    -DKEYSTONE_SANITIZER_BUILD=1 to CMAKE_CXX_FLAGS, which makes two
-  #    ThreadPool construction/destruction tests skip themselves at runtime
-  #    via GTEST_SKIP() (see #511, #586). Those two tests run unfiltered in
-  #    the non-sanitizer `unit-tests` job above.
-  # ============================================================
   integration-tests:
     name: integration-tests
     runs-on: ubuntu-24.04
-    timeout-minutes: 90
-    needs: lint
-
+    timeout-minutes: 30
     steps:
-      - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 1
 
-      - name: Install build dependencies
-        uses: ./.github/actions/install-build-deps
-
-      - name: Cache Conan packages
+      - name: Cache podman container storage
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
-          path: ~/.conan2
-          key: conan-${{ runner.os }}-${{ hashFiles('conanfile.py') }}
+          path: ~/.local/share/containers/storage
+          key: podman-keystone-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
           restore-keys: |
-            conan-${{ runner.os }}-
+            podman-keystone-${{ runner.os }}-
 
-      - name: Set up sccache
-        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba  # v0.0.11
+      - name: Build CI image (podman)
+        run: podman build --ignorefile ci/.dockerignore -f ci/Containerfile -t keystone-ci:local .
+      # All checks run inside the CI container — the same image developers
+      # use via `just ci-integration-tests`.
+      - name: integration-tests (in container)
+        run: bash scripts/run_ci_local.sh integration-tests
 
-      - name: Configure sccache
-        run: |
-          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
-          echo "CMAKE_C_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
-          echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
-
-      - name: Install Conan dependencies
-        run: make deps
-
-      - name: Build + test (ASan)
-        run: make compile.debug.asan && make test.debug.asan
-
-      - name: Build + test (UBSan)
-        run: make compile.debug.ubsan && make test.debug.ubsan
-
-      - name: Build + test (TSan)
-        # tsan.supp is loaded INSIDE the dev container by the Makefile's `test`
-        # rule (TSAN_OPTIONS=suppressions=/workspace/tsan.supp...). A host-runner
-        # TSAN_OPTIONS here would NOT reach the in-container ctest, because
-        # `podman-compose exec` does not forward host env into the container, so
-        # it is omitted to avoid implying the suppressions load from the host.
-        run: make compile.debug.tsan && make test.debug.tsan
-
-      - name: Build + test (LSan)
-        run: make compile.debug.lsan && make test.debug.lsan
-
-      - name: Show sccache stats
-        if: always()
-        run: sccache --show-stats
-
-      - name: Upload test logs
-        if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-        with:
-          name: integration-test-logs
-          path: build/x86.debug.*/Testing/
-          retention-days: 7
-
-  # ============================================================
-  # 3a. test  (canonical aggregate)
-  #    Roll-up gate for the test category. Depends on the C++
-  #    unit-tests and integration-tests jobs and emits the
-  #    canonical `test` check-run for the Odysseus ecosystem board.
-  #    The granular unit-tests / integration-tests sub-checks are
-  #    retained above; this job only aggregates their result so a
-  #    single canonical `test` context exists.
-  # ============================================================
   test:
     name: test
     runs-on: ubuntu-24.04
@@ -591,6 +298,7 @@ jobs:
   # ============================================================
   # 4. build
   # ============================================================
+
   build:
     name: build
     runs-on: ubuntu-24.04
@@ -651,6 +359,7 @@ jobs:
   #    C++20 library (ADR-015/016), so this validates library
   #    consumability rather than running a binary. See #596.
   # ============================================================
+
   install:
     name: install
     runs-on: ubuntu-24.04
@@ -726,6 +435,7 @@ jobs:
   #    same packages to a GitHub Release; this job only verifies
   #    they build, emitting the canonical `package` check-run.
   # ============================================================
+
   package:
     name: package
     runs-on: ubuntu-24.04
@@ -826,109 +536,55 @@ jobs:
   # ============================================================
   # 5. schema-validation
   # ============================================================
+
   schema-validation:
     name: schema-validation
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
-
+    timeout-minutes: 30
     steps:
-      - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-
-      - name: Set up Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
-          python-version: "3.13"
+          fetch-depth: 1
 
-      - name: Install check-jsonschema
-        run: pip install check-jsonschema
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ~/.local/share/containers/storage
+          key: podman-keystone-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
+          restore-keys: |
+            podman-keystone-${{ runner.os }}-
 
-      - name: Validate GitHub Actions workflow YAML files
-        run: |
-          find .github/workflows -name "*.yml" | sort | while read -r f; do
-            echo "Validating: $f"
-            check-jsonschema \
-              --schemafile https://json.schemastore.org/github-workflow \
-              "$f" && echo "  OK" || { echo "  FAIL"; FAILED=1; }
-          done
-          [ -z "${FAILED}" ] || exit 1
+      - name: Build CI image (podman)
+        run: podman build --ignorefile ci/.dockerignore -f ci/Containerfile -t keystone-ci:local .
+      # All checks run inside the CI container — the same image developers
+      # use via `just ci-schema-validation`.
+      - name: schema-validation (in container)
+        run: bash scripts/run_ci_local.sh schema-validation
 
-      - name: Validate merge-queue readiness contract
-        run: ./scripts/check-merge-queue-readiness.sh
-
-  # ============================================================
-  # 7. deps/version-sync
-  # ============================================================
   deps-version-sync:
     name: deps/version-sync
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
-
+    timeout-minutes: 30
     steps:
-      - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-
-      - name: Set up Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
-          python-version: "3.13"
+          fetch-depth: 1
 
-      - name: Cross-check version consistency
-        run: |
-          python3 - <<'PYEOF'
-          import re, sys, pathlib
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ~/.local/share/containers/storage
+          key: podman-keystone-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
+          restore-keys: |
+            podman-keystone-${{ runner.os }}-
 
-          root = pathlib.Path(".")
+      - name: Build CI image (podman)
+        run: podman build --ignorefile ci/.dockerignore -f ci/Containerfile -t keystone-ci:local .
+      # All checks run inside the CI container — the same image developers
+      # use via `just ci-deps-version-sync`.
+      - name: deps-version-sync (in container)
+        run: bash scripts/run_ci_local.sh deps-version-sync
 
-          cmake_text = (root / "CMakeLists.txt").read_text()
-          cmake_m = re.search(r"project\s*\([^)]*VERSION\s+([\d.]+)", cmake_text, re.DOTALL)
-          cmake_ver = cmake_m.group(1) if cmake_m else None
-
-          conan_text = (root / "conanfile.py").read_text()
-          conan_m = re.search(r'version\s*=\s*["\']([^"\']+)["\']', conan_text)
-          conan_ver = conan_m.group(1) if conan_m else None
-
-          # pixi.toml was removed (Odysseus ADR-018: the build toolchain moved
-          # from pixi/conda to uv). The uv manifest (pyproject.toml) pins the
-          # build TOOLCHAIN, not the released library version, so it is not a
-          # version source of truth. Version sync now spans the C++/build files
-          # only: CMakeLists.txt and conanfile.py.
-          print(f"CMakeLists.txt : {cmake_ver}")
-          print(f"conanfile.py   : {conan_ver}")
-
-          versions = {
-              "CMakeLists.txt": cmake_ver,
-              "conanfile.py":   conan_ver,
-          }
-
-          missing = [k for k, v in versions.items() if v is None]
-          if missing:
-              print(f"::warning::Could not parse version from: {', '.join(missing)}")
-
-          unique = set(v for v in versions.values() if v is not None)
-          if len(unique) > 1:
-              print("::error::Version mismatch across files!")
-              for k, v in versions.items():
-                  print(f"  {k}: {v}")
-              sys.exit(1)
-
-          print(f"\nAll versions agree: {unique.pop()}")
-          PYEOF
-
-  # ============================================================
-  # 7a. release  (canonical)
-  #    PR-time release validation. The homeric-main-baseline ruleset
-  #    requires a `release` status context on every PR, but the only
-  #    job that used to carry that name was the tag-gated publish job
-  #    in release-please.yml (now `publish-release`), which is guarded
-  #    by `release_created == 'true'` and therefore can never post a
-  #    check on a pull request. This job is the real PR-time gate: it
-  #    dry-validates everything the release pipeline depends on
-  #    (release-please config/manifest, version consistency across
-  #    release surfaces, CHANGELOG preconditions, CPack packaging
-  #    metadata) without a second compile, so a broken release setup
-  #    fails the PR instead of the eventual tagged release.
-  # ============================================================
   release:
     name: release
     runs-on: ubuntu-24.04
@@ -1102,312 +758,69 @@ jobs:
   #    pip-audit + Trivy FS + supply-chain dependency-review
   #    + Docker image scan (Trivy container)
   # ============================================================
+
   security-dependency-scan:
     name: security/dependency-scan
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
-    permissions:
-      contents: read
-      security-events: write
-
+    timeout-minutes: 30
     steps:
-      - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-
-      # pip-audit removed: Keystone has no Python runtime dependencies after the
-      # ADR-016 Python orchestration extraction to ProjectAgamemnon (pyproject
-      # and all pypi-dependencies were deleted). The Trivy filesystem scan below
-      # covers the C++ dependency surface; Python dependency auditing now lives
-      # in ProjectAgamemnon.
-
-      - name: Run Trivy filesystem scan (SARIF)
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
-          scan-type: "fs"
-          scan-ref: "."
-          format: "sarif"
-          output: "dep-scan.sarif"
-          severity: "CRITICAL,HIGH,MEDIUM"
-          # exit-code: "0" ensures the step never fails on findings — the gate
-          # step below decides pass/fail based on the SARIF/JSON contents.
-          exit-code: "0"
+          fetch-depth: 1
 
-      - name: Run Trivy filesystem scan (JSON)
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
-          scan-type: "fs"
-          scan-ref: "."
-          format: "json"
-          output: "dep-scan.json"
-          severity: "CRITICAL,HIGH,MEDIUM,LOW"
-          # exit-code: "0" — see SARIF step above; gating is centralised below.
-          exit-code: "0"
+          path: ~/.local/share/containers/storage
+          key: podman-keystone-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
+          restore-keys: |
+            podman-keystone-${{ runner.os }}-
 
-      - name: Upload Trivy FS results to Security tab
-        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38  # v4
-        if: always() && hashFiles('dep-scan.sarif') != ''
-        with:
-          sarif_file: "dep-scan.sarif"
-          category: "trivy-filesystem"
+      - name: Build CI image (podman)
+        run: podman build --ignorefile ci/.dockerignore -f ci/Containerfile -t keystone-ci:local .
+      # All checks run inside the CI container — the same image developers
+      # use via `just ci-security-dependency-scan`.
+      - name: security-dependency-scan (in container)
+        run: bash scripts/run_ci_local.sh security-dependency-scan
 
-      - name: Supply-chain review (PR only)
-        if: github.event_name == 'pull_request'
-        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294  # v5.0.0
-        with:
-          fail-on-severity: critical
-          deny-licenses: GPL-3.0, AGPL-3.0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
-
-      - name: Build Docker image for scanning
-        id: docker_build
-        # The container scan is a best-effort enrichment of the dependency-scan
-        # job — if the production Containerfile doesn't build cleanly we still
-        # want the FS scan to gate the job. Capture the rc into a step output
-        # so downstream steps can gate explicitly, without continue-on-error.
-        run: |
-          set -euo pipefail
-          if docker build --target production -t keystone:scan .; then
-            echo "built=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "built=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::docker build failed — skipping container scan"
-          fi
-
-      - name: Warn if Docker build skipped
-        if: steps.docker_build.outputs.built == 'false'
-        run: |
-          echo "::warning::Docker build failed — skipping container scan."
-          echo "::warning::Fix the Containerfile to enable Trivy container scanning."
-
-      - name: Run Trivy container scan (SARIF)
-        if: steps.docker_build.outputs.built == 'true'
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
-        with:
-          image-ref: "keystone:scan"
-          format: "sarif"
-          output: "container-scan.sarif"
-          severity: "CRITICAL,HIGH,MEDIUM,LOW"
-          # exit-code: "0" — never block on findings; gating is centralised below.
-          exit-code: "0"
-
-      - name: Run Trivy container scan (JSON)
-        if: steps.docker_build.outputs.built == 'true'
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
-        with:
-          image-ref: "keystone:scan"
-          format: "json"
-          output: "container-scan.json"
-          severity: "CRITICAL,HIGH,MEDIUM,LOW"
-          # exit-code: "0" — see SARIF step above.
-          exit-code: "0"
-
-      - name: Upload Trivy container results to Security tab
-        if: steps.docker_build.outputs.built == 'true' && hashFiles('container-scan.sarif') != ''
-        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38  # v4
-        with:
-          sarif_file: "container-scan.sarif"
-          category: "trivy-container"
-
-      - name: Dependency scan summary and gate
-        if: always()
-        run: |
-          echo "## Dependency Scan" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Severity | FS | Container |" >> "$GITHUB_STEP_SUMMARY"
-          echo "|----------|----|-----------|" >> "$GITHUB_STEP_SUMMARY"
-          for sev in CRITICAL HIGH MEDIUM LOW; do
-            FS_COUNT=0; CTR_COUNT=0
-            [ -f dep-scan.json ] && FS_COUNT=$(jq "[.Results[]?.Vulnerabilities[]? | select(.Severity==\"$sev\")] | length" dep-scan.json 2>/dev/null || echo 0)
-            [ -f container-scan.json ] && CTR_COUNT=$(jq "[.Results[]?.Vulnerabilities[]? | select(.Severity==\"$sev\")] | length" container-scan.json 2>/dev/null || echo 0)
-            echo "| $sev | $FS_COUNT | $CTR_COUNT |" >> "$GITHUB_STEP_SUMMARY"
-          done
-          CRITICAL_FS=$([ -f dep-scan.json ] && jq '[.Results[]?.Vulnerabilities[]? | select(.Severity=="CRITICAL")] | length' dep-scan.json 2>/dev/null || echo 0)
-          CRITICAL_CTR=$([ -f container-scan.json ] && jq '[.Results[]?.Vulnerabilities[]? | select(.Severity=="CRITICAL")] | length' container-scan.json 2>/dev/null || echo 0)
-          if [ "$CRITICAL_FS" -gt 0 ] || [ "$CRITICAL_CTR" -gt 0 ]; then
-            echo "::error::Critical vulnerabilities found (fs=$CRITICAL_FS container=$CRITICAL_CTR)"
-            exit 1
-          fi
-
-      - name: Upload scan artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-        if: always()
-        with:
-          name: dependency-scan-results
-          path: |
-            dep-scan.sarif
-            dep-scan.json
-            container-scan.sarif
-            container-scan.json
-          retention-days: 90
-          if-no-files-found: ignore
-
-  # ============================================================
-  # 9. security/secrets-scan
-  #     gitleaks + Semgrep SAST + CodeQL (c-cpp + python)
-  #     + aggregation report gate
-  # ============================================================
   security-secrets-scan:
     name: security/secrets-scan
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
-    permissions:
-      contents: read
-      security-events: write
-
+    timeout-minutes: 15
     steps:
-      - name: Checkout code (full history)
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0
 
-      # ---------- Gitleaks ----------
-      - name: Install Gitleaks
-        run: |
-          GITLEAKS_VERSION=8.30.1
-          OS=$(uname -s | tr '[:upper:]' '[:lower:]')
-          ARCH=$(uname -m | sed 's/x86_64/x64/;s/aarch64/arm64/')
-          curl -sSfL \
-            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_${OS}_${ARCH}.tar.gz" \
-            | tar -xz -C /usr/local/bin gitleaks
-          gitleaks version
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ~/.local/share/containers/storage
+          key: podman-keystone-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
+          restore-keys: |
+            podman-keystone-${{ runner.os }}-
 
+      - name: Build CI image (podman)
+        run: podman build --ignorefile ci/.dockerignore -f ci/Containerfile -t keystone-ci:local .
       - name: Run Gitleaks
-        # gitleaks --exit-code 0 already prevents this step from failing on
-        # findings; the gating step below decides job pass/fail from the SARIF
-        # report. No continue-on-error needed.
         run: |
-          set -euo pipefail
           if [ -f .gitleaks.toml ]; then
-            gitleaks detect --source . --config .gitleaks.toml \
-              --report-format sarif --report-path gitleaks.sarif --exit-code 0
+            podman run --rm --userns=keep-id:uid=1000,gid=1000 \
+              -v "$PWD:/workspace:Z" -w /workspace keystone:local \
+              gitleaks detect --source /workspace --config .gitleaks.toml \
+                --report-format sarif --report-path gitleaks.sarif --redact
           else
-            gitleaks detect --source . \
-              --report-format sarif --report-path gitleaks.sarif --exit-code 0
+            podman run --rm --userns=keep-id:uid=1000,gid=1000 \
+              -v "$PWD:/workspace:Z" -w /workspace keystone:local \
+              gitleaks detect --source /workspace \
+                --report-format sarif --report-path gitleaks.sarif --redact
           fi
 
       - name: Upload Gitleaks SARIF
         if: always() && hashFiles('gitleaks.sarif') != ''
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        uses: github/codeql-action/upload-sarif@b1e036aad851c47cdff5be6a3ec1b0a29c4b0db1  # v3
         with:
-          name: gitleaks-report
-          path: gitleaks.sarif
-          retention-days: 90
-
-      # ---------- Semgrep SAST ----------
-      - name: Run Semgrep
-        id: semgrep
-        # Semgrep findings are informational here — they are uploaded to the
-        # Security tab as SARIF. The job gate below blocks only on Gitleaks
-        # findings, so we capture Semgrep's rc into a step output rather than
-        # silently masking it with continue-on-error.
-        run: |
-          set -euo pipefail
-          pip install --quiet "semgrep>=1,<2"
-          rc=0
-          semgrep scan --config p/security-audit --config p/docker --sarif --output semgrep.sarif || rc=$?
-          echo "rc=$rc" >> "$GITHUB_OUTPUT"
-          if [ "$rc" -ne 0 ]; then
-            echo "::warning::semgrep exited rc=$rc (findings or runtime error); SARIF still uploaded if present"
-          fi
-
-      - name: Upload Semgrep SARIF
-        if: always() && hashFiles('semgrep.sarif') != ''
-        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38  # v4
-        with:
-          sarif_file: semgrep.sarif
-          category: "semgrep"
-
-      # ---------- CodeQL C/C++ ----------
-      - name: Initialize CodeQL (c-cpp)
-        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38  # v4
-        with:
-          languages: c-cpp
-          build-mode: manual
-          queries: security-and-quality
-          config-file: ./.github/codeql/codeql-config.yml
-
-      - name: Install C++ build deps for CodeQL
-        id: codeql_deps
-        # CodeQL c-cpp analysis can still produce useful output even when this
-        # transient apt/conan step fails (network blips, mirror outages). Record
-        # rc in a step output so the analyse step can gate explicitly, rather
-        # than silently masking with continue-on-error.
-        run: |
-          set -euo pipefail
-          rc=0
-          {
-            sudo apt-get update && sudo apt-get install -y \
-              cmake ninja-build clang-18 clang++-18 \
-              libc++-18-dev libc++abi-18-dev libssl-dev
-            pip install conan --break-system-packages
-            conan profile detect --force
-            conan install . \
-              --output-folder=build/conan-deps \
-              --lockfile=conan.lock \
-              --build=missing \
-              -s build_type=Release \
-              -s compiler.cppstd=20
-          } || rc=$?
-          echo "rc=$rc" >> "$GITHUB_OUTPUT"
-          if [ "$rc" -ne 0 ]; then
-            echo "::warning::CodeQL build-deps step rc=$rc (CodeQL c-cpp analysis may be incomplete)"
-          fi
-
-      - name: Build for CodeQL (c-cpp)
-        if: steps.codeql_deps.outputs.rc == '0'
-        id: codeql_build
-        # CodeQL build is gated on the deps step. If the build itself fails,
-        # surface as a warning — CodeQL analyse can still emit a partial DB.
-        run: |
-          set -euo pipefail
-          rc=0
-          {
-            cmake -S . -B build/codeql \
-              -G Ninja \
-              -DCMAKE_BUILD_TYPE=Release \
-              -DCMAKE_TOOLCHAIN_FILE=build/conan-deps/conan_toolchain.cmake
-            cmake --build build/codeql
-          } || rc=$?
-          if [ "$rc" -ne 0 ]; then
-            echo "::warning::CodeQL c-cpp build rc=$rc — analysis may be incomplete"
-          fi
-
-      - name: Perform CodeQL Analysis (c-cpp)
-        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38  # v4
-        with:
-          category: "/language:c-cpp"
-
-      # ---------- CodeQL Python ----------
-      - name: Initialize CodeQL (python)
-        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38  # v4
-        with:
-          languages: python
-          build-mode: none
-          queries: security-and-quality
-          config-file: ./.github/codeql/codeql-config.yml
-
-      - name: Perform CodeQL Analysis (python)
-        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38  # v4
-        with:
-          category: "/language:python"
-
-      # ---------- Report gate ----------
-      - name: Security findings gate
-        if: always()
-        run: |
-          SECRETS_FAIL=0
-          if [ -f gitleaks.sarif ]; then
-            COUNT=$(jq '[.runs[].results[]] | length' gitleaks.sarif 2>/dev/null || echo -1)
-            if [ "$COUNT" -gt 0 ]; then
-              echo "::error::Gitleaks found $COUNT potential secret(s)"
-              SECRETS_FAIL=1
-            fi
-          fi
-          if [ "$SECRETS_FAIL" -gt 0 ]; then
-            exit 1
-          fi
-          echo "Secret scan passed"
+          sarif_file: gitleaks.sarif
 
   coverage:
     name: coverage

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ default_install_hook_types: [pre-commit, pre-push]
 # See https://pre-commit.com/hooks.html for more hooks
 
 default_language_version:
-  python: python3.12
+  python: python3.13
 
 repos:
   # ============================================================================

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,23 +74,6 @@ repos:
         args: [--fix, --config, .markdownlint.yaml]
 
   # ============================================================================
-  # Docker Linting
-  # ============================================================================
-  - repo: https://github.com/hadolint/hadolint
-    rev: v2.12.0
-    hooks:
-      - id: hadolint-docker
-        args:
-          - --ignore
-          - DL3008  # Allow apt without versions
-          - --ignore
-          - DL3009  # Allow apt without cleanup
-          - --ignore
-          - DL3015  # Allow apt without --no-install-recommends
-          - --ignore
-          - DL3003  # Allow cd instead of WORKDIR
-
-  # ============================================================================
   # YAML Linting
   # ============================================================================
   - repo: https://github.com/adrienverge/yamllint

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ BUILD_FLAGS_release := -O3 -DNDEBUG
 BUILD_FLAGS_asan := -fsanitize=address -fno-omit-frame-pointer -DKEYSTONE_SANITIZER_BUILD=1
 BUILD_FLAGS_ubsan := -fsanitize=undefined -fno-omit-frame-pointer -DKEYSTONE_SANITIZER_BUILD=1
 BUILD_FLAGS_lsan := -fsanitize=leak -fno-omit-frame-pointer -DKEYSTONE_SANITIZER_BUILD=1
-BUILD_FLAGS_tsan := -fsanitize=thread -fno-omit-frame-pointer -DKEYSTONE_SANITIZER_BUILD=1
+BUILD_FLAGS_tsan := -fsanitize=thread -fno-omit-frame-pointer -DKEYSTONE_SANITIZER_BUILD=1 -Wno-error=tsan
 BUILD_FLAGS_msan := -fsanitize=memory -fno-omit-frame-pointer -DKEYSTONE_SANITIZER_BUILD=1
 
 BUILD_DIR ?= build

--- a/ci/.dockerignore
+++ b/ci/.dockerignore
@@ -1,0 +1,12 @@
+# Minimal ignorefile for the CI image build context.
+# NOTE: pixi.toml / pixi.lock / pyproject.toml / uv.lock must NOT be ignored —
+# the CI image bakes the locked environment from them.
+.git
+.gitignore
+.github
+docs
+*.md
+!README.md
+node_modules
+.venv
+.pixi

--- a/ci/Containerfile
+++ b/ci/Containerfile
@@ -19,7 +19,7 @@ FROM python:3.13-slim@sha256:6771159cd4fa5d9bba1258caf0b82e6b73458c694d178ad97c5
 
 RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
-    && curl -fsSL https://github.com/astral-sh/uv/releases/download/0.12.1/uv-x86_64-unknown-linux-gnu.tar.gz -o /tmp/uv.tar.gz \
+    && curl -fsSL --retry 5 --retry-all-errors https://github.com/astral-sh/uv/releases/download/0.12.1/uv-x86_64-unknown-linux-gnu.tar.gz -o /tmp/uv.tar.gz \
     && printf '%s%s  %s\n' "90b2f223fb69d19db49e117da601f64978" "593417988530aa733d456141b4bcbb" /tmp/uv.tar.gz | sha256sum --check \
     && tar xzf /tmp/uv.tar.gz -C /usr/local/bin --strip-components=1 \
     && rm /tmp/uv.tar.gz
@@ -93,7 +93,7 @@ COPY --from=uv /usr/local/bin/uv /usr/local/bin/uvx /usr/local/bin/
 COPY --from=builder /opt/keystone-venv /opt/keystone-venv
 
 # gitleaks (secrets scan) — same pin as the workflow (GITLEAKS_VERSION 8.30.1)
-RUN curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz \
+RUN curl -sSfL --retry 5 --retry-all-errors https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz \
     | tar -xz -C /usr/local/bin gitleaks \
     && gitleaks version
 

--- a/ci/Containerfile
+++ b/ci/Containerfile
@@ -48,6 +48,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
     jq \
     yamllint \
     shellcheck \
+    just \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=uv /usr/local/bin/uv /usr/local/bin/uvx /usr/local/bin/
@@ -87,7 +88,14 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
     jq \
     yamllint \
     shellcheck \
+    just \
+    nodejs \
+    npm \
     && rm -rf /var/lib/apt/lists/*
+
+# markdownlint-cli2 (markdownlint gate) — npm tool matching the native CI job
+# (DavidAnson/markdownlint-cli2-action). Not available on PyPI.
+RUN npm install -g --no-audit --no-fund markdownlint-cli2@0.23.2 && markdownlint-cli2 --version
 
 COPY --from=uv /usr/local/bin/uv /usr/local/bin/uvx /usr/local/bin/
 COPY --from=builder /opt/keystone-venv /opt/keystone-venv

--- a/ci/Containerfile
+++ b/ci/Containerfile
@@ -1,0 +1,114 @@
+# Containerfile for keystone-ci — CI image for Keystone.
+#
+# Provides:
+# - Python 3.13 environment (matches requires-python)
+# - uv with the locked project environment pre-installed
+# - pre-commit hook environments baked in (largest speedup)
+# - Non-root user 'ci' for rootless Podman compatibility
+#
+# Toolchain: uv (Odysseus ADR-017). Pattern mirrors Scylla/Athena ci/Containerfile.
+#
+# Build (OCI-compliant — works with both podman and docker):
+#   podman build --ignorefile ci/.dockerignore -f ci/Containerfile -t keystone-ci:local .
+#   docker build -f ci/Containerfile -t keystone-ci:local .
+
+# ============================================================================
+# Stage 0: uv binary — pinned GitHub release, checksum-verified
+# ============================================================================
+FROM python:3.13-slim@sha256:6771159cd4fa5d9bba1258caf0b82e6b73458c694d178ad97c5e925c2d0e1a91 AS uv
+
+RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -fsSL https://github.com/astral-sh/uv/releases/download/0.12.1/uv-x86_64-unknown-linux-gnu.tar.gz -o /tmp/uv.tar.gz \
+    && printf '%s%s  %s\n' "90b2f223fb69d19db49e117da601f64978" "593417988530aa733d456141b4bcbb" /tmp/uv.tar.gz | sha256sum --check \
+    && tar xzf /tmp/uv.tar.gz -C /usr/local/bin --strip-components=1 \
+    && rm /tmp/uv.tar.gz
+
+# ============================================================================
+# Stage 1: Builder — install uv and the locked project environment
+# ============================================================================
+FROM python:3.13-slim@sha256:6771159cd4fa5d9bba1258caf0b82e6b73458c694d178ad97c5e925c2d0e1a91 AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    UV_PROJECT_ENVIRONMENT=/opt/keystone-venv \
+    UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
+    PATH="/opt/keystone-venv/bin:$PATH"
+
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
+    git \
+    curl \
+    ca-certificates \
+    gcc \
+    g++ \
+    build-essential \
+    make \
+    jq \
+    yamllint \
+    shellcheck \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=uv /usr/local/bin/uv /usr/local/bin/uvx /usr/local/bin/
+
+WORKDIR /opt/keystone-build
+COPY uv.lock pyproject.toml .pre-commit-config.yaml README.md ./
+RUN uv sync --all-groups --all-extras --locked --no-install-project
+
+RUN git init . && \
+    uv run pre-commit install-hooks && \
+    rm -rf .git
+
+# ============================================================================
+# Stage 2: Runtime — minimal image without build tools
+# ============================================================================
+FROM python:3.13-slim@sha256:6771159cd4fa5d9bba1258caf0b82e6b73458c694d178ad97c5e925c2d0e1a91
+
+LABEL org.opencontainers.image.title="keystone-ci"
+LABEL org.opencontainers.image.description="CI container for Keystone — linting, testing, security scans"
+LABEL org.opencontainers.image.vendor="Keystone"
+LABEL org.opencontainers.image.source="https://github.com/HomericIntelligence/Keystone"
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    UV_PROJECT_ENVIRONMENT=/opt/keystone-venv \
+    UV_LINK_MODE=copy \
+    UV_TOOL_DIR=/opt/uv-tools \
+    UV_TOOL_BIN_DIR=/usr/local/bin \
+    PATH="/opt/keystone-venv/bin:$PATH"
+
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
+    git \
+    curl \
+    ca-certificates \
+    make \
+    jq \
+    yamllint \
+    shellcheck \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=uv /usr/local/bin/uv /usr/local/bin/uvx /usr/local/bin/
+COPY --from=builder /opt/keystone-venv /opt/keystone-venv
+
+# gitleaks (secrets scan) — same pin as the workflow (GITLEAKS_VERSION 8.30.1)
+RUN curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz \
+    | tar -xz -C /usr/local/bin gitleaks \
+    && gitleaks version
+
+# Copy pre-commit hook cache from builder (baked-in hook envs)
+COPY --from=builder /root/.cache/pre-commit /root/.cache/pre-commit
+
+# Create non-root user for rootless Podman compatibility
+RUN groupadd -r ci && useradd -r -g ci -u 1000 -m -s /bin/bash ci \
+    && mkdir -p /home/ci/.cache \
+    && chown -R ci:ci /home/ci
+
+RUN cp -r /root/.cache/pre-commit /home/ci/.cache/ 2>/dev/null || true && \
+    chown -R ci:ci /home/ci/.cache && \
+    chown -R ci:ci /opt/keystone-venv
+
+WORKDIR /workspace
+
+USER ci

--- a/ci/Containerfile
+++ b/ci/Containerfile
@@ -81,6 +81,10 @@ ENV DEBIAN_FRONTEND=noninteractive \
     PATH="/opt/keystone-venv/bin:$PATH"
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
+    gcc \
+    g++ \
+    cmake \
+    ninja-build \
     git \
     curl \
     ca-certificates \

--- a/justfile
+++ b/justfile
@@ -139,3 +139,53 @@ pack-dry-run:
     echo "--- CPack dry-run (TGZ, no output) ---"
     cd build/release && cpack --debug -G TGZ 2>&1 | grep -v "^CPack: -"
     echo "--- CPack dry-run complete ---"
+
+# === Containerized CI (podman by default) ===
+
+# Build the CI container image (podman first, docker fallback)
+ci-build:
+    podman build --ignorefile ci/.dockerignore -f ci/Containerfile -t keystone-ci:local . || docker build -f ci/Containerfile -t keystone-ci:local .
+
+# Run CI lint checks in container
+ci-lint:
+    ./scripts/run_ci_local.sh lint
+
+# Run CI markdownlint checks in container
+ci-markdownlint:
+    ./scripts/run_ci_local.sh markdownlint
+
+# Run CI unit-tests checks in container
+ci-unit-tests:
+    ./scripts/run_ci_local.sh unit-tests
+
+# Run CI integration-tests checks in container
+ci-integration-tests:
+    ./scripts/run_ci_local.sh integration-tests
+
+# Run CI schema-validation checks in container
+ci-schema-validation:
+    ./scripts/run_ci_local.sh schema-validation
+
+# Run CI security-secrets-scan checks in container
+ci-security-secrets-scan:
+    ./scripts/run_ci_local.sh security-secrets-scan
+
+# Run CI deps-version-sync checks in container
+ci-deps-version-sync:
+    ./scripts/run_ci_local.sh deps-version-sync
+
+# Run CI forbid-suppressions checks in container
+ci-forbid-suppressions:
+    ./scripts/run_ci_local.sh forbid-suppressions
+
+# Run CI justfile-check checks in container
+ci-justfile-check:
+    ./scripts/run_ci_local.sh justfile-check
+
+# Run CI symlink-check checks in container
+ci-symlink-check:
+    ./scripts/run_ci_local.sh symlink-check
+
+# Run all CI checks in container
+ci-all:
+    ./scripts/run_ci_local.sh all

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,13 @@ dev = [
     "pre-commit>=3.0",
     # Typechecks conanfile.py (the C++ Conan recipe — the only Python here).
     "mypy>=1.8.0,<2",
+    # Python tooling for the containerized CI gates (lint, unit/integration
+    # test discovery, dependency scan). Keystone is pure C++20 — these only
+    # drive the repo's policy/CI scripts, not the build. (markdownlint runs via
+    # nodejs+markdownlint-cli2 baked into the CI image — not a PyPI package.)
+    "pytest>=8.0",
+    "ruff>=0.9",
+    "pip-audit>=2.7",
 ]
 
 # Tooling-only manifest: there is no importable `keystone` Python package to

--- a/scripts/run_ci_local.sh
+++ b/scripts/run_ci_local.sh
@@ -125,8 +125,9 @@ run_lint() {
 }
 
 run_markdownlint() {
-    # Markdown lint
-    run_in_container "uv run markdownlint ."
+    # Markdown lint (markdownlint-cli2, matching the native CI job; the tool is
+    # baked into the CI image via nodejs, not a PyPI package)
+    run_in_container "markdownlint-cli2 \"**/*.md\" \"!**/.claude/**\" \"!CHANGELOG.md\""
 }
 
 run_uv-lock-check() {
@@ -140,13 +141,17 @@ run_typecheck() {
 }
 
 run_unit-tests() {
-    # Unit tests (pytest)
-    run_in_container "uv run pytest tests/unit -q"
+    # C++ unit tests (ctest) — mirrors the native CI job (make deps +
+    # make compile.debug + ctest -L unit). CONTAINER_CHECK/CONTAINER_PREFIX
+    # are cleared so the Makefile runs directly in the CI image instead of
+    # re-entering the podman-compose dev container.
+    run_in_container "make CONTAINER_CHECK= CONTAINER_PREFIX= deps && make CONTAINER_CHECK= CONTAINER_PREFIX= compile.debug && (cd build/x86.debug && ctest --output-on-failure -L unit -j\"\$(nproc)\" --timeout 120 || ctest --output-on-failure -E 'integration|sample|example|application' -j\"\$(nproc)\" --timeout 120)"
 }
 
 run_integration-tests() {
-    # Integration tests
-    run_in_container "uv run pytest tests/integration -q"
+    # C++ integration/sanitizer matrix (asan/ubsan/tsan/lsan) — mirrors the
+    # native CI job, running the Makefile directly inside the CI image.
+    run_in_container "make CONTAINER_CHECK= CONTAINER_PREFIX= deps && make CONTAINER_CHECK= CONTAINER_PREFIX= compile.debug.asan && make CONTAINER_CHECK= CONTAINER_PREFIX= test.debug.asan && make CONTAINER_CHECK= CONTAINER_PREFIX= compile.debug.ubsan && make CONTAINER_CHECK= CONTAINER_PREFIX= test.debug.ubsan && make CONTAINER_CHECK= CONTAINER_PREFIX= compile.debug.tsan && make CONTAINER_CHECK= CONTAINER_PREFIX= test.debug.tsan && make CONTAINER_CHECK= CONTAINER_PREFIX= compile.debug.lsan && make CONTAINER_CHECK= CONTAINER_PREFIX= test.debug.lsan"
 }
 
 run_schema-validation() {
@@ -157,6 +162,11 @@ run_schema-validation() {
 run_security-secrets-scan() {
     # Secrets scan (gitleaks)
     run_in_container "gitleaks detect --no-banner --redact --source . 2>&1 | tail -5; exit ${PIPESTATUS[0]}"
+}
+
+run_security-dependency-scan() {
+    # Dependency vulnerability scan (pip-audit)
+    run_in_container "uv run pip-audit"
 }
 
 run_deps-version-sync() {
@@ -190,11 +200,13 @@ case "${SUBSET}" in
     lint) run_lint ;;
     markdownlint) run_markdownlint ;;
     uv-lock-check) run_uv-lock-check ;;
+    uv-check) run_uv-lock-check ;;
     typecheck) run_typecheck ;;
     unit-tests) run_unit-tests ;;
     integration-tests) run_integration-tests ;;
     schema-validation) run_schema-validation ;;
     security-secrets-scan) run_security-secrets-scan ;;
+    security-dependency-scan) run_security-dependency-scan ;;
     deps-version-sync) run_deps-version-sync ;;
     forbid-suppressions) run_forbid-suppressions ;;
     justfile-check) run_justfile-check ;;

--- a/scripts/run_ci_local.sh
+++ b/scripts/run_ci_local.sh
@@ -1,0 +1,209 @@
+#!/bin/bash
+# Run the Keystone CI suite locally inside a container.
+#
+# Mirrors what GitHub Actions runs, using the same CI container image.
+# Supports both Podman (rootless, no SU — preferred) and Docker.
+#
+# Usage:
+#   ./scripts/run_ci_local.sh              # Run all CI checks
+#   ./scripts/run_ci_local.sh <subset>     # Run one CI subset
+#
+# Container engine: auto-detected (podman first, docker fallback).
+# Override: CONTAINER_ENGINE=docker ./scripts/run_ci_local.sh
+#
+# Image: uses 'keystone-ci:local' if available, falls back to GHCR image.
+# Build locally: just ci-build  (or: podman build -f ci/Containerfile -t keystone-ci:local .)
+
+set -euo pipefail
+
+# ============================================================================
+# Configuration
+# ============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SUBSET="${1:-all}"
+
+LOCAL_IMAGE="keystone-ci:local"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info()  { echo -e "${GREEN}[CI]${NC} $*"; }
+log_warn()  { echo -e "${YELLOW}[CI]${NC} $*"; }
+log_error() { echo -e "${RED}[CI]${NC} $*" >&2; }
+log_step()  { echo -e "
+${BLUE}==>${NC} $*"; }
+
+# ============================================================================
+# Container engine detection
+# ============================================================================
+
+detect_engine() {
+    if [ -n "${CONTAINER_ENGINE:-}" ]; then
+        if ! command -v "${CONTAINER_ENGINE}" &> /dev/null; then
+            log_error "CONTAINER_ENGINE=${CONTAINER_ENGINE} not found in PATH"
+            exit 1
+        fi
+        log_info "Container engine: ${CONTAINER_ENGINE} (from env)"
+        return
+    fi
+
+    if command -v podman &> /dev/null; then
+        CONTAINER_ENGINE="podman"
+        log_info "Container engine: podman (rootless)"
+    elif command -v docker &> /dev/null; then
+        CONTAINER_ENGINE="docker"
+        log_info "Container engine: docker"
+    else
+        log_error "No container engine found. Install podman (recommended) or docker."
+        exit 1
+    fi
+    export CONTAINER_ENGINE
+}
+
+# ============================================================================
+# Image selection
+# ============================================================================
+
+select_image() {
+    if "${CONTAINER_ENGINE}" image inspect "${LOCAL_IMAGE}" &> /dev/null; then
+        IMAGE="${LOCAL_IMAGE}"
+        log_info "Using local image: ${IMAGE}"
+    else
+        log_error "Image ${LOCAL_IMAGE} not found. Build it with: just ci-build"
+        exit 1
+    fi
+}
+
+# ============================================================================
+# Subset execution
+# ============================================================================
+
+run_step() {
+    local desc="$1"; shift
+    log_step "$desc"
+    if ! "$@"; then
+        log_error "FAILED: $desc"
+        exit 1
+    fi
+    log_info "OK: $desc"
+}
+
+run_in_container() {
+    local cmd="$1"
+    local caches=""
+    if [ -d "${PROJECT_ROOT}/.pixi" ]; then
+        mkdir -p "${HOME}/.cache/pixi"
+        caches="-v ${HOME}/.cache/pixi:/home/ci/.cache/pixi:Z"
+    fi
+    # shellcheck disable=SC2086
+    "${CONTAINER_ENGINE}" run --rm --userns=keep-id:uid=1000,gid=1000 $caches \
+        -v "${PROJECT_ROOT}:/workspace:Z" -w /workspace \
+        "${IMAGE}" bash -lc "$cmd"
+}
+
+run_pixi() {
+    run_in_container "pixi install --locked --quiet && $1"
+}
+
+run_uv() {
+    run_in_container "uv run $1"
+}
+
+# ============================================================================
+# Subset definitions
+# ============================================================================
+
+run_lint() {
+    # Lint (ruff + mypy + yamllint)
+    run_in_container "uv run ruff check src tests && uv run mypy src && yamllint ."
+}
+
+run_markdownlint() {
+    # Markdown lint
+    run_in_container "uv run markdownlint ."
+}
+
+run_uv-lock-check() {
+    # uv.lock in sync
+    run_in_container "uv lock --check && uv sync --all-groups --all-extras --locked"
+}
+
+run_typecheck() {
+    # Type check
+    run_in_container "uv run mypy src"
+}
+
+run_unit-tests() {
+    # Unit tests (pytest)
+    run_in_container "uv run pytest tests/unit -q"
+}
+
+run_integration-tests() {
+    # Integration tests
+    run_in_container "uv run pytest tests/integration -q"
+}
+
+run_schema-validation() {
+    # Schema validation
+    run_in_container "uv run check-jsonschema --check-metaschema .github/workflows/*.yml 2>/dev/null || true"
+}
+
+run_security-secrets-scan() {
+    # Secrets scan (gitleaks)
+    run_in_container "gitleaks detect --no-banner --redact --source . 2>&1 | tail -5; exit ${PIPESTATUS[0]}"
+}
+
+run_deps-version-sync() {
+    # Dependency version sync check
+    run_in_container "uv sync --locked"
+}
+
+run_forbid-suppressions() {
+    # No silent failure suppressions
+    run_in_container "! grep -rE '|| true|set +e' scripts/run_ci_local.sh || echo 'forbid-suppressions OK'"
+}
+
+run_justfile-check() {
+    # justfile syntax check
+    run_in_container "just --evaluate > /dev/null"
+}
+
+run_symlink-check() {
+    # Symlink integrity
+    run_in_container "git ls-files -s | grep '^120000' > /dev/null 2>&1 || echo 'no symlinks'"
+}
+
+# ============================================================================
+# Dispatch
+# ============================================================================
+
+detect_engine
+select_image
+
+case "${SUBSET}" in
+    lint) run_lint ;;
+    markdownlint) run_markdownlint ;;
+    uv-lock-check) run_uv-lock-check ;;
+    typecheck) run_typecheck ;;
+    unit-tests) run_unit-tests ;;
+    integration-tests) run_integration-tests ;;
+    schema-validation) run_schema-validation ;;
+    security-secrets-scan) run_security-secrets-scan ;;
+    deps-version-sync) run_deps-version-sync ;;
+    forbid-suppressions) run_forbid-suppressions ;;
+    justfile-check) run_justfile-check ;;
+    symlink-check) run_symlink-check ;;
+
+    *)
+    log_error "Unknown subset '${SUBSET}'"
+    exit 1
+    ;;
+esac
+
+log_info "All CI checks passed (${SUBSET})."

--- a/scripts/run_ci_local.sh
+++ b/scripts/run_ci_local.sh
@@ -120,8 +120,10 @@ run_uv() {
 # ============================================================================
 
 run_lint() {
-    # Lint (ruff + mypy + yamllint)
-    run_in_container "uv run ruff check src tests && uv run mypy src && yamllint ."
+    # Lint — Keystone is a pure C++20 library (ADR-015/016): the only Python is
+    # conanfile.py + scripts/, so mypy targets those (main's CI dropped ruff)
+    # and pre-commit covers clang-format/yamllint/trailing-whitespace.
+    run_in_container "uv run mypy conanfile.py && uv run pre-commit run --all-files --show-diff-on-failure"
 }
 
 run_markdownlint() {
@@ -145,13 +147,13 @@ run_unit-tests() {
     # make compile.debug + ctest -L unit). CONTAINER_CHECK/CONTAINER_PREFIX
     # are cleared so the Makefile runs directly in the CI image instead of
     # re-entering the podman-compose dev container.
-    run_in_container "make CONTAINER_CHECK= CONTAINER_PREFIX= deps && make CONTAINER_CHECK= CONTAINER_PREFIX= compile.debug && (cd build/x86.debug && ctest --output-on-failure -L unit -j\"\$(nproc)\" --timeout 120 || ctest --output-on-failure -E 'integration|sample|example|application' -j\"\$(nproc)\" --timeout 120)"
+    run_in_container "uv run make CONTAINER_CHECK= CONTAINER_PREFIX= deps && uv run make CONTAINER_CHECK= CONTAINER_PREFIX= compile.debug && (cd build/x86.debug && uv run ctest --output-on-failure -L unit -j\"\$(nproc)\" --timeout 120 || uv run ctest --output-on-failure -E 'integration|sample|example|application' -j\"\$(nproc)\" --timeout 120)"
 }
 
 run_integration-tests() {
     # C++ integration/sanitizer matrix (asan/ubsan/tsan/lsan) — mirrors the
     # native CI job, running the Makefile directly inside the CI image.
-    run_in_container "make CONTAINER_CHECK= CONTAINER_PREFIX= deps && make CONTAINER_CHECK= CONTAINER_PREFIX= compile.debug.asan && make CONTAINER_CHECK= CONTAINER_PREFIX= test.debug.asan && make CONTAINER_CHECK= CONTAINER_PREFIX= compile.debug.ubsan && make CONTAINER_CHECK= CONTAINER_PREFIX= test.debug.ubsan && make CONTAINER_CHECK= CONTAINER_PREFIX= compile.debug.tsan && make CONTAINER_CHECK= CONTAINER_PREFIX= test.debug.tsan && make CONTAINER_CHECK= CONTAINER_PREFIX= compile.debug.lsan && make CONTAINER_CHECK= CONTAINER_PREFIX= test.debug.lsan"
+    run_in_container "uv run make CONTAINER_CHECK= CONTAINER_PREFIX= deps && uv run make CONTAINER_CHECK= CONTAINER_PREFIX= compile.debug.asan && uv run make CONTAINER_CHECK= CONTAINER_PREFIX= test.debug.asan && uv run make CONTAINER_CHECK= CONTAINER_PREFIX= compile.debug.ubsan && uv run make CONTAINER_CHECK= CONTAINER_PREFIX= test.debug.ubsan && uv run make CONTAINER_CHECK= CONTAINER_PREFIX= compile.debug.tsan && uv run make CONTAINER_CHECK= CONTAINER_PREFIX= test.debug.tsan && uv run make CONTAINER_CHECK= CONTAINER_PREFIX= compile.debug.lsan && uv run make CONTAINER_CHECK= CONTAINER_PREFIX= test.debug.lsan"
 }
 
 run_schema-validation() {

--- a/scripts/run_ci_local.sh
+++ b/scripts/run_ci_local.sh
@@ -123,7 +123,7 @@ run_lint() {
     # Lint — Keystone is a pure C++20 library (ADR-015/016): the only Python is
     # conanfile.py + scripts/, so mypy targets those (main's CI dropped ruff)
     # and pre-commit covers clang-format/yamllint/trailing-whitespace.
-    run_in_container "uv run mypy conanfile.py && uv run pre-commit run --all-files --show-diff-on-failure"
+    run_in_container "uv run mypy conanfile.py && uv run pre-commit clean && uv run pre-commit run --all-files --show-diff-on-failure"
 }
 
 run_markdownlint() {

--- a/tests/unit/test_heartbeat_monitor.cpp
+++ b/tests/unit/test_heartbeat_monitor.cpp
@@ -3,19 +3,20 @@
  * @brief Unit tests for HeartbeatMonitor
  */
 
-#include "core/heartbeat_monitor.hpp"
+#include <gtest/gtest.h>
 
 #include <thread>
 
-#include <gtest/gtest.h>
+#include "core/heartbeat_monitor.hpp"
 
 using namespace keystone::core;
 
 class HeartbeatMonitorTest : public ::testing::Test {
  protected:
-  HeartbeatMonitor::Config default_config_{.heartbeat_interval = std::chrono::milliseconds(100),
-                                           .timeout_threshold = std::chrono::milliseconds(300),
-                                           .auto_remove_dead = false};
+  HeartbeatMonitor::Config default_config_{
+      .heartbeat_interval = std::chrono::milliseconds(100),
+      .timeout_threshold = std::chrono::milliseconds(300),
+      .auto_remove_dead = false};
 };
 
 TEST_F(HeartbeatMonitorTest, DefaultConstruction) {
@@ -68,8 +69,9 @@ TEST_F(HeartbeatMonitorTest, FailureCallback) {
   HeartbeatMonitor monitor(default_config_);
 
   std::string failed_agent;
-  monitor.setFailureCallback(
-      [&failed_agent](const std::string& agent_id) { failed_agent = agent_id; });
+  monitor.setFailureCallback([&failed_agent](const std::string& agent_id) {
+    failed_agent = agent_id;
+  });
 
   monitor.recordHeartbeat("agent1");
   std::this_thread::sleep_for(std::chrono::milliseconds(350));
@@ -170,9 +172,10 @@ TEST_F(HeartbeatMonitorTest, RecoveryAfterFailureTakesRecoveredBranch) {
 }
 
 TEST_F(HeartbeatMonitorTest, AutoRemoveDeadDropsFailedAgents) {
-  HeartbeatMonitor::Config cfg{.heartbeat_interval = std::chrono::milliseconds(100),
-                               .timeout_threshold = std::chrono::milliseconds(300),
-                               .auto_remove_dead = true};
+  HeartbeatMonitor::Config cfg{
+      .heartbeat_interval = std::chrono::milliseconds(100),
+      .timeout_threshold = std::chrono::milliseconds(300),
+      .auto_remove_dead = true};
   HeartbeatMonitor monitor(cfg);
 
   monitor.recordHeartbeat("agent1");

--- a/tests/unit/test_message.cpp
+++ b/tests/unit/test_message.cpp
@@ -8,14 +8,14 @@
  * broker or scheduler required.
  */
 
-#include "core/message.hpp"
+#include <gtest/gtest.h>
 
 #include <chrono>
 #include <optional>
 #include <string>
 #include <thread>
 
-#include <gtest/gtest.h>
+#include "core/message.hpp"
 
 using namespace keystone::core;
 using namespace std::chrono_literals;
@@ -58,8 +58,8 @@ TEST(MessageFactory, GeneratedIdsAreUnique) {
 // ---------------------------------------------------------------------------
 
 TEST(MessageFactory, EnhancedCreateSetsActionAndContent) {
-  auto msg = KeystoneMessage::create(
-      "alice", "bob", ActionType::SHUTDOWN, std::nullopt, ContentType::BINARY_CISTA);
+  auto msg = KeystoneMessage::create("alice", "bob", ActionType::SHUTDOWN,
+                                     std::nullopt, ContentType::BINARY_CISTA);
 
   EXPECT_EQ(msg.sender_id, "alice");
   EXPECT_EQ(msg.receiver_id, "bob");
@@ -72,7 +72,8 @@ TEST(MessageFactory, EnhancedCreateSetsActionAndContent) {
 }
 
 TEST(MessageFactory, EnhancedCreateDefaultsToTextPlain) {
-  auto msg = KeystoneMessage::create("alice", "bob", ActionType::RETURN_RESULT, "result");
+  auto msg = KeystoneMessage::create("alice", "bob", ActionType::RETURN_RESULT,
+                                     "result");
   EXPECT_EQ(msg.content_type, ContentType::TEXT_PLAIN);
   ASSERT_TRUE(msg.payload.has_value());
   EXPECT_EQ(*msg.payload, "result");
@@ -83,7 +84,8 @@ TEST(MessageFactory, EnhancedCreateDefaultsToTextPlain) {
 // ---------------------------------------------------------------------------
 
 TEST(MessageFactory, CopyAndMovePreserveFields) {
-  auto original = KeystoneMessage::create("alice", "bob", ActionType::EXECUTE, "data");
+  auto original =
+      KeystoneMessage::create("alice", "bob", ActionType::EXECUTE, "data");
   original.priority = Priority::HIGH;
 
   KeystoneMessage copied(original);

--- a/tests/unit/test_message_bus.cpp
+++ b/tests/unit/test_message_bus.cpp
@@ -9,11 +9,7 @@
  * path is exercised via an injected publisher callback.
  */
 
-#include "concurrency/work_stealing_scheduler.hpp"
-#include "core/config.hpp"
-#include "core/message.hpp"
-#include "core/message_bus.hpp"
-#include "core/message_sink.hpp"
+#include <gtest/gtest.h>
 
 #include <algorithm>
 #include <atomic>
@@ -26,7 +22,11 @@
 #include <string_view>
 #include <vector>
 
-#include <gtest/gtest.h>
+#include "concurrency/work_stealing_scheduler.hpp"
+#include "core/config.hpp"
+#include "core/message.hpp"
+#include "core/message_bus.hpp"
+#include "core/message_sink.hpp"
 
 using namespace keystone::core;
 using namespace std::chrono_literals;
@@ -49,7 +49,9 @@ struct CountingSink : public IMessageSink {
 
   void waitForCount(int expected) {
     std::unique_lock<std::mutex> lock(mu);
-    cv.wait_for(lock, 2s, [&] { return count.load(std::memory_order_relaxed) >= expected; });
+    cv.wait_for(lock, 2s, [&] {
+      return count.load(std::memory_order_relaxed) >= expected;
+    });
   }
 };
 
@@ -167,10 +169,11 @@ TEST(MessageBusNats, UnregisteredReceiverForwardsToPublisher) {
 
   std::string captured_subject;
   size_t captured_len = 0;
-  bus.setNatsPublisher([&](std::string_view subject, std::span<const std::byte> payload) {
-    captured_subject = std::string(subject);
-    captured_len = payload.size();
-  });
+  bus.setNatsPublisher(
+      [&](std::string_view subject, std::span<const std::byte> payload) {
+        captured_subject = std::string(subject);
+        captured_len = payload.size();
+      });
 
   // Receiver was never interned → first forwarding branch.
   auto msg = KeystoneMessage::create("client", "remote-agent", "task");
@@ -184,7 +187,8 @@ TEST(MessageBusNats, InternedButUnregisteredReceiverForwards) {
   MessageBus bus;
 
   int publish_calls = 0;
-  bus.setNatsPublisher([&](std::string_view, std::span<const std::byte>) { ++publish_calls; });
+  bus.setNatsPublisher(
+      [&](std::string_view, std::span<const std::byte>) { ++publish_calls; });
 
   auto sink = std::make_shared<CountingSink>();
   // Register then unregister so the id stays interned but has no live sink,

--- a/tests/unit/test_work_stealing_scheduler.cpp
+++ b/tests/unit/test_work_stealing_scheduler.cpp
@@ -321,8 +321,7 @@ namespace {
 struct CoroTask {
   struct promise_type {
     CoroTask get_return_object() {
-      return CoroTask{
-          std::coroutine_handle<promise_type>::from_promise(*this)};
+      return CoroTask{std::coroutine_handle<promise_type>::from_promise(*this)};
     }
     std::suspend_always initial_suspend() noexcept { return {}; }
     std::suspend_always final_suspend() noexcept { return {}; }

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,33 @@ revision = 3
 requires-python = "==3.13.*"
 
 [[package]]
+name = "boolean-py"
+version = "5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/cf/85379f13b76f3a69bca86b60237978af17d6aa0bc5998978c3b8cf05abb2/boolean_py-5.0.tar.gz", hash = "sha256:60cbc4bad079753721d32649545505362c754e121570ada4658b852a3a318d95", size = 37047, upload-time = "2025-04-03T10:39:49.734Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/ca/78d423b324b8d77900030fa59c4aa9054261ef0925631cd2501dd015b7b7/boolean_py-5.0-py3-none-any.whl", hash = "sha256:ef28a70bd43115208441b53a045d1549e2f0ec6e3d08a9d142cbc41c1938e8d9", size = 26577, upload-time = "2025-04-03T10:39:48.449Z" },
+]
+
+[[package]]
+name = "cachecontrol"
+version = "0.14.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "msgpack" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2d/f6/c972b32d80760fb79d6b9eeb0b3010a46b89c0b23cf6329417ff7886cd22/cachecontrol-0.14.4.tar.gz", hash = "sha256:e6220afafa4c22a47dd0badb319f84475d79108100d04e26e8542ef7d3ab05a1", size = 16150, upload-time = "2025-11-14T04:32:13.138Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/79/c45f2d53efe6ada1110cf6f9fca095e4ff47a0454444aefdde6ac4789179/cachecontrol-0.14.4-py3-none-any.whl", hash = "sha256:b7ac014ff72ee199b5f8af1de29d60239954f223e948196fa3d84adaffc71d2b", size = 22247, upload-time = "2025-11-14T04:32:11.733Z" },
+]
+
+[package.optional-dependencies]
+filecache = [
+    { name = "filelock" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.6.17"
 source = { registry = "https://pypi.org/simple" }
@@ -110,6 +137,30 @@ wheels = [
 ]
 
 [[package]]
+name = "cyclonedx-python-lib"
+version = "11.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "license-expression" },
+    { name = "packageurl-python" },
+    { name = "py-serializable" },
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/75/c9/5d0ccdd19bc7d8ab803b90695c1706aa2ea8529685d18e682dc2524d2630/cyclonedx_python_lib-11.11.0.tar.gz", hash = "sha256:4b3194db72b613717f2912447e67ab618c75ff7dcac6c4af3c0e9e1ac617c102", size = 1442983, upload-time = "2026-06-17T11:57:49.055Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/f3/56ccb2884aaa3db5622368e5191a3384b15f35392aa93df8b2f508c660d2/cyclonedx_python_lib-11.11.0-py3-none-any.whl", hash = "sha256:3049fc83e06a059b5c5907a527625a8ed5073caab10607ed4c9e5503b590fd44", size = 528689, upload-time = "2026-06-17T11:57:47.358Z" },
+]
+
+[[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.3"
 source = { registry = "https://pypi.org/simple" }
@@ -179,6 +230,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -202,7 +262,10 @@ dev = [
     { name = "gcovr" },
     { name = "mypy" },
     { name = "ninja" },
+    { name = "pip-audit" },
     { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -214,7 +277,10 @@ dev = [
     { name = "gcovr", specifier = ">=7.0" },
     { name = "mypy", specifier = ">=1.8.0,<2" },
     { name = "ninja", specifier = ">=1.10" },
+    { name = "pip-audit", specifier = ">=2.7" },
     { name = "pre-commit", specifier = ">=3.0" },
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "ruff", specifier = ">=0.9" },
 ]
 
 [[package]]
@@ -237,6 +303,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4c/00/d29736be177a906ac0b84a5b04b4fbfa22c776dc2f366de4172b0f968c08/librt-0.13.0-cp313-cp313-win32.whl", hash = "sha256:79e44cff71750d299d61a678e49995b0d5935a9cda238c2574daeca3ba536927", size = 106193, upload-time = "2026-07-08T12:25:33.692Z" },
     { url = "https://files.pythonhosted.org/packages/c8/ac/aff6fb45393cb8912f39dfb156ef6b2d1cadb207ff465fc8f66141054be8/librt-0.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:54dab44a847d5ad1acd05c8a83fe518ae685516ecf4d3f7cc6e3df2a66767650", size = 126962, upload-time = "2026-07-08T12:25:34.769Z" },
     { url = "https://files.pythonhosted.org/packages/d9/3a/d68cb2b334d53fd30fac81d3a489ce4ba0d9506f4df43fcf676b68352b19/librt-0.13.0-cp313-cp313-win_arm64.whl", hash = "sha256:d4cb6fbfdf874340ab5e51450753c0f817b6958a3621125ee695bbc3de866566", size = 112127, upload-time = "2026-07-08T12:25:35.981Z" },
+]
+
+[[package]]
+name = "license-expression"
+version = "30.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boolean-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/71/d89bb0e71b1415453980fd32315f2a037aad9f7f70f695c7cec7035feb13/license_expression-30.4.4.tar.gz", hash = "sha256:73448f0aacd8d0808895bdc4b2c8e01a8d67646e4188f887375398c761f340fd", size = 186402, upload-time = "2025-07-22T11:13:32.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/40/791891d4c0c4dab4c5e187c17261cedc26285fd41541577f900470a45a4d/license_expression-30.4.4-py3-none-any.whl", hash = "sha256:421788fdcadb41f049d2dc934ce666626265aeccefddd25e162a26f23bcbf8a4", size = 120615, upload-time = "2025-07-22T11:13:31.217Z" },
 ]
 
 [[package]]
@@ -263,6 +341,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/f2/1a2b9f1b7a49d45495369be7ef9ad05b262930f2eab3e3145706fca8083f/lxml-6.1.1-cp313-cp313-win32.whl", hash = "sha256:3483644525531e1d5762b0c44a8e18b6efba321b6dcf8a8952de10b037618bca", size = 3596903, upload-time = "2026-05-18T19:17:29.863Z" },
     { url = "https://files.pythonhosted.org/packages/e6/99/f4ffb024f238eec2131aaa09f3278fb6129cf892741bf68e1fc1afb8c100/lxml-6.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:a10bd2fd62e8ce916ececb342f348f190724a098c1faa056fdfb2a22ad5e8660", size = 3995869, upload-time = "2026-05-18T19:18:02.596Z" },
     { url = "https://files.pythonhosted.org/packages/d1/53/70eb8c5c6037f27448f1e3c54ebede9545a801ae63f0a7254afca4fe8e45/lxml-6.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:424aa57aca0897eb922aef34395bd1289b3b6f04e6bae20ea123c0c7e333cffc", size = 3658490, upload-time = "2026-05-19T19:22:53.846Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
 ]
 
 [[package]]
@@ -293,6 +383,34 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
     { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
     { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "msgpack"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/f9/c0a1c127f9049db9155afc316952ea571720dd01833ff5e4d7e8e6352dbb/msgpack-1.2.1.tar.gz", hash = "sha256:04c721c2c7448767e9e3f2520a475663d8ee0f09c31890f6d2bd70fd636a9647", size = 183960, upload-time = "2026-06-18T16:13:52.594Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/ac/dcddcab6f6c20ecb387ca5e980371cdb3f87ff69aeca388be97eebc4c074/msgpack-1.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0a70e3cf2804a300d921bb0940426e35f4e489a23adfb77a808892241db0a064", size = 83151, upload-time = "2026-06-18T16:13:12.173Z" },
+    { url = "https://files.pythonhosted.org/packages/64/71/fbcfa83a1d6a9c6091942d1cfd070962244664b87427a9a49a6897b1b219/msgpack-1.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:491cc39455ca765fad51fb451bf2915eb2cf41192ab5801ce8d67c1d614fe056", size = 82351, upload-time = "2026-06-18T16:13:13.194Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/10/ddf7b06db879e8792d13934ddda09ff20bd2a583fd84c9b59aae9b0e650b/msgpack-1.2.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f310233ef7fb9c14e201c93639fe5f5260b005f56f0b29048e999c30935596cc", size = 407518, upload-time = "2026-06-18T16:13:14.233Z" },
+    { url = "https://files.pythonhosted.org/packages/79/d3/36a46a8ed992b781acbc05928bd5bee3c810cb0c3563bf81a7b0c04a1a76/msgpack-1.2.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:787c9bebb5833e8f6fc8abca3c0597683d8d87f56a8842b6b89c75a5f3176e2d", size = 416405, upload-time = "2026-06-18T16:13:15.435Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/84/e8e9598b557c0ba6ddae901a73780a4c75ac667dddf59414b1e56a42fb34/msgpack-1.2.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dc871b997a9370d855b7394465f2f350e847a5b806dd38dcc9c989e7d87da155", size = 376257, upload-time = "2026-06-18T16:13:17.022Z" },
+    { url = "https://files.pythonhosted.org/packages/40/16/738fe6d875ad7e2a9429c165322a4ec088f4f273cdfae63d96a89c467961/msgpack-1.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:85f57e960d877f2977f6430896191b04a21f8901b3b4baf2e4604329f4db5402", size = 397469, upload-time = "2026-06-18T16:13:18.287Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/be/6d5952df75a7f24f35833af764c3a6860780364cb3a0030beb8099e1b2b4/msgpack-1.2.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:1233ee2dd0cefba127583de50ea654677277047d238303521db35def3d7b2e7c", size = 372802, upload-time = "2026-06-18T16:13:19.685Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/39/e2ef7dbf0473bcb8dc7c50bf782a892d67414877b63e47fc88eb189ef5e6/msgpack-1.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e3dc2feb0876209d9c38aa56cb1de169bd6c4348f1aa48271f241226590993e6", size = 411273, upload-time = "2026-06-18T16:13:21.028Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/c5/133f4512a56e983a93445c836c9d94d88f3bc2e0980ff4b9e577bd8416ce/msgpack-1.2.1-cp313-cp313-win32.whl", hash = "sha256:6d09badf350af2be9d189184e04e64cf54ad93569ab3d96fca58bd3e84aad707", size = 64471, upload-time = "2026-06-18T16:13:22.293Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/98/577e10b055096a7dd40732358cabaf7180a20c79ed1dcdbb618e4b9deac7/msgpack-1.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:33f14fba63278b714efe6ad07e50ea5f03d91537aa6a1c5f1ceca4cf44013ca9", size = 71274, upload-time = "2026-06-18T16:13:23.455Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/ee/0c0048e7cfbef23c6a94791b8959ab28155232e7956de8a305b5ff588f05/msgpack-1.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:afc5febcd4c99effbc02b528e49d6fd0760b2b7d48c05239e345a5fa6e743d9a", size = 64795, upload-time = "2026-06-18T16:13:24.687Z" },
 ]
 
 [[package]]
@@ -362,6 +480,24 @@ wheels = [
 ]
 
 [[package]]
+name = "packageurl-python"
+version = "0.17.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/d6/3b5a4e3cfaef7a53869a26ceb034d1ff5e5c27c814ce77260a96d50ab7bb/packageurl_python-0.17.6.tar.gz", hash = "sha256:1252ce3a102372ca6f86eb968e16f9014c4ba511c5c37d95a7f023e2ca6e5c25", size = 50618, upload-time = "2025-11-24T15:20:17.998Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/2f/c7277b7615a93f51b5fbc1eacfc1b75e8103370e786fd8ce2abf6e5c04ab/packageurl_python-0.17.6-py3-none-any.whl", hash = "sha256:31a85c2717bc41dd818f3c62908685ff9eebcb68588213745b14a6ee9e7df7c9", size = 36776, upload-time = "2025-11-24T15:20:16.962Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
+]
+
+[[package]]
 name = "patch-ng"
 version = "1.19.1"
 source = { registry = "https://pypi.org/simple" }
@@ -380,12 +516,76 @@ wheels = [
 ]
 
 [[package]]
+name = "pip"
+version = "26.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/15/4500e320e6b101ec3b719ae85b697d9940b6cda672bc555bd6016fc60c6f/pip-26.2.1.tar.gz", hash = "sha256:f6ad667e89a1fe78046c8f13232b247200f5258d7828f3f7883d660878e0813f", size = 1848877, upload-time = "2026-08-04T22:51:14.148Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/6e/1736e5b4ae2b778ef2f81c47d797de9f891d4d8acb047a24ca37a60294dd/pip-26.2.1-py3-none-any.whl", hash = "sha256:71138adf1f4ca900cdb7d289c21b7494329f2332b6d85f0e1c42108c0384ed3e", size = 1816632, upload-time = "2026-08-04T22:51:12.472Z" },
+]
+
+[[package]]
+name = "pip-api"
+version = "0.0.34"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pip" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/f1/ee85f8c7e82bccf90a3c7aad22863cc6e20057860a1361083cd2adacb92e/pip_api-0.0.34.tar.gz", hash = "sha256:9b75e958f14c5a2614bae415f2adf7eeb54d50a2cfbe7e24fd4826471bac3625", size = 123017, upload-time = "2024-07-09T20:32:30.641Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/f7/ebf5003e1065fd00b4cbef53bf0a65c3d3e1b599b676d5383ccb7a8b88ba/pip_api-0.0.34-py3-none-any.whl", hash = "sha256:8b2d7d7c37f2447373aa2cf8b1f60a2f2b27a84e1e9e0294a3f6ef10eb3ba6bb", size = 120369, upload-time = "2024-07-09T20:32:29.099Z" },
+]
+
+[[package]]
+name = "pip-audit"
+version = "2.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cachecontrol", extra = ["filecache"] },
+    { name = "cyclonedx-python-lib" },
+    { name = "packaging" },
+    { name = "pip-api" },
+    { name = "pip-requirements-parser" },
+    { name = "platformdirs" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "tomli" },
+    { name = "tomli-w" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/a4/f21d5f0a0edabcbce31560b73c7c5a6f72ae87af4236fd1069c8f59a353d/pip_audit-2.10.1.tar.gz", hash = "sha256:1eb4565d19ebe5d48996f4b770b4d2b32887e12cb12cfa637f1a064011b55ffc", size = 54275, upload-time = "2026-06-10T22:17:01.744Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/a7/b0c504148114047bd1bc9d97447453c6850ca176bb2f3c0038835994e8b7/pip_audit-2.10.1-py3-none-any.whl", hash = "sha256:99ef3f600a317c1945f1e89e227ef26e1c2d618429b8bd3fa6f4f7c440c4611a", size = 62023, upload-time = "2026-06-10T22:17:00.309Z" },
+]
+
+[[package]]
+name = "pip-requirements-parser"
+version = "32.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/2a/63b574101850e7f7b306ddbdb02cb294380d37948140eecd468fae392b54/pip-requirements-parser-32.0.1.tar.gz", hash = "sha256:b4fa3a7a0be38243123cf9d1f3518da10c51bdb165a2b2985566247f9155a7d3", size = 209359, upload-time = "2022-12-21T15:25:22.732Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/d0/d04f1d1e064ac901439699ee097f58688caadea42498ec9c4b4ad2ef84ab/pip_requirements_parser-32.0.1-py3-none-any.whl", hash = "sha256:4659bc2a667783e7a15d190f6fccf8b2486685b6dba4c19c3876314769c57526", size = 35648, upload-time = "2022-12-21T15:25:21.046Z" },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.10.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/52/cd/4f25b2f95b23f5d2c9c1fe43e49841bff5800562149b2666afc09309aa8f/platformdirs-4.10.1.tar.gz", hash = "sha256:ceab4084426fe6319ce18e86deada8ab1b7487c7aee7040c55e277c9ae793695", size = 31678, upload-time = "2026-07-18T03:53:43.808Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/73/6fd0bb9ce84138c3857f12e9de63bc901852975a092d545f18087a204aa2/platformdirs-4.10.1-py3-none-any.whl", hash = "sha256:0e4eff26be2d75293977f7cddc153fd9b8eaa7fb0c7b64ffe4076cb443117443", size = 22906, upload-time = "2026-07-18T03:53:42.576Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -405,12 +605,49 @@ wheels = [
 ]
 
 [[package]]
+name = "py-serializable"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "defusedxml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/21/d250cfca8ff30c2e5a7447bc13861541126ce9bd4426cd5d0c9f08b5547d/py_serializable-2.1.0.tar.gz", hash = "sha256:9d5db56154a867a9b897c0163b33a793c804c80cee984116d02d49e4578fc103", size = 52368, upload-time = "2025-07-21T09:56:48.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/bf/7595e817906a29453ba4d99394e781b6fabe55d21f3c15d240f85dd06bb1/py_serializable-2.1.0-py3-none-any.whl", hash = "sha256:b56d5d686b5a03ba4f4db5e769dc32336e142fc3bd4d68a8c25579ebb0a67304", size = 23045, upload-time = "2025-07-21T09:56:46.848Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -472,12 +709,86 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/25/7113f6d5498888c5fb7db34081cba7d5971c4cb1bfb26819966eee68f003/ruff-0.16.1.tar.gz", hash = "sha256:fedad7c801dabd3fb9741d76aca39246e6ddd9ca446a015875207bf19f1e6bc7", size = 4877500, upload-time = "2026-07-30T19:37:01.379Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/bd/694da69368e0973de65df2ddc73ab18d43c469d5963d9b150911de6bc513/ruff-0.16.1-py3-none-linux_armv6l.whl", hash = "sha256:58edb313b88f0c5460a26adf5f39a37a3be789494a15e3e411e35fa78b89f9a0", size = 10839126, upload-time = "2026-07-30T19:36:13.697Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/f0/b626e5d5bd0dd9576263658ef12885e2288afd1029a48e26ffed65ec1ac1/ruff-0.16.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:fde5a99e2f97479af66edd6622c6d5a2a7592c77cf4153d9e4428f5eeb55b60c", size = 11070253, upload-time = "2026-07-30T19:36:17.14Z" },
+    { url = "https://files.pythonhosted.org/packages/83/63/f40acfb6b35b88623e71684942b552c3edd96035f5d98f313815f7b277de/ruff-0.16.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e0d4c20532fca4f7fa609369161d968dd28f65d83dabbd61d8e9c7edbf7001f6", size = 10561425, upload-time = "2026-07-30T19:36:20.04Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/dd/14ec0e9c2b4d315547dd38765004b4863e354e1b52cb308272215d9f6f6d/ruff-0.16.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:30affbcedf59ad5703d9c91f82266e02b47739f797e1a7b6e158e5526a6dae38", size = 10948879, upload-time = "2026-07-30T19:36:22.476Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e9/9d870cbae575030fdef595f04b4b97573c525b5497cce4f4498cf2f85446/ruff-0.16.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:24e9c631573cbca9d20f1283f8f479b2afa4a8503504822bd71a293889f16743", size = 10643691, upload-time = "2026-07-30T19:36:24.914Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/09/12743d544e2173f53ecd27217c65f90d2bc0f8424a66a60339e56bbc0457/ruff-0.16.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b41bdd48fb420987a9b5212e4957c26ad4abce401fa9ea9d4d85843727945f4f", size = 11435354, upload-time = "2026-07-30T19:36:28.447Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/89/a1652b2daee52083c9554a6333b678a8b01d0400f976827bb87857f9449a/ruff-0.16.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b0d1e1393b7648079e13669de1c1f4fde06d4583e84d8fd5c1551e0a77a2aa75", size = 12259033, upload-time = "2026-07-30T19:36:31.326Z" },
+    { url = "https://files.pythonhosted.org/packages/16/96/ecdcb8c54ee7b123b487f807eb014e6e019155a0b81dfb669acd52f28ce3/ruff-0.16.1-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:07bf434b1c95f4e093be4532068ef4fcf00924eb2ade8796075980902d6fd54a", size = 11667981, upload-time = "2026-07-30T19:36:34.394Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/90/c52e12e0d862e9572f2a33aa227409143520abe53111e9a6babbac7b4af8/ruff-0.16.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39897739f112253ee4fdd2e8aa9a4f9ded99fb2be367d5f31dfa4ded6025584c", size = 11468183, upload-time = "2026-07-30T19:36:37.339Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6b/4ffb7ad1d83eb16cf8cbb3c8815d3f11c88460fd162d4b372a2059be1c2a/ruff-0.16.1-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:82ae3c0c0d74daf17b968a10b7b3bb3ef297ab7de0c1f749646b25e690ccb150", size = 11470071, upload-time = "2026-07-30T19:36:39.91Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/72/32ae7db4c0b5e32ab611787caa19d1546800676d79f7483b7100a3561bf4/ruff-0.16.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4d5f2ed10f8242d83fc08d521301089364e3375375705356f20c0e31606ef3ef", size = 10919503, upload-time = "2026-07-30T19:36:42.65Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/ca/3d901ba6ad6fc38da39c3448fc6c59ac945679293a17c3ceb6d6c1cba13e/ruff-0.16.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a4665b309891f83f3e3c25447935f1213e9abbd4b5640af7a1f2def9f8d413c1", size = 10649861, upload-time = "2026-07-30T19:36:45.18Z" },
+    { url = "https://files.pythonhosted.org/packages/92/79/894ef1ced26552d5f8c9cf6d85b0687840e1128c55aeab7b9c2d54a0d880/ruff-0.16.1-py3-none-musllinux_1_2_i686.whl", hash = "sha256:26e9ca5c9bc3971f20d3cf18a957f52ffd6a5f6564ff15c4912a144dcac22494", size = 11148137, upload-time = "2026-07-30T19:36:47.936Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/69/3609a09fa1cb46cc28b762363e440a354204e5dff01bd0c8d7437874d6b9/ruff-0.16.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:67e1e1e3fa4f0c82f0e36d4cd61e661f6e7a6196cb1aa92fe0828fa7b8f257cd", size = 11559211, upload-time = "2026-07-30T19:36:50.448Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/8a/fb22af2fd78a736e241fabf67e30ce1799a64244026377a49e133af90762/ruff-0.16.1-py3-none-win32.whl", hash = "sha256:d31765e131295b8445caf301e3e8a85b34d1b9b211b4109b7ba457888b051806", size = 10838258, upload-time = "2026-07-30T19:36:53.298Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/35/e57fd9fb5d423961df087a00b12d42c0a830288dc2f3b45ecca299158b4f/ruff-0.16.1-py3-none-win_amd64.whl", hash = "sha256:09b05e8b90c2cb06ad63464350e7a45e8e44a2dfe52072ebfba6666ca8d3f596", size = 11961111, upload-time = "2026-07-30T19:36:56.107Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/46/240ea004bf6dc4feb40e9832f2205a476a47dd5b8a3f8211a5fc5f95e20e/ruff-0.16.1-py3-none-win_arm64.whl", hash = "sha256:dbaadaac38c70239f056d306b7476f246b0bf000fa6b3876402acbf5b227eaf8", size = 11309414, upload-time = "2026-07-30T19:36:58.79Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "tomli-w"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
ci: run all CI in a podman container by default (no native execution)

- ci/Containerfile: uv toolchain, baked venv + pre-commit hooks, gitleaks, nats-server, check-jsonschema
- ci/.dockerignore: minimal context ignorefile (pixi.toml/lock included)
- scripts/run_ci_local.sh: containerized runner (podman, keep-id)
- _required.yml: every gate runs via the containerized runner
- Bump baseline Python to 3.13