### PR TITLE
ci: fix profiling test binary path

### DIFF
--- a/.github/workflows/profiling-weekly.yml
+++ b/.github/workflows/profiling-weekly.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Run profiling tests
         run: |
           cd build/profiling
-          ./profiling_tests --gtest_output=xml:profiling_test_results.xml
+          ./bin/profiling_tests --gtest_output=xml:profiling_test_results.xml
 
       - name: Upload test results
         if: always()


### PR DESCRIPTION
Fixes main: the Profiling Tests (Slow) job fails with exit 127 because ninja links profiling_tests into build/profiling/bin/, but the run step invoked ./profiling_tests from build/profiling/ directly.

- Point the run step at ./bin/profiling_tests