### PR TITLE
fix(codeql): restore C++ analysis + de-static Google Benchmark functions

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -990,3 +990,71 @@ jobs:
           fail_ci_if_error: false
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  # ============================================================
+  # 22. analyze  (restored CodeQL, see commit 79e8e0e)
+  #    The consolidation deleted codeql-analysis.yml but never added the
+  #    Analyze job to this file, so C++ had no CodeQL coverage and the
+  #    cpp/unused-* alerts from the old workflow could never auto-close.
+  #    Restored from the deleted workflow (c-cpp manual build + python).
+  # ============================================================
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: c-cpp
+            build-mode: manual
+          - language: python
+            build-mode: none
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3  # v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-and-quality
+          config-file: ./.github/codeql/codeql-config.yml
+
+      # C++ manual build steps -- only run for c-cpp
+      - name: Install build dependencies
+        if: matrix.language == 'c-cpp'
+        uses: ./.github/actions/install-build-deps
+        with:
+          cache-conan: "true"
+
+      - name: Cache FetchContent downloads
+        if: matrix.language == 'c-cpp'
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: build/codeql/_deps
+          key: fetchcontent-codeql-${{ runner.os }}-${{ hashFiles('CMakeLists.txt') }}
+          restore-keys: |
+            fetchcontent-codeql-${{ runner.os }}-
+
+      - name: Install Conan dependencies
+        if: matrix.language == 'c-cpp'
+        run: conan install . --output-folder=build/codeql/conan-deps --build=missing -s build_type=Release -s compiler.cppstd=20
+
+      - name: Build for CodeQL analysis
+        if: matrix.language == 'c-cpp'
+        run: |
+          cmake -S . -B build/codeql -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=build/codeql/conan-deps/conan_toolchain.cmake
+          cmake --build build/codeql
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3  # v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/benchmarks/distributed_work_stealing.cpp
+++ b/benchmarks/distributed_work_stealing.cpp
@@ -12,7 +12,7 @@ using namespace keystone::simulation;
 using namespace std::chrono_literals;
 
 // Benchmark: Local-only work stealing (single node baseline)
