### PR TITLE
fix(codeql): mark unused benchmark loop vars; NatsConfig by const ref

### DIFF
--- a/benchmarks/distributed_work_stealing.cpp
+++ b/benchmarks/distributed_work_stealing.cpp
@@ -16,6 +16,8 @@ static void BM_WorkStealing_LocalOnly(benchmark::State& state) {
   const size_t num_tasks = state.range(0);
 
   for (auto _ : state) {
+    (void)_;
+    (void)_;
     SimulatedCluster::Config config{
         .num_nodes = 1, .workers_per_node = 4, .network_config = {}};
     SimulatedCluster cluster(config);
@@ -52,6 +54,7 @@ static void BM_WorkStealing_TwoNodes_100us(benchmark::State& state) {
   const size_t num_tasks = state.range(0);
 
   for (auto _ : state) {
+    (void)_;
     SimulatedCluster::Config config{
         .num_nodes = 2,
         .workers_per_node = 4,
@@ -91,6 +94,7 @@ static void BM_WorkStealing_TwoNodes_500us(benchmark::State& state) {
   const size_t num_tasks = state.range(0);
 
   for (auto _ : state) {
+    (void)_;
     SimulatedCluster::Config config{
         .num_nodes = 2,
         .workers_per_node = 4,
@@ -128,6 +132,7 @@ static void BM_WorkStealing_TwoNodes_1ms(benchmark::State& state) {
   const size_t num_tasks = state.range(0);
 
   for (auto _ : state) {
+    (void)_;
     SimulatedCluster::Config config{
         .num_nodes = 2,
         .workers_per_node = 4,
@@ -164,6 +169,7 @@ static void BM_LoadBalancing_Imbalanced(benchmark::State& state) {
   const size_t num_tasks = state.range(0);
 
   for (auto _ : state) {
+    (void)_;
     SimulatedCluster::Config config{
         .num_nodes = 4,
         .workers_per_node = 2,
@@ -214,6 +220,7 @@ static void BM_NetworkOverhead_MessageOnly(benchmark::State& state) {
   const size_t num_messages = state.range(0);
 
   for (auto _ : state) {
+    (void)_;
     SimulatedCluster::Config config{
         .num_nodes = 2,
         .workers_per_node = 2,
@@ -257,6 +264,7 @@ static void BM_AgentAffinity_Registered(benchmark::State& state) {
   const size_t num_tasks = state.range(0);
 
   for (auto _ : state) {
+    (void)_;
     SimulatedCluster::Config config{
         .num_nodes = 4, .workers_per_node = 4, .network_config = {}};
     SimulatedCluster cluster(config);
@@ -300,6 +308,7 @@ static void BM_PacketLoss_Impact(benchmark::State& state) {
   const size_t num_messages = 100;
 
   for (auto _ : state) {
+    (void)_;
     SimulatedCluster::Config config{
         .num_nodes = 2,
         .workers_per_node = 2,

--- a/benchmarks/message_pool_performance.cpp
+++ b/benchmarks/message_pool_performance.cpp
@@ -24,6 +24,7 @@ using namespace keystone::core;
  */
 static void BM_MessageCreation_NoPooing(benchmark::State& state) {
   for (auto _ : state) {
+    (void)_;
     auto msg = KeystoneMessage::create("sender", "receiver", "test_command");
     msg.payload = "test payload data";
     msg.priority = Priority::HIGH;
@@ -45,6 +46,7 @@ static void BM_MessageCreation_WithPooling(benchmark::State& state) {
   }
 
   for (auto _ : state) {
+    (void)_;
     auto msg = MessagePool::acquire();
     msg.msg_id = "test-msg";
     msg.sender_id = "sender";
@@ -66,6 +68,8 @@ static void BM_MessageBurst_NoPooling(benchmark::State& state) {
   const int32_t burst_size = static_cast<int32_t>(state.range(0));
 
   for (auto _ : state) {
+    (void)_;
+    (void)_;
     std::vector<KeystoneMessage> messages;
     messages.reserve(static_cast<size_t>(burst_size));
 
@@ -95,6 +99,7 @@ static void BM_MessageBurst_WithPooling(benchmark::State& state) {
   }
 
   for (auto _ : state) {
+    (void)_;
     std::vector<KeystoneMessage> messages;
     messages.reserve(static_cast<size_t>(burst_size));
 
@@ -117,6 +122,7 @@ BENCHMARK(BM_MessageBurst_WithPooling)->Arg(10)->Arg(100)->Arg(1000);
  */
 static void BM_SteadyState_NoPooling(benchmark::State& state) {
   for (auto _ : state) {
+    (void)_;
     auto msg = KeystoneMessage::create("sender", "receiver", "cmd");
     msg.payload = "payload";
     benchmark::DoNotOptimize(msg);
@@ -137,6 +143,7 @@ static void BM_SteadyState_WithPooling(benchmark::State& state) {
   }
 
   for (auto _ : state) {
+    (void)_;
     auto msg = MessagePool::acquire();
     msg.sender_id = "sender";
     msg.receiver_id = "receiver";
@@ -160,6 +167,7 @@ static void BM_PoolStatistics(benchmark::State& state) {
   }
 
   for (auto _ : state) {
+    (void)_;
     auto stats = MessagePool::getStats();
     benchmark::DoNotOptimize(stats);
   }
@@ -184,6 +192,7 @@ static void BM_PoolHitRate(benchmark::State& state) {
   }
 
   for (auto _ : state) {
+    (void)_;
     auto msg = MessagePool::acquire();
     MessagePool::release(std::move(msg));
   }
@@ -215,6 +224,7 @@ static void BM_ThreadLocalPooling(benchmark::State& state) {
   }
 
   for (auto _ : state) {
+    (void)_;
     auto msg = MessagePool::acquire();
     msg.command = "test";
     benchmark::DoNotOptimize(msg);
@@ -237,6 +247,7 @@ BENCHMARK(BM_ThreadLocalPooling)->Threads(1)->Threads(2)->Threads(4);
  */
 static void BM_MessageReset(benchmark::State& state) {
   for (auto _ : state) {
+    (void)_;
     KeystoneMessage msg;
     msg.msg_id = "test-id-123";
     msg.sender_id = "sender-agent";

--- a/benchmarks/resilience_performance.cpp
+++ b/benchmarks/resilience_performance.cpp
@@ -28,6 +28,7 @@ using namespace keystone::core;
 // Benchmark: Retry policy creation
 static void BM_RetryPolicy_Creation(benchmark::State& state) {
   for (auto _ : state) {
+    (void)_;
     auto policy = RetryPolicy(5, std::chrono::milliseconds(100), 2.0,
                               std::chrono::seconds(30));
     benchmark::DoNotOptimize(policy);
@@ -42,6 +43,7 @@ static void BM_RetryPolicy_ShouldRetry(benchmark::State& state) {
 
   uint32_t attempt = 0;
   for (auto _ : state) {
+    (void)_;
     bool should_retry = policy.shouldRetry(attempt % 150);
     benchmark::DoNotOptimize(should_retry);
     attempt++;
@@ -58,6 +60,7 @@ static void BM_RetryPolicy_BackoffCalculation(benchmark::State& state) {
 
   uint32_t attempt = 0;
   for (auto _ : state) {
+    (void)_;
     auto delay = policy.getBackoffDelay(attempt % 20);
     benchmark::DoNotOptimize(delay);
     attempt++;
@@ -72,6 +75,7 @@ static void BM_RetryPolicy_FullSequence(benchmark::State& state) {
   int32_t max_retries = static_cast<int32_t>(state.range(0));
 
   for (auto _ : state) {
+    (void)_;
     auto policy = RetryPolicy(max_retries, std::chrono::milliseconds(10), 2.0,
                               std::chrono::seconds(10));
 
@@ -94,6 +98,7 @@ static void BM_RetryPolicy_VaryingMultiplier(benchmark::State& state) {
                             std::chrono::seconds(30));
 
   for (auto _ : state) {
+    (void)_;
     for (int32_t attempt = 0; attempt < 10; ++attempt) {
       auto delay = policy.getBackoffDelay(attempt);
       benchmark::DoNotOptimize(delay);
@@ -111,6 +116,7 @@ BENCHMARK(BM_RetryPolicy_VaryingMultiplier)->DenseRange(10, 50, 10);
 // Benchmark: Circuit breaker creation
 static void BM_CircuitBreaker_Creation(benchmark::State& state) {
   for (auto _ : state) {
+    (void)_;
     auto cb = CircuitBreaker("test", 5, std::chrono::seconds(10),
                              std::chrono::seconds(5));
     benchmark::DoNotOptimize(cb);
@@ -124,6 +130,7 @@ static void BM_CircuitBreaker_AllowRequest_Closed(benchmark::State& state) {
                            std::chrono::seconds(5));
 
   for (auto _ : state) {
+    (void)_;
     bool allowed = cb.allowRequest();
     benchmark::DoNotOptimize(allowed);
   }
@@ -138,6 +145,7 @@ static void BM_CircuitBreaker_RecordSuccess(benchmark::State& state) {
                            std::chrono::seconds(5));
 
   for (auto _ : state) {
+    (void)_;
     cb.recordSuccess();
   }
 
@@ -148,6 +156,7 @@ BENCHMARK(BM_CircuitBreaker_RecordSuccess);
 // Benchmark: recordFailure
 static void BM_CircuitBreaker_RecordFailure(benchmark::State& state) {
   for (auto _ : state) {
+    (void)_;
     state.PauseTiming();
     auto cb = CircuitBreaker("test", 100, std::chrono::seconds(10),
                              std::chrono::seconds(5));
@@ -165,6 +174,7 @@ static void BM_CircuitBreaker_StateTransition(benchmark::State& state) {
   int32_t failure_threshold = static_cast<int32_t>(state.range(0));
 
   for (auto _ : state) {
+    (void)_;
     auto cb = CircuitBreaker("test", failure_threshold,
                              std::chrono::seconds(10), std::chrono::seconds(5));
 
@@ -188,6 +198,7 @@ static void BM_CircuitBreaker_GetState(benchmark::State& state) {
                            std::chrono::seconds(5));
 
   for (auto _ : state) {
+    (void)_;
     auto state_val = cb.getState();
     benchmark::DoNotOptimize(state_val);
   }
@@ -202,6 +213,7 @@ static void BM_CircuitBreaker_Concurrent(benchmark::State& state) {
                            std::chrono::seconds(5));
 
   for (auto _ : state) {
+    (void)_;
     if (cb.allowRequest()) {
       // Simulate success
       cb.recordSuccess();
@@ -219,6 +231,7 @@ BENCHMARK(BM_CircuitBreaker_Concurrent)->ThreadRange(1, 8);
 // Benchmark: Heartbeat monitor creation
 static void BM_HeartbeatMonitor_Creation(benchmark::State& state) {
   for (auto _ : state) {
+    (void)_;
     auto monitor = HeartbeatMonitor(std::chrono::milliseconds(1000));
     benchmark::DoNotOptimize(monitor);
   }
@@ -231,6 +244,7 @@ static void BM_HeartbeatMonitor_RegisterAgent(benchmark::State& state) {
 
   size_t count = 0;
   for (auto _ : state) {
+    (void)_;
     monitor.registerAgent("agent-" + std::to_string(count++));
   }
 
@@ -244,6 +258,7 @@ static void BM_HeartbeatMonitor_RecordHeartbeat(benchmark::State& state) {
   monitor.registerAgent("test-agent");
 
   for (auto _ : state) {
+    (void)_;
     monitor.recordHeartbeat("test-agent");
   }
 
@@ -258,6 +273,7 @@ static void BM_HeartbeatMonitor_IsAgentAlive(benchmark::State& state) {
   monitor.recordHeartbeat("test-agent");
 
   for (auto _ : state) {
+    (void)_;
     bool alive = monitor.isAgentAlive("test-agent");
     benchmark::DoNotOptimize(alive);
   }
@@ -280,6 +296,7 @@ static void BM_HeartbeatMonitor_GetDeadAgents(benchmark::State& state) {
   std::this_thread::sleep_for(std::chrono::milliseconds(150));
 
   for (auto _ : state) {
+    (void)_;
     auto dead = monitor.getDeadAgents();
     benchmark::DoNotOptimize(dead);
   }
@@ -303,6 +320,7 @@ static void BM_HeartbeatMonitor_ConcurrentHeartbeat(benchmark::State& state) {
   std::string agent_id = "agent-" + std::to_string(agent_idx);
 
   for (auto _ : state) {
+    (void)_;
     monitor.recordHeartbeat(agent_id);
   }
 

--- a/benchmarks/scheduler_backoff_benchmark.cpp
+++ b/benchmarks/scheduler_backoff_benchmark.cpp
@@ -31,6 +31,7 @@ static void BM_IdleCPU_WithBackoff(benchmark::State& state) {
   std::this_thread::sleep_for(100ms);
 
   for (auto _ : state) {
+    (void)_;
     // Measure CPU usage over 100ms of idle time
     auto start = std::chrono::steady_clock::now();
     std::this_thread::sleep_for(100ms);
@@ -61,6 +62,7 @@ static void BM_LatencyUnderLoad(benchmark::State& state) {
   auto task_count = std::make_shared<std::atomic<int32_t>>(0);
 
   for (auto _ : state) {
+    (void)_;
     auto submit_time = std::chrono::steady_clock::now();
 
     scheduler.submit([submit_time, total_latency_ns, task_count]() {
@@ -98,6 +100,7 @@ static void BM_ThroughputWithBackoff(benchmark::State& state) {
   auto counter = std::make_shared<std::atomic<int64_t>>(0);
 
   for (auto _ : state) {
+    (void)_;
     scheduler.submit([counter]() { counter->fetch_add(1); });
   }
 
@@ -118,6 +121,7 @@ static void BM_WakeUpLatency(benchmark::State& state) {
   scheduler.start();
 
   for (auto _ : state) {
+    (void)_;
     // Let workers enter SLEEP phase
     std::this_thread::sleep_for(50ms);
 
@@ -156,6 +160,8 @@ static void BM_WorkStealingDuringBackoff(benchmark::State& state) {
   auto counter = std::make_shared<std::atomic<int32_t>>(0);
 
   for (auto _ : state) {
+    (void)_;
+    (void)_;
     // Submit all work to worker 0 (others will steal)
     for (int32_t i = 0; i < 100; ++i) {
       scheduler.submitTo(0, [counter]() {
@@ -180,6 +186,7 @@ static void BM_RapidSubmitExecute(benchmark::State& state) {
   scheduler.start();
 
   for (auto _ : state) {
+    (void)_;
     auto work_done = std::make_shared<std::atomic<bool>>(false);
 
     scheduler.submit([work_done]() { work_done->store(true); });
@@ -211,6 +218,7 @@ static void BM_BackoffPhaseLatencies(benchmark::State& state) {
   }
 
   for (auto _ : state) {
+    (void)_;
     // Wait to enter target phase
     std::this_thread::sleep_for(wait_time);
 

--- a/benchmarks/string_allocation_profiling.cpp
+++ b/benchmarks/string_allocation_profiling.cpp
@@ -30,6 +30,8 @@ using namespace keystone::core;
  */
 static void BM_MessageCreation_Baseline(benchmark::State& state) {
   for (auto _ : state) {
+    (void)_;
+    (void)_;
     auto msg = KeystoneMessage::create("sender-agent-001", "receiver-agent-002",
                                        "EXECUTE");
     benchmark::DoNotOptimize(msg);
@@ -49,6 +51,7 @@ static void BM_MessageCreation_VariableIDLength(benchmark::State& state) {
   std::string receiver(id_length, 'b');
 
   for (auto _ : state) {
+    (void)_;
     auto msg = KeystoneMessage::create(sender, receiver, "EXECUTE");
     benchmark::DoNotOptimize(msg);
   }
@@ -71,6 +74,7 @@ static void BM_MessageCreation_WithPayload(benchmark::State& state) {
   std::string payload_data(payload_size, 'x');
 
   for (auto _ : state) {
+    (void)_;
     auto msg =
         KeystoneMessage::create("sender", "receiver", "EXECUTE", payload_data);
     benchmark::DoNotOptimize(msg);
@@ -95,6 +99,7 @@ static void BM_HighFrequency_MessageCreation(benchmark::State& state) {
   const int32_t burst_size = static_cast<int32_t>(state.range(0));
 
   for (auto _ : state) {
+    (void)_;
     std::vector<KeystoneMessage> messages;
     messages.reserve(static_cast<size_t>(burst_size));
 
@@ -125,6 +130,7 @@ static void BM_MessageCopy_Overhead(benchmark::State& state) {
   original.payload = "test payload data";
 
   for (auto _ : state) {
+    (void)_;
     // Copy constructor - copies all strings
     KeystoneMessage copy = original;
     benchmark::DoNotOptimize(copy);
@@ -141,6 +147,7 @@ BENCHMARK(BM_MessageCopy_Overhead);
  */
 static void BM_MessageMove_Overhead(benchmark::State& state) {
   for (auto _ : state) {
+    (void)_;
     auto msg = KeystoneMessage::create("sender", "receiver", "EXECUTE");
     msg.payload = "test payload data";
 
@@ -167,6 +174,7 @@ static void BM_StringInterning_Simulation(benchmark::State& state) {
   pool.insert("EXECUTE");
 
   for (auto _ : state) {
+    (void)_;
     // Find interned strings (no allocation if exists)
     auto sender_it = pool.find("sender-agent");
     auto receiver_it = pool.find("receiver-agent");
@@ -202,6 +210,7 @@ static void BM_IntegerIDs_Simulation(benchmark::State& state) {
   AgentId receiver = 2002;
 
   for (auto _ : state) {
+    (void)_;
     // Integer operations - no allocation
     AgentId s = sender;
     AgentId r = receiver;
@@ -219,7 +228,9 @@ BENCHMARK(BM_IntegerIDs_Simulation);
  * Concurrent message creation (multi-threaded allocation pressure)
  */
 static void BM_Concurrent_MessageCreation(benchmark::State& state) {
+  (void)_;
   for (auto _ : state) {
+    (void)_;
     auto msg = KeystoneMessage::create(
         "sender-" + std::to_string(state.thread_index()),
         "receiver-" + std::to_string(state.thread_index()), "EXECUTE");
@@ -243,6 +254,8 @@ static void BM_Memory_Pressure(benchmark::State& state) {
   const int32_t message_count = static_cast<int32_t>(state.range(0));
 
   for (auto _ : state) {
+    (void)_;
+    (void)_;
     std::vector<KeystoneMessage> messages;
     messages.reserve(static_cast<size_t>(message_count));
 

--- a/benchmarks/string_allocation_profiling.cpp
+++ b/benchmarks/string_allocation_profiling.cpp
@@ -228,7 +228,6 @@ BENCHMARK(BM_IntegerIDs_Simulation);
  * Concurrent message creation (multi-threaded allocation pressure)
  */
 static void BM_Concurrent_MessageCreation(benchmark::State& state) {
-  (void)_;
   for (auto _ : state) {
     (void)_;
     auto msg = KeystoneMessage::create(

--- a/include/transport/nats_connection.hpp
+++ b/include/transport/nats_connection.hpp
@@ -192,7 +192,7 @@ using ClosedCallback = std::function<void()>;
  */
 class NatsConnection {
  public:
-  explicit NatsConnection(NatsConfig config = {});
+  explicit NatsConnection(const NatsConfig& config = {});
   ~NatsConnection();
 
   // Non-copyable, non-movable (owns raw nats.c handle)

--- a/src/transport/nats_connection.cpp
+++ b/src/transport/nats_connection.cpp
@@ -135,8 +135,8 @@ void NatsTlsConfig::validate() const {
 // Construction / destruction
 // ---------------------------------------------------------------------------
 
-NatsConnection::NatsConnection(NatsConfig config)
-    : config_(std::move(config)) {}
+NatsConnection::NatsConnection(const NatsConfig& config)
+    : config_(config) {}
 
 NatsConnection::~NatsConnection() { disconnect(); }
 

--- a/src/transport/nats_connection.cpp
+++ b/src/transport/nats_connection.cpp
@@ -135,8 +135,7 @@ void NatsTlsConfig::validate() const {
 // Construction / destruction
 // ---------------------------------------------------------------------------
 
-NatsConnection::NatsConnection(const NatsConfig& config)
-    : config_(config) {}
+NatsConnection::NatsConnection(const NatsConfig& config) : config_(config) {}
 
 NatsConnection::~NatsConnection() { disconnect(); }
 


### PR DESCRIPTION
Keystone CodeQL sweep:

- **cpp/unused-local-variable** (x~40): `(void)_;` for the google-benchmark `for (auto _ : state)` idiom across 5 benchmark files.
- **cpp/large-parameter**: `NatsConnection` ctor now takes `const NatsConfig&` instead of by value (NatsConfig is 176 B).

Remaining Keystone alerts are false positives/stale (vendored build/** nats.c, BENCHMARK macro registration, `with open()` py/file-not-closed) — no code change.