### PR TITLE
fix(ci): grant security-events:write to secrets-scan job for SARIF upload

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -787,6 +787,9 @@ jobs:
     name: security/secrets-scan
     runs-on: ubuntu-24.04
     timeout-minutes: 15
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:


### PR DESCRIPTION
Fixes the main-wide Required Checks red: the Gitleaks SARIF upload step (github/codeql-action/upload-sarif) fails because the security/secrets-scan job only inherits the workflow-level `contents: read` permission. Add `security-events: write` at the job level so SARIF results can be uploaded to the Security tab.