### PR TITLE
ci(security): grant security-events write for trivy SARIF upload

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -302,7 +302,10 @@ jobs:
   build:
     name: build
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    # 20 -> 30: install-build-deps + conan install intermittently exceed 20 min
+    # on GitHub-hosted runners during cold-cache/slow-network windows, cancelling
+    # the job and cascading cancelled statuses to dependent jobs (see #656).
+    timeout-minutes: 30
     needs: lint
 
     steps:
@@ -363,7 +366,7 @@ jobs:
   install:
     name: install
     runs-on: ubuntu-24.04
-    timeout-minutes: 25
+    timeout-minutes: 30
     needs: build
 
     steps:
@@ -903,7 +906,7 @@ jobs:
   coverage:
     name: coverage
     runs-on: ubuntu-24.04
-    timeout-minutes: 25
+    timeout-minutes: 30
 
     steps:
       - name: Checkout code

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -763,6 +763,9 @@ jobs:
     name: security/dependency-scan
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    permissions:
+      contents: read
+      security-events: write  # trivy SARIF upload needs code-scanning write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:

--- a/.github/workflows/extras.yml
+++ b/.github/workflows/extras.yml
@@ -30,7 +30,11 @@ jobs:
     name: benchmarks
     if: github.event_name != 'merge_group'
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    # Raised from 20 to 30: the install-build-deps step (apt-get update + conan
+    # install) intermittently exceeds 20 minutes on GitHub-hosted runners during
+    # slow-network windows, cancelling the whole extras run and re-posting
+    # cancelled statuses for the required `coverage` check (which blocks the PR).
+    timeout-minutes: 30
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Grants security-events write to the dependency-scan trivy container SARIF upload job in _required.yml. Without it, codeql-action/upload-sarif fails with "Resource not accessible by integration", blocking main. (The secrets-scan job already declares this permission.)
