### PR TITLE
fix(test): make ProfilingTest.PercentileCalculation TSan-robust

### DIFF
--- a/tests/unit/test_profiling.cpp
+++ b/tests/unit/test_profiling.cpp
@@ -84,11 +84,27 @@ TEST_F(ProfilingTest, PercentileCalculation) {
   EXPECT_NEAR(stats->p50_us, 500.0, 1200.0);
 
   // P95 should be near end (950µs ± tolerance for overhead)
+  //
+  // TSan-instrumented builds (integration-tests runs test.debug.tsan) inflate
+  // the tail of the timing distribution: occasional multi-ms stalls push p95
+  // past the 950±1200µs window even though the median stays well inside it
+  // (observed p95_us ≈ 2680µs on a loaded runner, diff 1730µs). The wall-clock
+  // assertions are therefore only meaningful without a race detector; the
+  // ordering + range checks below hold under every build configuration and are
+  // what actually validate the percentile calculation.
+#if !defined(__SANITIZE_THREAD__) && \
+    (!defined(__has_feature) || !__has_feature(thread_sanitizer))
   EXPECT_NEAR(stats->p95_us, 950.0, 1200.0);
+#endif
 
   // Ordering (this should always hold regardless of overhead)
   EXPECT_LE(stats->p50_us, stats->p95_us);
   EXPECT_LE(stats->p95_us, stats->p99_us);
+
+  // Bounds (percentiles must lie within the observed sample range)
+  EXPECT_GE(stats->p50_us, stats->min_us);
+  EXPECT_LE(stats->p95_us, stats->max_us);
+  EXPECT_LE(stats->p99_us, stats->max_us);
 }
 
 TEST_F(ProfilingTest, GenerateReport) {


### PR DESCRIPTION
Fixes the main-blocking `integration-tests` failure: `ProfilingTest.PercentileCalculation` was flaky under the TSan build (`test.debug.tsan`), where occasional multi-ms stalls inflate the tail of the timing distribution (observed `p95_us` = 2680µs vs `950±1200µs` expected).

## Change

- Guard the wall-clock `EXPECT_NEAR(p95_us, 950.0, 1200.0)` assertion for race-detector builds (GCC `__SANITIZE_THREAD__` / Clang `__has_feature(thread_sanitizer)`).
- Keep the assertions that actually validate the percentile calculation in every configuration: ordering (`p50 ≤ p95 ≤ p99`) and range bounds (`min ≤ p50`, `p95`, `p99 ≤ max`).
- `p50` (the median) stays unconditional — it is outlier-robust and was passing.

Verified against the 08-18 failure log: only `p95` exceeded tolerance (diff 1730µs > 1200µs); the fix directly addresses that single flake while preserving test coverage.