-static void BM_WorkStealing_LocalOnly(benchmark::State& state) {
+void BM_WorkStealing_LocalOnly(benchmark::State& state) {
   const size_t num_tasks = state.range(0);
 
   for (auto _ : state) {
@@ -50,7 +50,7 @@ static void BM_WorkStealing_LocalOnly(benchmark::State& state) {
 BENCHMARK(BM_WorkStealing_LocalOnly)->Arg(100)->Arg(500)->Arg(1000);
 
 // Benchmark: Two nodes with 100µs network latency
-static void BM_WorkStealing_TwoNodes_100us(benchmark::State& state) {
+void BM_WorkStealing_TwoNodes_100us(benchmark::State& state) {
   const size_t num_tasks = state.range(0);
 
   for (auto _ : state) {
@@ -90,7 +90,7 @@ static void BM_WorkStealing_TwoNodes_100us(benchmark::State& state) {
 BENCHMARK(BM_WorkStealing_TwoNodes_100us)->Arg(100)->Arg(500)->Arg(1000);
 
 // Benchmark: Two nodes with 500µs network latency
-static void BM_WorkStealing_TwoNodes_500us(benchmark::State& state) {
+void BM_WorkStealing_TwoNodes_500us(benchmark::State& state) {
   const size_t num_tasks = state.range(0);
 
   for (auto _ : state) {
@@ -128,7 +128,7 @@ static void BM_WorkStealing_TwoNodes_500us(benchmark::State& state) {
 BENCHMARK(BM_WorkStealing_TwoNodes_500us)->Arg(100)->Arg(500)->Arg(1000);
 
 // Benchmark: Two nodes with 1ms network latency
-static void BM_WorkStealing_TwoNodes_1ms(benchmark::State& state) {
+void BM_WorkStealing_TwoNodes_1ms(benchmark::State& state) {
   const size_t num_tasks = state.range(0);
 
   for (auto _ : state) {
@@ -165,7 +165,7 @@ static void BM_WorkStealing_TwoNodes_1ms(benchmark::State& state) {
 BENCHMARK(BM_WorkStealing_TwoNodes_1ms)->Arg(100)->Arg(500)->Arg(1000);
 
 // Benchmark: Load balancing effectiveness (imbalanced submission)
-static void BM_LoadBalancing_Imbalanced(benchmark::State& state) {
+void BM_LoadBalancing_Imbalanced(benchmark::State& state) {
   const size_t num_tasks = state.range(0);
 
   for (auto _ : state) {
@@ -216,7 +216,7 @@ static void BM_LoadBalancing_Imbalanced(benchmark::State& state) {
 BENCHMARK(BM_LoadBalancing_Imbalanced)->Arg(100)->Arg(500)->Arg(1000);
 
 // Benchmark: Network overhead measurement (message-only)
-static void BM_NetworkOverhead_MessageOnly(benchmark::State& state) {
+void BM_NetworkOverhead_MessageOnly(benchmark::State& state) {
   const size_t num_messages = state.range(0);
 
   for (auto _ : state) {
@@ -260,7 +260,7 @@ static void BM_NetworkOverhead_MessageOnly(benchmark::State& state) {
 BENCHMARK(BM_NetworkOverhead_MessageOnly)->Arg(50)->Arg(100)->Arg(200);
 
 // Benchmark: Agent affinity (registered agents)
-static void BM_AgentAffinity_Registered(benchmark::State& state) {
+void BM_AgentAffinity_Registered(benchmark::State& state) {
   const size_t num_tasks = state.range(0);
 
   for (auto _ : state) {
@@ -303,7 +303,7 @@ static void BM_AgentAffinity_Registered(benchmark::State& state) {
 BENCHMARK(BM_AgentAffinity_Registered)->Arg(100)->Arg(500)->Arg(1000);
 
 // Benchmark: Packet loss impact
-static void BM_PacketLoss_Impact(benchmark::State& state) {
+void BM_PacketLoss_Impact(benchmark::State& state) {
   const double packet_loss = static_cast<double>(state.range(0)) / 100.0;
   const size_t num_messages = 100;
 

--- a/benchmarks/message_pool_performance.cpp
+++ b/benchmarks/message_pool_performance.cpp
@@ -22,7 +22,7 @@ using namespace keystone::core;
 /**
  * Baseline: Create and destroy messages without pooling
  */
-static void BM_MessageCreation_NoPooing(benchmark::State& state) {
+void BM_MessageCreation_NoPooing(benchmark::State& state) {
   for (auto _ : state) {
     (void)_;
     auto msg = KeystoneMessage::create("sender", "receiver", "test_command");
@@ -38,7 +38,7 @@ BENCHMARK(BM_MessageCreation_NoPooing);
 /**
  * With pooling: Acquire and release messages
  */
-static void BM_MessageCreation_WithPooling(benchmark::State& state) {
+void BM_MessageCreation_WithPooling(benchmark::State& state) {
   // Warmup pool
   for (int32_t i = 0; i < 100; ++i) {
     auto msg = MessagePool::acquire();
@@ -64,7 +64,7 @@ BENCHMARK(BM_MessageCreation_WithPooling);
 /**
  * Burst pattern: Create many messages then destroy them (no pooling)
  */
-static void BM_MessageBurst_NoPooling(benchmark::State& state) {
+void BM_MessageBurst_NoPooling(benchmark::State& state) {
   const int32_t burst_size = static_cast<int32_t>(state.range(0));
 
   for (auto _ : state) {
@@ -88,7 +88,7 @@ BENCHMARK(BM_MessageBurst_NoPooling)->Arg(10)->Arg(100)->Arg(1000);
 /**
  * Burst pattern: Acquire many messages then release them (with pooling)
  */
-static void BM_MessageBurst_WithPooling(benchmark::State& state) {
+void BM_MessageBurst_WithPooling(benchmark::State& state) {
   const int32_t burst_size = static_cast<int32_t>(state.range(0));
 
   // Warmup pool
@@ -120,7 +120,7 @@ BENCHMARK(BM_MessageBurst_WithPooling)->Arg(10)->Arg(100)->Arg(1000);
 /**
  * Steady-state: Continuous acquire/release (simulates message passing)
  */
-static void BM_SteadyState_NoPooling(benchmark::State& state) {
+void BM_SteadyState_NoPooling(benchmark::State& state) {
   for (auto _ : state) {
     (void)_;
     auto msg = KeystoneMessage::create("sender", "receiver", "cmd");
@@ -135,7 +135,7 @@ BENCHMARK(BM_SteadyState_NoPooling);
 /**
  * Steady-state: Continuous acquire/release with pool (optimal case)
  */
-static void BM_SteadyState_WithPooling(benchmark::State& state) {
+void BM_SteadyState_WithPooling(benchmark::State& state) {
   // Warmup
   for (int32_t i = 0; i < 10; ++i) {
     auto msg = MessagePool::acquire();
@@ -159,7 +159,7 @@ BENCHMARK(BM_SteadyState_WithPooling);
 /**
  * Pool statistics overhead
  */
-static void BM_PoolStatistics(benchmark::State& state) {
+void BM_PoolStatistics(benchmark::State& state) {
   // Warmup
   for (int32_t i = 0; i < 100; ++i) {
     auto msg = MessagePool::acquire();
@@ -178,7 +178,7 @@ BENCHMARK(BM_PoolStatistics);
 /**
  * Pool hit rate under load
  */
-static void BM_PoolHitRate(benchmark::State& state) {
+void BM_PoolHitRate(benchmark::State& state) {
   MessagePool::clear();
   MessagePool::resetStats();
 
@@ -210,7 +210,7 @@ BENCHMARK(BM_PoolHitRate);
 /**
  * Multi-threaded pooling (thread-local isolation)
  */
-static void BM_ThreadLocalPooling(benchmark::State& state) {
+void BM_ThreadLocalPooling(benchmark::State& state) {
   // Each thread gets its own pool
   if (state.thread_index() == 0) {
     MessagePool::clear();
@@ -245,7 +245,7 @@ BENCHMARK(BM_ThreadLocalPooling)->Threads(1)->Threads(2)->Threads(4);
 /**
  * Message field reset overhead
  */
-static void BM_MessageReset(benchmark::State& state) {
+void BM_MessageReset(benchmark::State& state) {
   for (auto _ : state) {
     (void)_;
     KeystoneMessage msg;

--- a/benchmarks/resilience_performance.cpp
+++ b/benchmarks/resilience_performance.cpp
@@ -26,7 +26,7 @@ using namespace keystone::core;
 // ==========================
 
 // Benchmark: Retry policy creation
-static void BM_RetryPolicy_Creation(benchmark::State& state) {
+void BM_RetryPolicy_Creation(benchmark::State& state) {
   for (auto _ : state) {
     (void)_;
     auto policy = RetryPolicy(5, std::chrono::milliseconds(100), 2.0,
@@ -37,7 +37,7 @@ static void BM_RetryPolicy_Creation(benchmark::State& state) {
 BENCHMARK(BM_RetryPolicy_Creation);
 
 // Benchmark: shouldRetry check
-static void BM_RetryPolicy_ShouldRetry(benchmark::State& state) {
+void BM_RetryPolicy_ShouldRetry(benchmark::State& state) {
   auto policy = RetryPolicy(100, std::chrono::milliseconds(100), 2.0,
                             std::chrono::seconds(30));
 
@@ -54,7 +54,7 @@ static void BM_RetryPolicy_ShouldRetry(benchmark::State& state) {
 BENCHMARK(BM_RetryPolicy_ShouldRetry);
 
 // Benchmark: Backoff delay calculation
-static void BM_RetryPolicy_BackoffCalculation(benchmark::State& state) {
+void BM_RetryPolicy_BackoffCalculation(benchmark::State& state) {
   auto policy = RetryPolicy(100, std::chrono::milliseconds(100), 2.0,
                             std::chrono::seconds(30));
 
@@ -71,7 +71,7 @@ static void BM_RetryPolicy_BackoffCalculation(benchmark::State& state) {
 BENCHMARK(BM_RetryPolicy_BackoffCalculation);
 
 // Benchmark: Exponential backoff sequence
-static void BM_RetryPolicy_FullSequence(benchmark::State& state) {
+void BM_RetryPolicy_FullSequence(benchmark::State& state) {
   int32_t max_retries = static_cast<int32_t>(state.range(0));
 
   for (auto _ : state) {
@@ -91,7 +91,7 @@ static void BM_RetryPolicy_FullSequence(benchmark::State& state) {
 BENCHMARK(BM_RetryPolicy_FullSequence)->Range(1, 64);
 
 // Benchmark: Retry policy with varying multipliers
-static void BM_RetryPolicy_VaryingMultiplier(benchmark::State& state) {
+void BM_RetryPolicy_VaryingMultiplier(benchmark::State& state) {
   double multiplier = state.range(0) / 10.0;  // 1.0 to 5.0
 
   auto policy = RetryPolicy(20, std::chrono::milliseconds(100), multiplier,
@@ -114,7 +114,7 @@ BENCHMARK(BM_RetryPolicy_VaryingMultiplier)->DenseRange(10, 50, 10);
 // ==========================
 
 // Benchmark: Circuit breaker creation
-static void BM_CircuitBreaker_Creation(benchmark::State& state) {
+void BM_CircuitBreaker_Creation(benchmark::State& state) {
   for (auto _ : state) {
     (void)_;
     auto cb = CircuitBreaker("test", 5, std::chrono::seconds(10),
@@ -125,7 +125,7 @@ static void BM_CircuitBreaker_Creation(benchmark::State& state) {
 BENCHMARK(BM_CircuitBreaker_Creation);
 
 // Benchmark: allowRequest check (closed state)
-static void BM_CircuitBreaker_AllowRequest_Closed(benchmark::State& state) {
+void BM_CircuitBreaker_AllowRequest_Closed(benchmark::State& state) {
   auto cb = CircuitBreaker("test", 5, std::chrono::seconds(10),
                            std::chrono::seconds(5));
 
@@ -140,7 +140,7 @@ static void BM_CircuitBreaker_AllowRequest_Closed(benchmark::State& state) {
 BENCHMARK(BM_CircuitBreaker_AllowRequest_Closed);
 
 // Benchmark: recordSuccess
-static void BM_CircuitBreaker_RecordSuccess(benchmark::State& state) {
+void BM_CircuitBreaker_RecordSuccess(benchmark::State& state) {
   auto cb = CircuitBreaker("test", 5, std::chrono::seconds(10),
                            std::chrono::seconds(5));
 
@@ -154,7 +154,7 @@ static void BM_CircuitBreaker_RecordSuccess(benchmark::State& state) {
 BENCHMARK(BM_CircuitBreaker_RecordSuccess);
 
 // Benchmark: recordFailure
-static void BM_CircuitBreaker_RecordFailure(benchmark::State& state) {
+void BM_CircuitBreaker_RecordFailure(benchmark::State& state) {
   for (auto _ : state) {
     (void)_;
     state.PauseTiming();
@@ -170,7 +170,7 @@ static void BM_CircuitBreaker_RecordFailure(benchmark::State& state) {
 BENCHMARK(BM_CircuitBreaker_RecordFailure);
 
 // Benchmark: State transition (closed -> open)
-static void BM_CircuitBreaker_StateTransition(benchmark::State& state) {
+void BM_CircuitBreaker_StateTransition(benchmark::State& state) {
   int32_t failure_threshold = static_cast<int32_t>(state.range(0));
 
   for (auto _ : state) {
@@ -193,7 +193,7 @@ static void BM_CircuitBreaker_StateTransition(benchmark::State& state) {
 BENCHMARK(BM_CircuitBreaker_StateTransition)->Range(1, 128);
 
 // Benchmark: getState
-static void BM_CircuitBreaker_GetState(benchmark::State& state) {
+void BM_CircuitBreaker_GetState(benchmark::State& state) {
   auto cb = CircuitBreaker("test", 5, std::chrono::seconds(10),
                            std::chrono::seconds(5));
 
@@ -208,7 +208,7 @@ static void BM_CircuitBreaker_GetState(benchmark::State& state) {
 BENCHMARK(BM_CircuitBreaker_GetState);
 
 // Benchmark: Concurrent circuit breaker access
-static void BM_CircuitBreaker_Concurrent(benchmark::State& state) {
+void BM_CircuitBreaker_Concurrent(benchmark::State& state) {
   static CircuitBreaker cb("test", 100, std::chrono::seconds(10),
                            std::chrono::seconds(5));
 
@@ -229,7 +229,7 @@ BENCHMARK(BM_CircuitBreaker_Concurrent)->ThreadRange(1, 8);
 // ==========================
 
 // Benchmark: Heartbeat monitor creation
-static void BM_HeartbeatMonitor_Creation(benchmark::State& state) {
+void BM_HeartbeatMonitor_Creation(benchmark::State& state) {
   for (auto _ : state) {
     (void)_;
     auto monitor = HeartbeatMonitor(std::chrono::milliseconds(1000));
@@ -239,7 +239,7 @@ static void BM_HeartbeatMonitor_Creation(benchmark::State& state) {
 BENCHMARK(BM_HeartbeatMonitor_Creation);
 
 // Benchmark: registerAgent
-static void BM_HeartbeatMonitor_RegisterAgent(benchmark::State& state) {
+void BM_HeartbeatMonitor_RegisterAgent(benchmark::State& state) {
   HeartbeatMonitor monitor(std::chrono::milliseconds(1000));
 
   size_t count = 0;
@@ -253,7 +253,7 @@ static void BM_HeartbeatMonitor_RegisterAgent(benchmark::State& state) {
 BENCHMARK(BM_HeartbeatMonitor_RegisterAgent);
 
 // Benchmark: recordHeartbeat
-static void BM_HeartbeatMonitor_RecordHeartbeat(benchmark::State& state) {
+void BM_HeartbeatMonitor_RecordHeartbeat(benchmark::State& state) {
   HeartbeatMonitor monitor(std::chrono::milliseconds(1000));
   monitor.registerAgent("test-agent");
 
@@ -267,7 +267,7 @@ static void BM_HeartbeatMonitor_RecordHeartbeat(benchmark::State& state) {
 BENCHMARK(BM_HeartbeatMonitor_RecordHeartbeat);
 
 // Benchmark: isAgentAlive check
-static void BM_HeartbeatMonitor_IsAgentAlive(benchmark::State& state) {
+void BM_HeartbeatMonitor_IsAgentAlive(benchmark::State& state) {
   HeartbeatMonitor monitor(std::chrono::seconds(10));
   monitor.registerAgent("test-agent");
   monitor.recordHeartbeat("test-agent");
@@ -283,7 +283,7 @@ static void BM_HeartbeatMonitor_IsAgentAlive(benchmark::State& state) {
 BENCHMARK(BM_HeartbeatMonitor_IsAgentAlive);
 
 // Benchmark: getDeadAgents
-static void BM_HeartbeatMonitor_GetDeadAgents(benchmark::State& state) {
+void BM_HeartbeatMonitor_GetDeadAgents(benchmark::State& state) {
   int32_t num_agents = static_cast<int32_t>(state.range(0));
 
   HeartbeatMonitor monitor(std::chrono::milliseconds(100));
@@ -306,7 +306,7 @@ static void BM_HeartbeatMonitor_GetDeadAgents(benchmark::State& state) {
 BENCHMARK(BM_HeartbeatMonitor_GetDeadAgents)->Range(8, 512);
 
 // Benchmark: Concurrent heartbeat recording
-static void BM_HeartbeatMonitor_ConcurrentHeartbeat(benchmark::State& state) {
+void BM_HeartbeatMonitor_ConcurrentHeartbeat(benchmark::State& state) {
   static HeartbeatMonitor monitor(std::chrono::seconds(10));
   static std::atomic<bool> initialized{false};
 

--- a/benchmarks/scheduler_backoff_benchmark.cpp
+++ b/benchmarks/scheduler_backoff_benchmark.cpp
@@ -23,7 +23,7 @@ using namespace std::chrono_literals;
 
 // Benchmark: Idle CPU usage (no work)
 // This measures CPU consumption when scheduler has no work
-static void BM_IdleCPU_WithBackoff(benchmark::State& state) {
+void BM_IdleCPU_WithBackoff(benchmark::State& state) {
   WorkStealingScheduler scheduler(4);
   scheduler.start();
 
@@ -54,7 +54,7 @@ static void BM_IdleCPU_WithBackoff(benchmark::State& state) {
 BENCHMARK(BM_IdleCPU_WithBackoff)->UseManualTime()->Iterations(10);
 
 // Benchmark: Latency under load
-static void BM_LatencyUnderLoad(benchmark::State& state) {
+void BM_LatencyUnderLoad(benchmark::State& state) {
   WorkStealingScheduler scheduler(4);
   scheduler.start();
 
@@ -93,7 +93,7 @@ static void BM_LatencyUnderLoad(benchmark::State& state) {
 BENCHMARK(BM_LatencyUnderLoad)->Iterations(1000);
 
 // Benchmark: Throughput with backoff
-static void BM_ThroughputWithBackoff(benchmark::State& state) {
+void BM_ThroughputWithBackoff(benchmark::State& state) {
   WorkStealingScheduler scheduler(4);
   scheduler.start();
 
@@ -116,7 +116,7 @@ static void BM_ThroughputWithBackoff(benchmark::State& state) {
 BENCHMARK(BM_ThroughputWithBackoff);
 
 // Benchmark: Wake-up latency from SLEEP phase
-static void BM_WakeUpLatency(benchmark::State& state) {
+void BM_WakeUpLatency(benchmark::State& state) {
   WorkStealingScheduler scheduler(4);
   scheduler.start();
 
@@ -153,7 +153,7 @@ static void BM_WakeUpLatency(benchmark::State& state) {
 BENCHMARK(BM_WakeUpLatency)->Iterations(10);
 
 // Benchmark: Work stealing across workers during backoff
-static void BM_WorkStealingDuringBackoff(benchmark::State& state) {
+void BM_WorkStealingDuringBackoff(benchmark::State& state) {
   WorkStealingScheduler scheduler(4);
   scheduler.start();
 
@@ -181,7 +181,7 @@ static void BM_WorkStealingDuringBackoff(benchmark::State& state) {
 BENCHMARK(BM_WorkStealingDuringBackoff)->Iterations(10);
 
 // Benchmark: Rapid submit/execute cycles (stress test)
-static void BM_RapidSubmitExecute(benchmark::State& state) {
+void BM_RapidSubmitExecute(benchmark::State& state) {
   WorkStealingScheduler scheduler(4);
   scheduler.start();
 
@@ -202,7 +202,7 @@ static void BM_RapidSubmitExecute(benchmark::State& state) {
 BENCHMARK(BM_RapidSubmitExecute);
 
 // Benchmark: Compare SPIN vs YIELD vs SLEEP phase latencies
-static void BM_BackoffPhaseLatencies(benchmark::State& state) {
+void BM_BackoffPhaseLatencies(benchmark::State& state) {
   WorkStealingScheduler scheduler(1);  // Single worker for determinism
   scheduler.start();
 

--- a/benchmarks/string_allocation_profiling.cpp
+++ b/benchmarks/string_allocation_profiling.cpp
@@ -28,7 +28,7 @@ using namespace keystone::core;
  * Baseline: Message creation with string allocations
  * Allocates 4+ strings: msg_id (UUID), sender_id, receiver_id, command
  */
-static void BM_MessageCreation_Baseline(benchmark::State& state) {
+void BM_MessageCreation_Baseline(benchmark::State& state) {
   for (auto _ : state) {
     (void)_;
     (void)_;
@@ -45,7 +45,7 @@ BENCHMARK(BM_MessageCreation_Baseline);
 /**
  * Measure string allocation overhead by varying sender/receiver ID lengths
  */
-static void BM_MessageCreation_VariableIDLength(benchmark::State& state) {
+void BM_MessageCreation_VariableIDLength(benchmark::State& state) {
   int32_t id_length = static_cast<int32_t>(state.range(0));
   std::string sender(id_length, 'a');
   std::string receiver(id_length, 'b');
@@ -69,7 +69,7 @@ BENCHMARK(BM_MessageCreation_VariableIDLength)
 /**
  * Measure allocation overhead with payload strings
  */
-static void BM_MessageCreation_WithPayload(benchmark::State& state) {
+void BM_MessageCreation_WithPayload(benchmark::State& state) {
   int32_t payload_size = static_cast<int32_t>(state.range(0));
   std::string payload_data(payload_size, 'x');
 
@@ -95,7 +95,7 @@ BENCHMARK(BM_MessageCreation_WithPayload)
  * High-frequency message creation (simulates 10K msgs/sec load)
  * This measures allocation rate under realistic load
  */
-static void BM_HighFrequency_MessageCreation(benchmark::State& state) {
+void BM_HighFrequency_MessageCreation(benchmark::State& state) {
   const int32_t burst_size = static_cast<int32_t>(state.range(0));
 
   for (auto _ : state) {
@@ -125,7 +125,7 @@ BENCHMARK(BM_HighFrequency_MessageCreation)
 /**
  * Measure string copy overhead when passing messages
  */
-static void BM_MessageCopy_Overhead(benchmark::State& state) {
+void BM_MessageCopy_Overhead(benchmark::State& state) {
   auto original = KeystoneMessage::create("sender", "receiver", "EXECUTE");
   original.payload = "test payload data";
 
@@ -145,7 +145,7 @@ BENCHMARK(BM_MessageCopy_Overhead);
 /**
  * Measure string move overhead (should be cheaper than copy)
  */
-static void BM_MessageMove_Overhead(benchmark::State& state) {
+void BM_MessageMove_Overhead(benchmark::State& state) {
   for (auto _ : state) {
     (void)_;
     auto msg = KeystoneMessage::create("sender", "receiver", "EXECUTE");
@@ -166,7 +166,7 @@ BENCHMARK(BM_MessageMove_Overhead);
  * Measure allocation overhead of string interning simulation
  * (Potential optimization from issue #22)
  */
-static void BM_StringInterning_Simulation(benchmark::State& state) {
+void BM_StringInterning_Simulation(benchmark::State& state) {
   // Simulate string pool (unordered_set keeps single copy)
   static std::unordered_set<std::string> pool;
   pool.insert("sender-agent");
@@ -204,7 +204,7 @@ BENCHMARK(BM_StringInterning_Simulation);
 /**
  * Measure overhead of integer agent IDs (potential optimization)
  */
-static void BM_IntegerIDs_Simulation(benchmark::State& state) {
+void BM_IntegerIDs_Simulation(benchmark::State& state) {
   using AgentId = uint64_t;
   AgentId sender = 1001;
   AgentId receiver = 2002;
@@ -227,7 +227,7 @@ BENCHMARK(BM_IntegerIDs_Simulation);
 /**
  * Concurrent message creation (multi-threaded allocation pressure)
  */
-static void BM_Concurrent_MessageCreation(benchmark::State& state) {
+void BM_Concurrent_MessageCreation(benchmark::State& state) {
   for (auto _ : state) {
     (void)_;
     auto msg = KeystoneMessage::create(
@@ -249,7 +249,7 @@ BENCHMARK(BM_Concurrent_MessageCreation)
 /**
  * Memory pressure test: Create and hold many messages
  */
-static void BM_Memory_Pressure(benchmark::State& state) {
+void BM_Memory_Pressure(benchmark::State& state) {
   const int32_t message_count = static_cast<int32_t>(state.range(0));
 
   for (auto _ : state) {


### PR DESCRIPTION
Restores C++ CodeQL coverage (lost during the 79e8e0e workflow consolidation) and clears the 19 `cpp/unused-static-function` alerts.

## What & why

**Root cause of the 72 stale C++ alerts:** the consolidation deleted `codeql-analysis.yml` and claimed to add `Analyze (c-cpp/python)` to `_required.yml`, but the job was never added. GitHub's default-setup CodeQL only analyzes Python, so:
- C++ has had **zero** code-scanning coverage since the consolidation
- the 72 old `cpp/unused-*` alerts (53 unused-local-variable + 19 unused-static-function, from April/May) can never auto-close, even though the code was fixed (`(void)_`, `[[maybe_unused]]`)

## Changes

1. **`_required.yml`** — restored the CodeQL `analyze` job with the c-cpp manual build (uses `install-build-deps` action + conan/cmake) and python `build-mode: none`, matching the deleted workflow.
2. **Benchmarks** — de-static'd all 53 `BM_*` Google Benchmark functions across 6 files. CodeQL's `cpp/unused-static-function` treats functions registered via the `BENCHMARK()` macro as unreachable (macro static-init registration is not a call); external linkage is the standard resolution.

## After merge

The restored c-cpp analysis runs on main and auto-closes the stale alerts; the benchmark changes prevent the 34 same-pattern functions from being re-flagged.
