### PR TITLE
fix(cve): pin ubuntu base digest + apt upgrade; restore trivy container scan

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -783,6 +783,78 @@ jobs:
       - name: security-dependency-scan (in container)
         run: bash scripts/run_ci_local.sh security-dependency-scan
 
+      # Container image scan (Trivy). Builds the production stage and scans
+      # the OS layer for package CVEs, uploading SARIF so findings surface in
+      # the Security tab (category trivy-container). This is the scan that
+      # produced the historical library/projectkeystone OsPackageVulnerability
+      # alerts; the base digest pin + apt-get upgrade in Containerfile keep
+      # the OS layer patched, and this step keeps the alerts fresh. The SARIF
+      # upload carries ALL severities so MEDIUM/LOW findings stay honestly
+      # reported (auto-closing only once actually fixed), while the summary
+      # gate fails fast on CRITICAL/HIGH per Bucket F (no continue-on-error).
+      - name: Build production image for scan (podman)
+        run: podman build --target production -t keystone:scan .
+
+      - name: Save scan image to OCI tar
+        run: podman save -o container-scan.tar keystone:scan
+
+      - name: Run Trivy container scan (SARIF, all severities)
+        run: |
+          podman run --rm \
+            -v "$PWD:/workspace:Z" -w /workspace \
+            aquasec/trivy:0.58.1 image \
+              --severity CRITICAL,HIGH,MEDIUM,LOW \
+              --no-progress \
+              --format sarif \
+              --output container-scan.sarif \
+              --scanners vuln \
+              --input container-scan.tar
+
+      - name: Run Trivy container scan (JSON summary)
+        run: |
+          podman run --rm \
+            -v "$PWD:/workspace:Z" -w /workspace \
+            aquasec/trivy:0.58.1 image \
+              --severity CRITICAL,HIGH,MEDIUM,LOW \
+              --no-progress \
+              --format json \
+              --output container-scan.json \
+              --scanners vuln \
+              --input container-scan.tar
+
+      - name: Container scan summary
+        if: always()
+        run: |
+          python3 - <<'PYEOF'
+          import json, pathlib
+
+          p = pathlib.Path("container-scan.json")
+          if not p.is_file():
+              print("container-scan.json missing — scan did not run")
+              raise SystemExit(0)
+          data = json.loads(p.read_text())
+          counts = {}
+          for res in data.get("Results", []):
+              for v in res.get("Vulnerabilities", []):
+                  sev = v.get("Severity", "UNKNOWN")
+                  counts[sev] = counts.get(sev, 0) + 1
+          print("## Container scan")
+          print("| Severity | Count |")
+          print("|----------|-------|")
+          for sev in ("CRITICAL", "HIGH", "MEDIUM", "LOW"):
+              print(f"| {sev} | {counts.get(sev, 0)} |")
+          if counts.get("CRITICAL", 0) or counts.get("HIGH", 0):
+              print("::error::Critical/high vulnerabilities in container image")
+              raise SystemExit(1)
+          PYEOF
+
+      - name: Upload Trivy container SARIF to Security tab
+        if: always() && hashFiles('container-scan.sarif') != ''
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3  # v3
+        with:
+          sarif_file: container-scan.sarif
+          category: trivy-container
+
   security-secrets-scan:
     name: security/secrets-scan
     runs-on: ubuntu-24.04

--- a/Containerfile
+++ b/Containerfile
@@ -11,7 +11,12 @@
 FROM ghcr.io/astral-sh/uv:0.12.2@sha256:069a51314a7bb6031777a9273205fe1b0b19e914ef418207d1338b268df641dd AS uv
 
 # Stage 1: Build environment
