### PR TITLE
fix(codeql): clear last live C++ finding (empty-if) + dismiss 99 stale

### DIFF
--- a/tests/unit/test_agent_id_interning.cpp
+++ b/tests/unit/test_agent_id_interning.cpp
@@ -122,10 +122,11 @@ TEST(AgentIdInterningTest, ThreadSafety) {
           successes++;
         }
 
-        // Verify forward lookup
+        // Verify forward lookup (decrement on mismatch so the final
+        // EXPECT_EQ(successes, total) still catches a broken forward lookup)
         auto id_result = interning.tryGetId(agent_id);
-        if (id_result && *id_result == int_id) {
-          // Success (expected)
+        if (!(id_result && *id_result == int_id)) {
+          successes--;
         }
       }
     });


### PR DESCRIPTION
Fixes the last live C++ CodeQL finding in Keystone: cpp/empty-if in tests/unit/test_agent_id_interning.cpp (forward-lookup branch had an empty then-body). The forward lookup now decrements the success counter on mismatch, preserving the existing EXPECT_EQ(successes, total) assertion semantics.

Companion cleanup: the 99 remaining open alerts (98 cpp/unused-* + 1 cpp/large-parameter) are stale pre-2026-08-08 instances — verified absent from current main source (fixed by #652 or later refactors; the NatsConnection constructor is already const-ref). They are dismissed with evidence; no C++ CodeQL analysis has run since 2026-08-08, so they cannot auto-close.
