### PR TITLE
fix(tooling): make lint must not hang or mask container failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,10 @@ NPROC ?= $(shell nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
 
 # Container runtime (Podman)
 # Use podman-compose instead of docker compose CLI plugin (which delegates to snap)
-CONTAINER_CHECK := DOCKER_HOST="$(DOCKER_HOST)" podman-compose up -d dev >/dev/null 2>&1 || true;
+# Only start the dev container if it is not already running; bound the start with
+# a 60s timeout and never mask a genuine failure (fixes #636 — the old form
+# hung 10+ minutes on a wedged compose and swallowed errors with `|| true`).
+CONTAINER_CHECK := @if [ -z "$$(DOCKER_HOST="$(DOCKER_HOST)" podman-compose ps -q dev 2>/dev/null)" ]; then echo "Starting dev container (timeout 60s)..."; timeout 60 DOCKER_HOST="$(DOCKER_HOST)" podman-compose up -d dev; fi
 CONTAINER_PREFIX := DOCKER_HOST="$(DOCKER_HOST)" podman-compose exec -T dev
 
 # Sanitizer runtime options that must be set INSIDE the dev container.

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ NPROC ?= $(shell nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
 # Only start the dev container if it is not already running; bound the start with
 # a 60s timeout and never mask a genuine failure (fixes #636 — the old form
 # hung 10+ minutes on a wedged compose and swallowed errors with `|| true`).
-CONTAINER_CHECK := @if [ -z "$$(DOCKER_HOST="$(DOCKER_HOST)" podman-compose ps -q dev 2>/dev/null)" ]; then echo "Starting dev container (timeout 60s)..."; timeout 60 DOCKER_HOST="$(DOCKER_HOST)" podman-compose up -d dev; fi
+CONTAINER_CHECK := @if [ -z "$$(env DOCKER_HOST="$(DOCKER_HOST)" podman-compose ps -q dev 2>/dev/null)" ]; then echo "Starting dev container (timeout 60s)..."; env DOCKER_HOST="$(DOCKER_HOST)" timeout 60 podman-compose up -d dev; fi
 CONTAINER_PREFIX := DOCKER_HOST="$(DOCKER_HOST)" podman-compose exec -T dev
 
 # Sanitizer runtime options that must be set INSIDE the dev container.


### PR DESCRIPTION
Fixes the 10-minute hang in \`make lint\` (and any \`just ci\` caller): the old \`CONTAINER_CHECK\` ran \`podman-compose up -d dev\` with no timeout and \`|| true\`, so a wedged compose blocked every target silently.\n\nThe new form skips the start when the container is already up, bounds the start at 60s via \`timeout\`, and propagates a genuine failure instead of masking it.\n\nCloses #636