-FROM ubuntu:24.04 AS builder
+# Base digest pinned 2026-08-16 (noble): carries security patches for glibc
+# (2.39-0ubuntu8.8), libcap2 (2.66-5ubuntu2.4), tar, expat, dpkg, python3.12,
+# libgcrypt20 (CVE-2026-4046/4437/4438, CVE-2026-4878, CVE-2025-45582/66382,
+# CVE-2026-2219, CVE-2025-13462, CVE-2024-2236). Bump the digest regularly
+# (see `docker buildx imagetools inspect ubuntu:24.04`).
+FROM ubuntu:24.04@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467 AS builder
 
 # Build arguments for user permissions (host UID/GID compatibility)
 ARG BUILD_UID=1000
@@ -32,7 +37,10 @@ ENV DEBIAN_FRONTEND=noninteractive
 # OpenSSL headers, lcov, and git come from apt; the CMake/Ninja/Conan/gcovr
 # build toolchain is uv-managed as locked PyPI wheels (Odysseus ADR-018), not
 # apt/pip. build-essential is retained for the system linker/headers.
-RUN apt-get update && apt-get install -y \
+# `apt-get upgrade` first applies the remaining noble security updates on top
+# of the pinned base digest (e.g. libssl3t64, libsystemd0/libudev1) so the
+# image ships the latest patched OS layer.
+RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     build-essential \
     clang-18 \
     clang++-18 \
@@ -120,10 +128,10 @@ RUN cmake -S . -B build/release -G Ninja \
     && cmake --build build/release
 
 # Stage 2: Test runner (runs the built test suites)
-FROM ubuntu:24.04 AS test
+FROM ubuntu:24.04@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467 AS test
 
 # Install only runtime dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     libstdc++6 \
     && rm -rf /var/lib/apt/lists/*
 
@@ -146,11 +154,11 @@ CMD ["sh", "-c", "transport_unit_tests && bridge_unit_tests && concurrency_unit_
 # Stage 3: Production environment (Kubernetes deployment)
 # Ships the Keystone daemon service binary — NOT test executables.
 # See issue #513: the previous version incorrectly packaged test binaries here.
-FROM ubuntu:24.04 AS production
+FROM ubuntu:24.04@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467 AS production
 
 # Install runtime dependencies. wget is used for the healthcheck so that
 # Python3 (a dev tool) is not required in the production image.
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     libstdc++6 \
     wget \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Triage + fix for the 25 open Trivy OsPackageVulnerability alerts (path library/projectkeystone) and the base-image hardening to clear them.

## Root cause

The alerts are stale: they came from the last Trivy **container-image** scan (category trivy-container), which was dropped during the podman migration. The current security/dependency-scan job only runs pip-audit, so no fresh scan re-reports the OS-layer state — the April 2026 instances never updated.

Of the 25 alerts, 14 are fixable by rebuilding on today's ubuntu:24.04 (glibc 2.39-0ubuntu8.8, libcap2 2.66-5ubuntu2.4, tar, expat, dpkg, python3.12, libgcrypt20 all carry patches). The remaining 11 (util-linux CVE-2026-27456 x7, shadow CVE-2024-56433 x2, plus zlib/systemd variants) have **no upstream fix yet** (Ubuntu candidate == installed) and stay reported until Canonical ships them.

## What this PR does

- **Containerfile**: pin ubuntu:24.04 to the 2026-08-16 noble digest in the builder/test/production stages (reproducible, patched OS layer) and run `apt-get upgrade` before install so the remaining noble security updates (libssl3t64, libsystemd0/libudev1) land at build time.
- **_required.yml security/dependency-scan**: restore the Trivy container-image scan that was lost in the podman migration — build the production stage with podman, save an OCI tar, scan all severities (SARIF upload under category trivy-container so MEDIUM/LOW stay honestly reported), and gate CI on CRITICAL/HIGH (fail-fast per Bucket F, no continue-on-error).

## Verified locally

- Fresh base + apt upgrade: **0 CRITICAL/HIGH**, 12 MEDIUM + 6 LOW (util-linux/shadow/zlib/systemd — no upstream fix yet).
- The exact podman save + trivy --input scan flow the workflow runs was exercised against the base image; SARIF parses and the summary gate works.
