### PR TITLE
fix(scan): close file-not-closed + unused-variable alerts

- scripts/lint-changelog.py: use a with-block so the file handle always closes
  (py/file-not-closed)
- src/monitoring/prometheus_exporter.cpp + health_check_server.cpp: replace
  [[maybe_unused]] result vars with explicit (void)write(...) — CodeQL does not honor
  the attribute on these sites, but discarding the value satisfies the query.

### DIFF
--- a/scripts/lint-changelog.py
+++ b/scripts/lint-changelog.py
@@ -41,7 +41,8 @@ def lint(path: str) -> list[str]:
     errors: list[str] = []
 
     try:
-        content = open(path, encoding="utf-8").read()
+        with open(path, encoding="utf-8") as fh:
+            content = fh.read()
     except OSError as exc:
         return [f"Cannot read {path}: {exc}"]
 

--- a/src/monitoring/health_check_server.cpp
+++ b/src/monitoring/health_check_server.cpp
@@ -281,7 +281,8 @@ void HealthCheckServer::handleRequest(int client_fd) {
         "HTTP/1.1 405 Method Not Allowed\r\n"
         "Allow: GET\r\n"
         "Content-Length: 0\r\n\r\n";
-    (void)write(client_fd, method_not_allowed.c_str(), method_not_allowed.size());
+    (void)write(client_fd, method_not_allowed.c_str(),
+                method_not_allowed.size());
     return;
   }
 

--- a/src/monitoring/health_check_server.cpp
+++ b/src/monitoring/health_check_server.cpp
@@ -263,8 +263,7 @@ void HealthCheckServer::handleRequest(int client_fd) {
   if (bytes_read < 5) {
     std::string bad_request =
         "HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n\r\n";
-    [[maybe_unused]] auto result =
-        write(client_fd, bad_request.c_str(), bad_request.size());
+    (void)write(client_fd, bad_request.c_str(), bad_request.size());
     return;
   }
 
@@ -282,8 +281,7 @@ void HealthCheckServer::handleRequest(int client_fd) {
         "HTTP/1.1 405 Method Not Allowed\r\n"
         "Allow: GET\r\n"
         "Content-Length: 0\r\n\r\n";
-    [[maybe_unused]] auto result =
-        write(client_fd, method_not_allowed.c_str(), method_not_allowed.size());
+    (void)write(client_fd, method_not_allowed.c_str(), method_not_allowed.size());
     return;
   }
 
@@ -310,8 +308,7 @@ void HealthCheckServer::handleRequest(int client_fd) {
     response << body;
 
     std::string response_str = response.str();
-    [[maybe_unused]] auto result =
-        write(client_fd, response_str.c_str(), response_str.size());
+    (void)write(client_fd, response_str.c_str(), response_str.size());
 
   } else if (is_liveness) {
     // Liveness probe - always return 200 OK if process is alive
@@ -325,8 +322,7 @@ void HealthCheckServer::handleRequest(int client_fd) {
     response << body;
 
     std::string response_str = response.str();
-    [[maybe_unused]] auto result =
-        write(client_fd, response_str.c_str(), response_str.size());
+    (void)write(client_fd, response_str.c_str(), response_str.size());
 
   } else if (is_readiness) {
     // Readiness probe - check if system is ready
@@ -354,8 +350,7 @@ void HealthCheckServer::handleRequest(int client_fd) {
     response << body;
 
     std::string response_str = response.str();
-    [[maybe_unused]] auto result =
-        write(client_fd, response_str.c_str(), response_str.size());
+    (void)write(client_fd, response_str.c_str(), response_str.size());
 
   } else {
     // Send 404 for other paths
@@ -365,8 +360,7 @@ void HealthCheckServer::handleRequest(int client_fd) {
         "Content-Length: 27\r\n"
         "\r\n"
         "{\"error\":\"endpoint not found\"}";
-    [[maybe_unused]] auto result =
-        write(client_fd, not_found.c_str(), not_found.size());
+    (void)write(client_fd, not_found.c_str(), not_found.size());
   }
 }
 

--- a/src/monitoring/prometheus_exporter.cpp
+++ b/src/monitoring/prometheus_exporter.cpp
@@ -201,8 +201,7 @@ void PrometheusExporter::handleRequest(int client_fd) {
   if (bytes_read < 5) {
     std::string bad_request =
         "HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n\r\n";
-    [[maybe_unused]] auto result =
-        write(client_fd, bad_request.c_str(), bad_request.size());
+    (void)write(client_fd, bad_request.c_str(), bad_request.size());
     return;
   }
 
@@ -222,8 +221,7 @@ void PrometheusExporter::handleRequest(int client_fd) {
         "HTTP/1.1 405 Method Not Allowed\r\n"
         "Allow: GET\r\n"
         "Content-Length: 0\r\n\r\n";
-    [[maybe_unused]] auto result =
-        write(client_fd, method_not_allowed.c_str(), method_not_allowed.size());
+    (void)write(client_fd, method_not_allowed.c_str(), method_not_allowed.size());
     return;
   }
 
@@ -242,14 +240,12 @@ void PrometheusExporter::handleRequest(int client_fd) {
     response << metrics;
 
     std::string response_str = response.str();
-    [[maybe_unused]] auto result =
-        write(client_fd, response_str.c_str(), response_str.size());
+    (void)write(client_fd, response_str.c_str(), response_str.size());
   } else {
     // Send 404 for other paths
     std::string not_found =
         "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n";
-    [[maybe_unused]] auto result =
-        write(client_fd, not_found.c_str(), not_found.size());
+    (void)write(client_fd, not_found.c_str(), not_found.size());
   }
 }
 

--- a/src/monitoring/prometheus_exporter.cpp
+++ b/src/monitoring/prometheus_exporter.cpp
@@ -221,7 +221,8 @@ void PrometheusExporter::handleRequest(int client_fd) {
         "HTTP/1.1 405 Method Not Allowed\r\n"
         "Allow: GET\r\n"
         "Content-Length: 0\r\n\r\n";
-    (void)write(client_fd, method_not_allowed.c_str(), method_not_allowed.size());
+    (void)write(client_fd, method_not_allowed.c_str(),
+                method_not_allowed.size());
     return;
   }
 


### PR DESCRIPTION
## Summary
fix(scan): close file-not-closed + unused-variable alerts

- scripts/lint-changelog.py: use a with-block so the file handle always closes
  (py/file-not-closed)
- src/monitoring/prometheus_exporter.cpp + health_check_server.cpp: replace
  [[maybe_unused]] result vars with explicit (void)write(...) — CodeQL does not honor
  the attribute on these sites, but discarding the value satisfies the query.

## Validation
- Signed commit (GPG) with DCO sign-off
- Targeted validation run per-repo (unit tests / tsc / actionlint / syntax checks)

Closes nothing (fleet-wide code-scanning alert remediation).